### PR TITLE
debug: test ci on new windows machine

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,7 +60,7 @@ jobs:
             min_macos_version: "14"
             platform_id: "macosx_arm64"
 
-          - name: "windows-2025"
+          - name: "windows-2025-vs2026"
             platform: "windows"
             platform_id: "win_amd64"      
 


### PR DESCRIPTION
This PR is following the GitHub notice that between June 8, 2026 and June 15, 2026 all the default windows will be updates to this tag