### PR TITLE
Update pdf_parser.py

### DIFF
--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -254,6 +254,11 @@ class PdfDocument:
                 orig=row[header.index(f"text")],
                 font_key=row[header.index(f"font-key")],
                 font_name=row[header.index(f"font-name")],
+                # Attempt to read font_size, assuming key "font-size" from C++
+                # The C++ code divides by 1000, so we multiply back if needed,
+                # or adjust based on how the C++ JSON output is structured.
+                # We'll store it directly for now.
+                font_size=row[header.index(f"font-size")] if f"font-size" in header else None,
                 widget=row[header.index(f"widget")],
                 text_direction=(
                     TextDirection.LEFT_TO_RIGHT


### PR DESCRIPTION
feat: added font_size to `PdfTextCell` object

My project needs a font size (if available) within the pdf spans. It appears the C++ already contains this information, so we added it to the python class.

The change ensures that if the `font-size` key exists in the data provided by the C++ layer, its value is read and passed during the creation of the `PdfTextCell` object. 

Note we also changed docling-core/docling_core/types/doc/page.py to include an optional `font_size` field. This is reflected in a separate pull request.