### PR TITLE
fix: Build lines from word level cells

### DIFF
--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -367,10 +367,13 @@ class PdfDocument:
         if len(segmented_page.textline_cells) > 0:
             return
 
+        self._create_word_cells(segmented_page, _loglevel)
+
         sanitizer = pdf_sanitizer(level=_loglevel)
 
         char_data = []
-        for item in segmented_page.char_cells:
+        # Note: We build the lines from the word level cells.
+        for item in segmented_page.word_cells:
             item_dict = item.model_dump(mode="json", by_alias=True, exclude_none=True)
 
             # TODO changing representation for the C++ parser, need to update on C++ code.


### PR DESCRIPTION
This switches the logic for the sanitation to build line-level cells from word-level cells instead of char-level cells, since the word-level cell sanitation does some important pre-cleaning that improves the lines downstream.

## Before

**Char-level**
![Estrategia-de-Gestion-Financiera-ante-el-Riesgo-de-Desastres pdf page_25 char](https://github.com/user-attachments/assets/3144dd89-ead6-4b9d-b2a9-285bed9f1179)

**Line-level**
![Estrategia-de-Gestion-Financiera-ante-el-Riesgo-de-Desastres pdf page_25 line](https://github.com/user-attachments/assets/ddf57e94-4995-4481-9077-d16ae445dd9e)

## After

**Word-level**
![Estrategia-de-Gestion-Financiera-ante-el-Riesgo-de-Desastres pdf page_25 word](https://github.com/user-attachments/assets/79377676-449d-462b-999d-6f7227a9f739)

**Line-level**
![Estrategia-de-Gestion-Financiera-ante-el-Riesgo-de-Desastres pdf page_25 line](https://github.com/user-attachments/assets/20cd85cc-474b-4178-971d-f5b3c8d1e4ef)
