### PR TITLE
fix: bridge PointerHolder<T> to std::shared_ptr<T> for qpdf 10.x +

### DIFF
--- a/app/page_images.cpp
+++ b/app/page_images.cpp
@@ -6,6 +6,8 @@
 #include <qpdf/QPDFPageObjectHelper.hh>
 #include <qpdf/Buffer.hh>
 
+#include <parse/qpdf/qpdf_compat.h>
+
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -120,25 +122,24 @@ int main(int argc, char* argv[])
                     auto filters = get_filters(img);
 
                     std::shared_ptr<Buffer> data;
-		    //PointerHolder<Buffer> data;
                     bool wrote_decoded = false;
 
                     if (want_decoded)
                     {
                         try
                         {
-                            data = img.getStreamData();
+                            data = to_shared_ptr(img.getStreamData());
                             wrote_decoded = true;
                         }
                         catch (...)
                         {
-                            data = img.getRawStreamData();
+                            data = to_shared_ptr(img.getRawStreamData());
                             wrote_decoded = false;
                         }
                     }
                     else
                     {
-                        data = img.getRawStreamData();
+                        data = to_shared_ptr(img.getRawStreamData());
                         wrote_decoded = false;
                     }
 

--- a/src/parse/pdf_resources/page_font.h
+++ b/src/parse/pdf_resources/page_font.h
@@ -3,6 +3,8 @@
 #ifndef PDF_PAGE_FONT_RESOURCE_H
 #define PDF_PAGE_FONT_RESOURCE_H
 
+#include <parse/qpdf/qpdf_compat.h>
+
 namespace pdflib
 {
 
@@ -1016,8 +1018,8 @@ namespace pdflib
 	  }
 
 	{
-	  auto buffer = qpdf_obj.getRawStreamData();
-	  
+	  auto buffer = to_shared_ptr(qpdf_obj.getRawStreamData());
+
 	  LOG_S(INFO) << "buffer-size: " << buffer->getSize();
 	  //LOG_S(INFO) << "buffer: " << buffer->getBuffer();
 
@@ -1039,7 +1041,7 @@ namespace pdflib
 	}
 
 	{
-	auto buffer = qpdf_obj.getStreamData(qpdf_dl_generalized);
+	auto buffer = to_shared_ptr(qpdf_obj.getStreamData(qpdf_dl_generalized));
 	  
 	LOG_S(INFO) << "buffer-size: " << buffer->getSize();
 	//LOG_S(INFO) << "buffer: " << buffer->getBuffer();

--- a/src/parse/pdf_resources/page_xobject_image.h
+++ b/src/parse/pdf_resources/page_xobject_image.h
@@ -4,6 +4,7 @@
 #define PDF_PAGE_XOBJECT_IMAGE_RESOURCE_H
 
 #include <parse/utils/jpeg/jpeg_utils.h>
+#include <parse/qpdf/qpdf_compat.h>
 
 namespace pdflib
 {
@@ -293,7 +294,7 @@ namespace pdflib
 
     try
       {
-        raw_stream_data = qpdf_xobject.getRawStreamData();
+        raw_stream_data = to_shared_ptr(qpdf_xobject.getRawStreamData());
         LOG_S(INFO) << "raw stream size: " << raw_stream_data->getSize() << " bytes";
       }
     catch(std::exception const& e)
@@ -304,7 +305,7 @@ namespace pdflib
 
     try
       {
-        decoded_stream_data = qpdf_xobject.getStreamData();
+        decoded_stream_data = to_shared_ptr(qpdf_xobject.getStreamData());
         LOG_S(INFO) << "decoded stream size: " << decoded_stream_data->getSize() << " bytes";
       }
     catch(std::exception const& e)

--- a/src/parse/qpdf/annots.h
+++ b/src/parse/qpdf/annots.h
@@ -11,6 +11,8 @@
 #include <nlohmann/json.hpp>
 #include <qpdf/QPDF.hh>
 
+#include <parse/qpdf/qpdf_compat.h>
+
 namespace pdflib
 {
   // FIXME: add a begin time to cap the max time spent in this routine
@@ -89,7 +91,7 @@ namespace pdflib
 
 	    if(metadata.isStream())
 	      {
-		auto ptr = metadata.getStreamData(qpdf_dl_all);
+		auto ptr = to_shared_ptr(metadata.getStreamData(qpdf_dl_all));
 		
 		// Convert raw data to std::string
 		std::string content(reinterpret_cast<const char*>(ptr->getBuffer()), ptr->getSize());

--- a/src/parse/qpdf/qpdf_compat.h
+++ b/src/parse/qpdf/qpdf_compat.h
@@ -1,0 +1,45 @@
+//-*-C++-*-
+
+#ifndef QPDF_COMPAT_H
+#define QPDF_COMPAT_H
+
+#include <memory>
+
+// qpdf 10.x uses PointerHolder<T> for stream APIs; qpdf 11+ uses
+// std::shared_ptr<T>.  GCC 13+ refuses the implicit conversion from
+// PointerHolder to shared_ptr.  This helper bridges the gap so that
+// callers can write:
+//
+//   auto sp = to_shared_ptr(obj.getRawStreamData());
+//
+// and get a std::shared_ptr<T> regardless of qpdf version.
+
+// Passthrough for qpdf 11+ which already returns std::shared_ptr<T>.
+template<typename T>
+std::shared_ptr<T> to_shared_ptr(std::shared_ptr<T> sp) { return sp; }
+
+// Overload for qpdf 10.x which returns PointerHolder<T>.
+// qpdf 11+ defines POINTERHOLDER_IS_SHARED_POINTER, meaning
+// PointerHolder<T> (if it exists) is already derived from
+// std::shared_ptr<T> and the passthrough overload above suffices.
+// qpdf 10.x does NOT define that macro, and its PointerHolder<T> is
+// an independent smart pointer that GCC 13+ refuses to implicitly
+// convert to std::shared_ptr<T>.
+#if __has_include(<qpdf/PointerHolder.hh>)
+#include <qpdf/PointerHolder.hh>
+
+#if !defined(POINTERHOLDER_IS_SHARED_POINTER)
+template<typename T>
+std::shared_ptr<T> to_shared_ptr(PointerHolder<T> ph)
+{
+  T* raw = ph.getPointer();
+  if(!raw)
+    return nullptr;
+  // prevent_delete captured by value keeps PointerHolder alive,
+  // preventing premature deallocation while shared_ptr exists
+  return std::shared_ptr<T>(raw, [prevent_delete = std::move(ph)](T*) {});
+}
+#endif // !POINTERHOLDER_IS_SHARED_POINTER
+#endif // __has_include
+
+#endif // QPDF_COMPAT_H


### PR DESCRIPTION
GCC 13+ rejects the implicit conversion from qpdf 10.x's PointerHolder<T> to std::shared_ptr<T>. Add a to_shared_ptr() shim and apply it to all getRawStreamData()/getStreamData() call sites.

Fixes #220