### PR TITLE
fix: avoid setting global root logger

### DIFF
--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -27,9 +27,7 @@ from docling_parse.pdf_parsers import pdf_parser_v2  # type: ignore[import]
 from docling_parse.pdf_parsers import pdf_sanitizer  # type: ignore[import]
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
+_log = logging.getLogger(__name__)
 
 
 class PdfDocument:
@@ -442,25 +440,25 @@ class PdfDocument:
             segmented_page.word_cells = self._to_cells(page["word_cells"])
             segmented_page.has_words = len(segmented_page.word_cells) > 0
         elif keep_chars:
-            logging.warning(
+            _log.warning(
                 "`words` will be created for segmented_page in an inefficient way!"
             )
             self._create_word_cells(segmented_page, enforce_same_font=enforce_same_font)
         # else:
-        #    logging.warning("No `words` will be created for segmented_page")
+        #    _log.warning("No `words` will be created for segmented_page")
 
         if create_textlines and ("line_cells" in page):
             segmented_page.textline_cells = self._to_cells(page["line_cells"])
             segmented_page.has_lines = len(segmented_page.textline_cells) > 0
         elif keep_chars:
-            logging.warning(
+            _log.warning(
                 "`text_lines` will be created for segmented_page in an inefficient way!"
             )
             self._create_textline_cells(
                 segmented_page, enforce_same_font=enforce_same_font
             )
         # else:
-        #    logging.warning("No `text_lines` will be created for segmented_page")
+        #    _log.warning("No `text_lines` will be created for segmented_page")
 
         return segmented_page
 

--- a/docling_parse/processing_dir.py
+++ b/docling_parse/processing_dir.py
@@ -11,11 +11,6 @@ from tabulate import tabulate
 
 from docling_parse import pdf_parser_v2  # type: ignore[attr-defined]
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
-
 
 @dataclass
 class FileTask:
@@ -153,6 +148,10 @@ def process_files_from_queue(file_queue: Queue, page_level: bool, loglevel: str)
 
 
 def main():
+    # Configure logging
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
 
     directory, recursive, loglevel, page_level_parsing = parse_arguments()
 

--- a/docling_parse/processing_s3.py
+++ b/docling_parse/processing_s3.py
@@ -27,11 +27,6 @@ except ImportError as e:
 
 from docling_parse import pdf_parser_v2  # type: ignore[attr-defined]
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
-
 queue_lock = threading.Lock()
 
 
@@ -342,6 +337,10 @@ def process_files_from_queue(
 
 
 def main():
+    # Configure logging
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
 
     s3_config, threads, loglevel = parse_arguments()
 

--- a/docling_parse/visualize.py
+++ b/docling_parse/visualize.py
@@ -8,11 +8,6 @@ from docling_core.types.doc.page import SegmentedPdfPage, TextCellUnit
 
 from docling_parse.pdf_parser import DoclingPdfParser, PdfDocument
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
-
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Process a PDF file.")
@@ -254,6 +249,10 @@ def visualise_py(
 
 
 def main():
+    # Configure logging
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
 
     (
         log_level,


### PR DESCRIPTION
As reported in the issue, we should avoid setting the root logger, otherwise every library including docling will have the changes imposed.

Resolves #178