### PR TITLE
feat: add page unloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ options:
   -p PDF, --pdf PDF  Path to the PDF file
 ```
 
-
 ## Performance Benchmarks
 
 ### Characteristics of different parser versions
@@ -185,21 +184,25 @@ If you dont have an input file, then a template input file will be printed on th
 
 To build the package, simply run (make sure [uv](https://docs.astral.sh/uv/) is [installed](https://docs.astral.sh/uv/getting-started/installation)),
 
-```
+```sh
 uv sync
+```
+
+The latter will only work after a clean `git clone`. If you are developing and updating C++ code, please use,
+
+```sh
+uv pip install --force-reinstall --no-deps -e .
 ```
 
 To test the package, run:
 
-```
+```sh
 uv run pytest ./tests -v -s
 ```
-
 
 ## Contributing
 
 Please read [Contributing to Docling Parse](https://github.com/docling-project/docling-parse/blob/main/CONTRIBUTING.md) for details.
-
 
 ## References
 

--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -291,6 +291,33 @@ PYBIND11_MODULE(pdf_parsers, m) {
     Returns:
         bool: True if the document was successfully unloaded, False otherwise.)")
 
+    .def("unload_document_pages",
+	 [](docling::docling_parser_v2 &self, const std::string &key) -> bool {
+	   return self.unload_document(key);
+	 },
+	 R"(
+    Unload the only the cached pages of the document by its unique key.
+
+    Parameters:
+        key (str): The unique key of the document to unload.
+
+    Returns:
+        bool: True if the document was successfully unloaded, False otherwise.)")
+
+    .def("unload_document_page",
+	 [](docling::docling_parser_v2 &self, const std::string &key, const int page_number) -> bool {
+	   return self.unload_document_page(key, page_number);
+	 },
+	 R"(
+    Unload a single page of the document by its unique key and page_number.
+
+    Parameters:
+        key (str): The unique key of the document to unload.
+        page_number (int): The page number of the document to unload.
+
+    Returns:
+        bool: True if the document was successfully unloaded, False otherwise.)")
+    
     .def("number_of_pages",
 	 [](docling::docling_parser_v2 &self, const std::string &key) -> int {
 	   return self.number_of_pages(key);

--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -293,8 +293,9 @@ PYBIND11_MODULE(pdf_parsers, m) {
 
     .def("unload_document_pages",
 	 [](docling::docling_parser_v2 &self, const std::string &key) -> bool {
-	   return self.unload_document(key);
+	   return self.unload_document_pages(key);
 	 },
+	 pybind11::arg("key"),
 	 R"(
     Unload the only the cached pages of the document by its unique key.
 
@@ -305,15 +306,17 @@ PYBIND11_MODULE(pdf_parsers, m) {
         bool: True if the document was successfully unloaded, False otherwise.)")
 
     .def("unload_document_page",
-	 [](docling::docling_parser_v2 &self, const std::string &key, const int page_number) -> bool {
-	   return self.unload_document_page(key, page_number);
+	 [](docling::docling_parser_v2 &self, const std::string &key, int page) -> bool {
+	   return self.unload_document_page(key, page);
 	 },
+	 pybind11::arg("key"),
+	 pybind11::arg("page"),	 
 	 R"(
     Unload a single page of the document by its unique key and page_number.
 
     Parameters:
         key (str): The unique key of the document to unload.
-        page_number (int): The page number of the document to unload.
+        page (int): The page number of the document to unload.
 
     Returns:
         bool: True if the document was successfully unloaded, False otherwise.)")

--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -58,6 +58,12 @@ class PdfDocument:
         else:
             return False
 
+    def unload_pages(self, page_range: tuple[int, int]):
+        """unload page in range [page_range[0], page_range[1]["""
+        for page_no in range(page_range[0], page_range[1]):
+            if page_no in self._pages:
+                del self._pages[page_no]
+                
     def number_of_pages(self) -> int:
         if self.is_loaded():
             return self._parser.number_of_pages(key=self._key)

--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -63,7 +63,7 @@ class PdfDocument:
         for page_no in range(page_range[0], page_range[1]):
             if page_no in self._pages:
                 del self._pages[page_no]
-                
+
     def number_of_pages(self) -> int:
         if self.is_loaded():
             return self._parser.number_of_pages(key=self._key)

--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -62,6 +62,7 @@ class PdfDocument:
         """unload page in range [page_range[0], page_range[1]["""
         for page_no in range(page_range[0], page_range[1]):
             if page_no in self._pages:
+                self._parser.unload_document_page(key=self._key, page=page_no)
                 del self._pages[page_no]
 
     def number_of_pages(self) -> int:

--- a/docling_parse/visualize.py
+++ b/docling_parse/visualize.py
@@ -237,7 +237,8 @@ def visualise_py(
                 print(f"text-lines (sanitized, page_no: {page_no}):")
                 print("\n".join(lines))
 
-
+        pdf_doc.unload_pages(page_range=(page_no, page_no+1))
+        
 def main():
 
     (

--- a/docling_parse/visualize.py
+++ b/docling_parse/visualize.py
@@ -237,8 +237,9 @@ def visualise_py(
                 print(f"text-lines (sanitized, page_no: {page_no}):")
                 print("\n".join(lines))
 
-        pdf_doc.unload_pages(page_range=(page_no, page_no+1))
-        
+        pdf_doc.unload_pages(page_range=(page_no, page_no + 1))
+
+
 def main():
 
     (

--- a/src/pybind/docling_parser_v2.h
+++ b/src/pybind/docling_parser_v2.h
@@ -35,6 +35,8 @@ namespace docling
     bool load_document_from_bytesio(std::string key, pybind11::object bytes_io);
 
     bool unload_document(std::string key);
+    bool unload_document_pages(std::string key);
+    bool unload_document_page(std::string key, int page_num);
 
     void unload_documents();
 
@@ -254,6 +256,40 @@ namespace docling
     return false;    
   }
 
+  bool docling_parser_v2::unload_document_page(std::string key, int page_num)
+  {
+    auto itr = key2doc.find(key);
+
+    if(itr!=key2doc.end())
+      {
+	decoder_ptr_type decoder_ptr = itr->second;
+	decoder_ptr->unload_page(page_num);
+      }
+    else
+      {
+	LOG_S(ERROR) << "key not found: " << key;	
+      }
+    
+    return false;    
+  }
+
+  bool docling_parser_v2::unload_document_pages(std::string key)
+  {
+    auto itr = key2doc.find(key);
+
+    if(itr!=key2doc.end())
+      {
+	decoder_ptr_type decoder_ptr = itr->second;
+	decoder_ptr->unload_pages();
+      }
+    else
+      {
+	LOG_S(ERROR) << "key not found: " << key;	
+      }
+    
+    return false;    
+  }
+  
   void docling_parser_v2::unload_documents()
   {
     key2doc.clear();

--- a/src/v1/proj_folders/pdf_library/qpdf/parser/font.h
+++ b/src/v1/proj_folders/pdf_library/qpdf/parser/font.h
@@ -911,11 +911,9 @@ namespace pdf_lib
       std::string name = _handle.getKey("/Subtype").getName();
       logging_lib::info("pdf-parser") << __FILE__ << ":" << __LINE__ << "\t detected /Subtype: " << name;
 
-      //std::cout << name << "\n";
-      
-      //if(bbox.isInitialized())
-      if(bbox) // use the new `bool()`
-        {
+      //if(bbox) // use the new `bool()`      
+      if(bbox.isInitialized())
+	{
           if(not fm.ascent)
             {
               fm.ascent = bbox.getArrayItem(3).getNumericValue();

--- a/src/v1/proj_folders/pdf_library/qpdf/parser/font.h
+++ b/src/v1/proj_folders/pdf_library/qpdf/parser/font.h
@@ -913,7 +913,8 @@ namespace pdf_lib
 
       //std::cout << name << "\n";
       
-      if(bbox.isInitialized())
+      //if(bbox.isInitialized())
+      if(bbox) // use the new `bool()`
         {
           if(not fm.ascent)
             {

--- a/src/v2/pdf_decoders/page.h
+++ b/src/v2/pdf_decoders/page.h
@@ -16,9 +16,11 @@ namespace pdflib
   {
   public:
 
-    pdf_decoder(QPDFObjectHandle page);
+    pdf_decoder(QPDFObjectHandle page, int page_num);
     ~pdf_decoder();
 
+    int get_page_number();
+    
     nlohmann::json get();
 
     std::map<std::string, double> decode_page(std::string page_boundary, bool do_sanitization);
@@ -49,6 +51,9 @@ namespace pdflib
   private:
 
     QPDFObjectHandle qpdf_page;
+
+    int page_number;
+    
     QPDFObjectHandle qpdf_parent_resources;
     QPDFObjectHandle qpdf_resources;
     QPDFObjectHandle qpdf_grphs;
@@ -81,19 +86,27 @@ namespace pdflib
     std::map<std::string, double> timings;
   };
 
-  pdf_decoder<PAGE>::pdf_decoder(QPDFObjectHandle page):
-    qpdf_page(page)
+  pdf_decoder<PAGE>::pdf_decoder(QPDFObjectHandle page, int page_num):
+    qpdf_page(page),
+    page_number(page_num)    
   {
   }
 
   pdf_decoder<PAGE>::~pdf_decoder()
   {
   }
+
+  int pdf_decoder<PAGE>::get_page_number()
+  {
+    return page_number;
+  }
   
   nlohmann::json pdf_decoder<PAGE>::get()
   {
     nlohmann::json result;
     {
+      result["page_number"] = page_number;
+      
       result["annotations"] = json_annots;
       
       nlohmann::json& timings_ = result["timings"];

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -289,7 +289,7 @@ def test_reference_documents_from_filenames():
             # img.show()
 
             print(f"unloading page: {page_no}")
-            pdf_doc.unload_pages(page_range=(page_no, page_no+1))
+            pdf_doc.unload_pages(page_range=(page_no, page_no + 1))
 
         toc: PdfTableOfContents = pdf_doc.get_table_of_contents()
         """

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -288,6 +288,9 @@ def test_reference_documents_from_filenames():
             img = pred_page.render_as_image(cell_unit=TextCellUnit.LINE)
             # img.show()
 
+            print(f"unloading page: {page_no}")
+            pdf_doc.unload_pages(page_range=(page_no, page_no+1))
+
         toc: PdfTableOfContents = pdf_doc.get_table_of_contents()
         """
         if toc is not None:


### PR DESCRIPTION
Added new function in the C++ to unload pages

```
1. `unload_document_pages(std::string document_key)`
2. `unload_document_page(std::string document_key, int page_number)`
```

Added new function to PdfDocument

```
unload_pages(self, page_range: tuple[int, int]):
``` 

example code:

```
import argparse
import logging
import os
from pathlib import Path

import time

from docling_core.types.doc.page import SegmentedPdfPage, TextCellUnit

from docling_parse.pdf_parser import DoclingPdfParser, PdfDocument

delta = 4
log_level = "error"

enforce_same_font = True

pdf_path = Path("/Users/taa/Downloads/pg4500.pdf")


parser = DoclingPdfParser(loglevel=log_level)

pdf_doc: PdfDocument = parser.load(path_or_stream=pdf_path, lazy=True)

page_nos = [(page_ind + 1) for page_ind in range(0, pdf_doc.number_of_pages(), delta)]

for page_no in page_nos:
    print(page_no)

    for page_no_ in range(page_no, page_no+delta):
        pdf_page: SegmentedPdfPage = pdf_doc.get_page(
            page_no=page_no,
            create_words=True,
            create_textlines=True,
            enforce_same_font=enforce_same_font
        )

    pdf_doc.unload_pages(page_range=(page_no, page_no+delta)) # this is the important line to keep memory under control!!!
```
