### PR TITLE
feat: add materialize_bitmap_bytes flag to skip bitmap byte extraction

### DIFF
--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -276,6 +276,7 @@ PYBIND11_MODULE(pdf_parsers, m) {
         max_num_bitmaps (int): Maximum number of bitmaps to keep (-1 means no cap) [default=-1].
         keep_glyphs (bool): If true, keep GLYPH<...> fallback strings in output; if false, replace them with a space [default=false].
         keep_qpdf_warnings (bool): If true, QPDF warnings are emitted; if false, they are suppressed [default=false].
+        materialize_bitmap_bytes (bool): If true (default), bitmap byte data is extracted and embedded in BitmapResource objects. If false, only bitmap geometry (rectangles) is preserved and image bytes are skipped. Consumed by the Python layer only; has no effect in C++ [default=true].
     )")
     .def(pybind11::init<>())
     .def_readwrite("page_boundary", &pdflib::decode_config::page_boundary)
@@ -295,7 +296,10 @@ PYBIND11_MODULE(pdf_parsers, m) {
     .def_readwrite("do_thread_safe", &pdflib::decode_config::do_thread_safe)
     .def_readwrite("release_native_memory_every_n_pages", &pdflib::decode_config::release_native_memory_every_n_pages)
     .def_readwrite("keep_glyphs", &pdflib::decode_config::keep_glyphs)
-    .def_readwrite("keep_qpdf_warnings", &pdflib::decode_config::keep_qpdf_warnings);
+    .def_readwrite("keep_qpdf_warnings", &pdflib::decode_config::keep_qpdf_warnings)
+    .def_readwrite("materialize_bitmap_bytes", &pdflib::decode_config::materialize_bitmap_bytes)
+    .def("__copy__", [](const pdflib::decode_config& self) { return self; })
+    .def("__deepcopy__", [](const pdflib::decode_config& self, pybind11::dict) { return self; });
 
   // ============= Typed Resource Bindings (for zero-copy access) =============
 

--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -269,7 +269,7 @@ PYBIND11_MODULE(pdf_parsers, m) {
     Attributes:
         page_boundary (str): The page boundary specification [choices: crop_box, media_box].
         do_sanitization (bool): Sanitize the chars into lines [default=true].
-        keep_char_cells (bool): Keep all the individual char cells [default=true].
+        keep_char_cells (bool): Expose individual char cells in the decoded output. Internal base text cells are still built when words or lines are requested [default=true].
         keep_shapes (bool): Keep all the graphic shapes [default=true].
         keep_bitmaps (bool): Keep all the bitmap resources [default=true].
         max_num_lines (int): Maximum number of lines to keep (-1 means no cap) [default=-1].

--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -1,5 +1,6 @@
 """Parser for PDF files"""
 
+import copy
 import hashlib
 import logging
 import math
@@ -366,46 +367,52 @@ def _to_hyperlinks_from_decoder(hyperlinks_container) -> List[PdfHyperlink]:
     return result
 
 
-def _to_bitmap_resources_from_decoder(images_container) -> List[BitmapResource]:
+def _to_bitmap_resources_from_decoder(
+    images_container,
+    materialize_bitmap_bytes: bool = True,
+) -> List[BitmapResource]:
     result: List[BitmapResource] = []
 
     for ind, image in enumerate(images_container):
         image_ref = None
         mode = ImageRefMode.PLACEHOLDER
 
-        try:
-            image_bytes = image.get_image_as_bytes()
+        if materialize_bitmap_bytes:
+            try:
+                image_bytes = image.get_image_as_bytes()
 
-            if image_bytes and len(image_bytes) > 0:
-                fmt = image.get_image_format()
-                pil_image: PILImage.Image | None = None
+                if image_bytes and len(image_bytes) > 0:
+                    fmt = image.get_image_format()
+                    pil_image: PILImage.Image | None = None
 
-                if fmt in ("jpeg", "jp2"):
-                    pil_image = PILImage.open(BytesIO(image_bytes))
-                elif fmt in ("raw", "jbig2"):
-                    pil_mode = image.get_pil_mode()
-                    w = image.image_width
-                    h = image.image_height
-                    if w > 0 and h > 0:
-                        pil_image = PILImage.frombytes(pil_mode, (w, h), image_bytes)
+                    if fmt in ("jpeg", "jp2"):
+                        pil_image = PILImage.open(BytesIO(image_bytes))
+                    elif fmt in ("raw", "jbig2"):
+                        pil_mode = image.get_pil_mode()
+                        w = image.image_width
+                        h = image.image_height
+                        if w > 0 and h > 0:
+                            pil_image = PILImage.frombytes(
+                                pil_mode, (w, h), image_bytes
+                            )
 
-                if pil_image is not None:
-                    if pil_image.mode != "RGBA":
-                        pil_image = pil_image.convert("RGBA")
+                    if pil_image is not None:
+                        if pil_image.mode != "RGBA":
+                            pil_image = pil_image.convert("RGBA")
 
-                    bbox_width = abs(image.x1 - image.x0)
-                    if bbox_width > 0 and image.image_width > 0:
-                        dpi = round(image.image_width * 72.0 / bbox_width)
-                    else:
-                        dpi = 72
+                        bbox_width = abs(image.x1 - image.x0)
+                        if bbox_width > 0 and image.image_width > 0:
+                            dpi = round(image.image_width * 72.0 / bbox_width)
+                        else:
+                            dpi = 72
 
-                    image_ref = ImageRef.from_pil(pil_image, dpi=dpi)
-                    mode = ImageRefMode.EMBEDDED
+                        image_ref = ImageRef.from_pil(pil_image, dpi=dpi)
+                        mode = ImageRefMode.EMBEDDED
 
-        except Exception:
-            _log.debug(
-                "Failed to extract image data for bitmap, falling back to placeholder"
-            )
+            except Exception:
+                _log.debug(
+                    "Failed to extract image data for bitmap, falling back to placeholder"
+                )
 
         result.append(
             BitmapResource(
@@ -432,6 +439,7 @@ def _to_bitmap_resources_from_decoder(images_container) -> List[BitmapResource]:
 def segmented_page_from_decoder(
     page_decoder: PdfPageDecoder,
     boundary_type: PdfPageBoundaryType = PdfPageBoundaryType.CROP_BOX,
+    materialize_bitmap_bytes: bool = True,
 ) -> SegmentedPdfPage:
     """Convert a C++ PdfPageDecoder to a SegmentedPdfPage."""
     char_cells = _to_cells_from_decoder(page_decoder.get_char_cells())
@@ -445,7 +453,8 @@ def segmented_page_from_decoder(
         textline_cells=[],
         has_chars=len(char_cells) > 0,
         bitmap_resources=_to_bitmap_resources_from_decoder(
-            page_decoder.get_page_images()
+            page_decoder.get_page_images(),
+            materialize_bitmap_bytes=materialize_bitmap_bytes,
         ),
         shapes=_to_shapes_from_decoder(page_decoder.get_page_shapes()),
         widgets=_to_widgets_from_decoder(page_decoder.get_page_widgets()),
@@ -492,7 +501,7 @@ class PdfDocument:
         self._parser: pdf_parser = parser
         self._key = key
         self._boundary_type = boundary_type
-        self._pages: Dict[int, SegmentedPdfPage] = {}
+        self._pages: Dict[tuple[int, bool], SegmentedPdfPage] = {}
         self._toc: PdfTableOfContents | None = None
         self._meta: PdfMetaData | None = None
         self._annotations: PdfAnnotations | None = None
@@ -520,11 +529,13 @@ class PdfDocument:
             if page_no < 1:
                 _log.error("page_no should always be >=1!")
 
-            if page_no in self._pages:
+            cache_keys = [k for k in self._pages if k[0] == page_no]
+            if cache_keys:
                 # we are using 0 indexing in the C++ docling-parse!
                 page_num = page_no - 1
                 self._parser.unload_document_page(key=self._key, page=page_num)
-                del self._pages[page_no]
+                for k in cache_keys:
+                    del self._pages[k]
 
     def number_of_pages(self) -> int:
         if self.is_loaded():
@@ -702,6 +713,7 @@ class PdfDocument:
 
         segmented_page = self._to_segmented_page_from_decoder(
             page_decoder=page_decoder,
+            materialize_bitmap_bytes=config.materialize_bitmap_bytes,
         )
 
         # Get timings from the page decoder
@@ -740,19 +752,26 @@ class PdfDocument:
         return _to_hyperlinks_from_decoder(hyperlinks_container)
 
     def _to_bitmap_resources_from_decoder(
-        self, images_container
+        self,
+        images_container,
+        materialize_bitmap_bytes: bool = True,
     ) -> List[BitmapResource]:
         """Convert typed PdfImages container to list of BitmapResource objects."""
-        return _to_bitmap_resources_from_decoder(images_container)
+        return _to_bitmap_resources_from_decoder(
+            images_container,
+            materialize_bitmap_bytes=materialize_bitmap_bytes,
+        )
 
     def _to_segmented_page_from_decoder(
         self,
         page_decoder,
+        materialize_bitmap_bytes: bool = True,
     ) -> SegmentedPdfPage:
         """Convert typed PdfPageDecoder to SegmentedPdfPage (zero-copy path)."""
         return segmented_page_from_decoder(
             page_decoder=page_decoder,
             boundary_type=self._boundary_type,
+            materialize_bitmap_bytes=materialize_bitmap_bytes,
         )
 
     def _get_page_typed(
@@ -773,8 +792,9 @@ class PdfDocument:
         Returns:
             SegmentedPdfPage with the parsed page data.
         """
-        if page_no in self._pages.keys():
-            return self._pages[page_no]
+        cache_key = (page_no, config.materialize_bitmap_bytes)
+        if cache_key in self._pages:
+            return self._pages[cache_key]
 
         if 1 <= page_no <= self.number_of_pages():
             page_decoder = self._parser.get_page_decoder(
@@ -786,10 +806,11 @@ class PdfDocument:
             if page_decoder is None:
                 raise ValueError(f"Failed to decode page {page_no}")
 
-            self._pages[page_no] = self._to_segmented_page_from_decoder(
+            self._pages[cache_key] = self._to_segmented_page_from_decoder(
                 page_decoder=page_decoder,
+                materialize_bitmap_bytes=config.materialize_bitmap_bytes,
             )
-            return self._pages[page_no]
+            return self._pages[cache_key]
 
         raise ValueError(
             f"incorrect page_no: {page_no} for key={self._key} (min:1, max:{self.number_of_pages()})"
@@ -923,10 +944,12 @@ class PageParseResult:
         *,
         boundary_type: PdfPageBoundaryType,
         render_config: RenderConfig | None,
+        decode_config: DecodePageConfig,
     ):
         self._raw = raw_result
         self._boundary_type = boundary_type
         self._render_config = render_config
+        self._decode_config = decode_config
         self._page: SegmentedPdfPage | None = None
         self._page_decoder: PdfPageDecoder | None = None
         self._default_image: PILImage.Image | None = None
@@ -972,6 +995,7 @@ class PageParseResult:
             self._page = segmented_page_from_decoder(
                 page_decoder=self._require_page_decoder(),
                 boundary_type=self._boundary_type,
+                materialize_bitmap_bytes=self._decode_config.materialize_bitmap_bytes,
             )
         return self._page
 
@@ -1113,31 +1137,6 @@ class PageParseResult:
         return self._require_page_decoder().export_bitmap_artifacts()
 
 
-def _copy_decode_config(src: DecodePageConfig) -> DecodePageConfig:
-    dst = DecodePageConfig()
-    dst.page_boundary = src.page_boundary
-    dst.do_sanitization = src.do_sanitization
-    dst.keep_char_cells = src.keep_char_cells
-    dst.keep_shapes = src.keep_shapes
-    dst.keep_bitmaps = src.keep_bitmaps
-    dst.max_num_lines = src.max_num_lines
-    dst.max_num_bitmaps = src.max_num_bitmaps
-    dst.create_word_cells = src.create_word_cells
-    dst.create_line_cells = src.create_line_cells
-    dst.enforce_same_font = src.enforce_same_font
-    dst.horizontal_cell_tolerance = src.horizontal_cell_tolerance
-    dst.word_space_width_factor_for_merge = src.word_space_width_factor_for_merge
-    dst.line_space_width_factor_for_merge = src.line_space_width_factor_for_merge
-    dst.line_space_width_factor_for_merge_with_space = (
-        src.line_space_width_factor_for_merge_with_space
-    )
-    dst.do_thread_safe = src.do_thread_safe
-    dst.release_native_memory_every_n_pages = src.release_native_memory_every_n_pages
-    dst.keep_glyphs = src.keep_glyphs
-    dst.keep_qpdf_warnings = src.keep_qpdf_warnings
-    return dst
-
-
 def _copy_render_config(src: RenderConfig) -> RenderConfig:
     dst = RenderConfig()
     dst.render_text = src.render_text
@@ -1189,7 +1188,7 @@ class DoclingThreadedPdfParser:
                 parser_config.render_config
             )
         self._decode_config = (
-            _copy_decode_config(decode_config)
+            copy.copy(decode_config)
             if decode_config is not None
             else DecodePageConfig()
         )
@@ -1318,4 +1317,5 @@ class DoclingThreadedPdfParser:
             self._parser.get_task(),
             boundary_type=self._parser_config.boundary_type,
             render_config=self._parser_config.render_config,
+            decode_config=self._decode_config,
         )

--- a/perf/run_scaling.py
+++ b/perf/run_scaling.py
@@ -7,7 +7,7 @@ scaling table.  Three modes are supported:
 
   parse   — decode-only (render_config=None); always includes a
             single-threaded DoclingPdfParser baseline.
-  render  — decode + rasterise (RenderConfig.canvas_width=...).
+  render  — decode + rasterise (RenderConfig.scale=...).
   both    — runs both of the above and prints two tables.
 
 Third-party single-threaded backends (selected via --other) are run as
@@ -104,7 +104,8 @@ def _decode_config():
     c = DecodePageConfig()
     c.keep_char_cells = False
     c.keep_shapes = False
-    c.keep_bitmaps = False
+    c.keep_bitmaps = True
+    c.materialize_bitmap_bytes = False
     c.create_word_cells = False
     c.create_line_cells = True
     return c
@@ -123,7 +124,7 @@ def run_sequential_parse(pdf_paths: List[Path]) -> float:
     parser = DoclingPdfParser(loglevel="fatal")
 
     t0 = time.perf_counter()
-    for pdf_path in pdf_paths:
+    for pdf_path in tqdm(pdf_paths, desc="  sequential parse", unit="doc", leave=False):
         try:
             doc = parser.load(str(pdf_path), lazy=True)
             for _, _ in doc.iterate_pages(config=config):
@@ -344,7 +345,7 @@ def run_threaded(
     total_pages: int,
     *,
     render: bool,
-    canvas_width: int,
+    scale: float,
 ) -> float:
     """Run DoclingThreadedPdfParser; render=True enables rasterisation."""
     from docling_parse.pdf_parser import (
@@ -358,7 +359,7 @@ def run_threaded(
     render_config = None
     if render:
         render_config = RenderConfig()
-        render_config.canvas_width = canvas_width
+        render_config.scale = scale
 
     parser_config = ThreadedPdfParserConfig(
         loglevel="fatal",
@@ -386,7 +387,7 @@ def run_threaded(
             if result.success:
                 if render:
                     _ = result.get_image()
-                    _ = result.get_page()
+                    #_ = result.get_page()
                 else:
                     _ = result.get_page()
             else:
@@ -473,7 +474,7 @@ def _run_one_mode(
     other_backends: List[str],
     *,
     render: bool,
-    canvas_width: int,
+    scale: float,
 ) -> Tuple[List[Tuple[str, float]], List[Tuple[int, float]]]:
     baselines: List[Tuple[str, float]] = []
 
@@ -505,7 +506,7 @@ def _run_one_mode(
             max_concurrent_results=max_concurrent_results,
             total_pages=total_pages,
             render=render,
-            canvas_width=canvas_width,
+            scale=scale,
         )
         threaded_results.append((n, t))
         print(f"  threads={n}: {t:.3f}s")
@@ -553,8 +554,8 @@ def main(argv: List[str]) -> int:
         help="Comma-separated list of thread counts to test (default: 1,2,4,8,12,16)",
     )
     ap.add_argument(
-        "--canvas-width", type=int, default=1024,
-        help="Canvas width in pixels for rendering (default: 1024; render/both modes only)",
+        "--scale", type=float, default=1.0,
+        help="Render scale for rendering (default: 1.0; render/both modes only)",
     )
     ap.add_argument(
         "--other",
@@ -588,7 +589,7 @@ def main(argv: List[str]) -> int:
     print(f"Max concurrent results: {args.max_concurrent_results}")
     print(f"Other backends: {other_backends if other_backends else '(none)'}")
     if args.mode in ("render", "both"):
-        print(f"Canvas width: {args.canvas_width}px")
+        print(f"Render scale: {args.scale}")
     print()
 
     modes_to_run = ["parse", "render"] if args.mode == "both" else [args.mode]
@@ -603,7 +604,7 @@ def main(argv: List[str]) -> int:
             total_pages,
             other_backends,
             render=render,
-            canvas_width=args.canvas_width,
+            scale=args.scale,
         )
         _print_table(title, baselines, threaded_results, total_pages)
 

--- a/perf/run_scaling.py
+++ b/perf/run_scaling.py
@@ -386,6 +386,7 @@ def run_threaded(
             if result.success:
                 if render:
                     _ = result.get_image()
+                    _ = result.get_page()
                 else:
                     _ = result.get_page()
             else:

--- a/src/parse/config.h
+++ b/src/parse/config.h
@@ -39,10 +39,13 @@ namespace pdflib
     bool do_thread_safe = true; // slight compute/memory overhead in single threaded case
     int release_native_memory_every_n_pages = 0; // 0 disables allocator trimming
 
-    // debug: in production, we dont want to have ugly GLYPH<...> 
+    // debug: in production, we dont want to have ugly GLYPH<...>
     bool keep_glyphs = false;
     bool keep_qpdf_warnings = false;
-    
+
+    // consumed by Python layer only; C++ ignores this field
+    bool materialize_bitmap_bytes = true;
+
     nlohmann::json to_json() const;
     void from_json(const nlohmann::json& j);
 
@@ -83,6 +86,7 @@ namespace pdflib
 
     j["keep_glyphs"] = keep_glyphs;
     j["keep_qpdf_warnings"] = keep_qpdf_warnings;
+    j["materialize_bitmap_bytes"] = materialize_bitmap_bytes;
 
     return j;
   }
@@ -116,6 +120,7 @@ namespace pdflib
 
     if(j.count("keep_glyphs")) { keep_glyphs = j["keep_glyphs"]; }
     if(j.count("keep_qpdf_warnings")) { keep_qpdf_warnings = j["keep_qpdf_warnings"]; }
+    if(j.count("materialize_bitmap_bytes")) { materialize_bitmap_bytes = j["materialize_bitmap_bytes"]; }
   }
 
   bool decode_config::load(const std::string& filename)
@@ -169,7 +174,8 @@ namespace pdflib
        << std::setw(48) << "populate_json_objects" << (populate_json_objects ? "true" : "false") << "\n"
        << std::setw(48) << "release_native_memory_every_n_pages" << release_native_memory_every_n_pages << "\n"
        << std::setw(48) << "keep_glyphs" << (keep_glyphs ? "true" : "false") << "\n"
-       << std::setw(48) << "keep_qpdf_warnings" << (keep_qpdf_warnings ? "true" : "false") << "\n";
+       << std::setw(48) << "keep_qpdf_warnings" << (keep_qpdf_warnings ? "true" : "false") << "\n"
+       << std::setw(48) << "materialize_bitmap_bytes" << (materialize_bitmap_bytes ? "true" : "false") << "\n";
 
     return ss.str();
   }

--- a/src/parse/pdf_decoders/page.h
+++ b/src/parse/pdf_decoders/page.h
@@ -42,8 +42,9 @@ namespace pdflib
     page_item<PAGE_WIDGETS>& get_page_widgets() { return page_widgets; }
     page_item<PAGE_HYPERLINKS>& get_page_hyperlinks() { return page_hyperlinks; }
 
-    // Char, word and line cells (char_cells is alias for page_cells, word/line are computed)
-    page_item<PAGE_CELLS>& get_char_cells() { return page_cells; }
+    // page_cells is the internal base stream used to derive words/lines.
+    // char_cells is the public/exposed char output, which may be suppressed.
+    page_item<PAGE_CELLS>& get_char_cells() { return char_cells; }
     page_item<PAGE_CELLS>& get_word_cells() { return word_cells; }
     page_item<PAGE_CELLS>& get_line_cells() { return line_cells; }
 
@@ -136,6 +137,7 @@ namespace pdflib
     page_item<PAGE_DIMENSION> page_dimension;
 
     page_item<PAGE_CELLS>  page_cells;
+    page_item<PAGE_CELLS>  char_cells;
     page_item<PAGE_SHAPES> page_shapes;
     page_item<PAGE_IMAGES> page_images;
 
@@ -456,6 +458,15 @@ namespace pdflib
     else
       {
         LOG_S(WARNING) << "skipping sanitization!";
+      }
+
+    if(config.keep_char_cells)
+      {
+        char_cells = page_cells;
+      }
+    else
+      {
+        char_cells.clear();
       }
 
     timings.add_timing(pdf_timings::KEY_DECODE_PAGE, global.get_time());

--- a/src/parse/pdf_states/text.h
+++ b/src/parse/pdf_states/text.h
@@ -492,10 +492,8 @@ namespace pdflib
                                  int stack_size,
                                  std::vector<page_item<PAGE_CELL> >& cells)
   {
-    if(not config.keep_char_cells)
-      {
-        return;
-      }
+    const bool need_base_text_cells =
+      config.keep_char_cells or config.create_word_cells or config.create_line_cells;
 
     LOG_S(INFO) << __FUNCTION__ << " with text='" << text << "', width=" << width << " from base-font: " << font.get_base_font() << ", font-key: " << font.get_key();
 
@@ -653,7 +651,10 @@ namespace pdflib
 	cell.rgb_filling_ops    = grph_state.get_rgb_filling_ops();
       }
       
-      cells.push_back(cell);
+      if(need_base_text_cells)
+        {
+          cells.push_back(cell);
+        }
 
       {
 	// some characters have specific bounding-box spec's

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -723,13 +723,13 @@ def test_get_page_individually():
 
     # Access page 2 directly (should not load other pages)
     page_2 = pdf_doc.get_page(2)
-    assert 2 in pdf_doc._pages
-    assert 1 not in pdf_doc._pages  # Page 1 should not be loaded
-    assert 3 not in pdf_doc._pages  # Page 3 should not be loaded
+    assert any(k[0] == 2 for k in pdf_doc._pages)
+    assert not any(k[0] == 1 for k in pdf_doc._pages)  # Page 1 should not be loaded
+    assert not any(k[0] == 3 for k in pdf_doc._pages)  # Page 3 should not be loaded
 
     # Access page 1
     page_1 = pdf_doc.get_page(1)
-    assert 1 in pdf_doc._pages
+    assert any(k[0] == 1 for k in pdf_doc._pages)
 
     # Verify pages are different
     assert page_1 != page_2
@@ -747,13 +747,13 @@ def test_unload_individual_pages():
 
     # Unload page 1
     pdf_doc.unload_pages(page_range=(1, 2))
-    assert 1 not in pdf_doc._pages
+    assert not any(k[0] == 1 for k in pdf_doc._pages)
     assert len(pdf_doc._pages) == num_pages - 1
 
     # Unload pages 2-3
     pdf_doc.unload_pages(page_range=(2, 4))
-    assert 2 not in pdf_doc._pages
-    assert 3 not in pdf_doc._pages
+    assert not any(k[0] == 2 for k in pdf_doc._pages)
+    assert not any(k[0] == 3 for k in pdf_doc._pages)
 
 
 def test_boundary_types():
@@ -1019,3 +1019,125 @@ def test_annotations_match_groundtruth():
         verify_annotations_recursive(true_annotations, pred_dict)
 
         pdf_doc.unload()
+
+
+BITMAP_PDF = "tests/data/regression/annots_01.pdf"
+
+
+def _make_bitmap_config() -> DecodePageConfig:
+    config = DecodePageConfig()
+    config.keep_bitmaps = True
+    config.do_sanitization = False
+    return config
+
+
+def test_bitmap_no_materialization_preserves_geometry():
+    """bitmap_resources count and rects match regardless of materialize_bitmap_bytes."""
+    parser = DoclingPdfParser(loglevel="fatal")
+    pdf_doc = parser.load(path_or_stream=BITMAP_PDF, lazy=True)
+
+    config_full = _make_bitmap_config()
+    config_full.materialize_bitmap_bytes = True
+
+    config_geo = _make_bitmap_config()
+    config_geo.materialize_bitmap_bytes = False
+
+    page_full = pdf_doc.get_page(1, config=config_full)
+    page_geo = pdf_doc.get_page(1, config=config_geo)
+
+    assert len(page_full.bitmap_resources) == len(page_geo.bitmap_resources), (
+        "bitmap count must match between full and geometry-only modes"
+    )
+    assert len(page_full.bitmap_resources) > 0, "test PDF must contain bitmaps"
+
+    eps = 1e-3
+    for i, (full, geo) in enumerate(
+        zip(page_full.bitmap_resources, page_geo.bitmap_resources)
+    ):
+        full_poly = full.rect.to_polygon()
+        geo_poly = geo.rect.to_polygon()
+        for pt in range(4):
+            assert abs(full_poly[pt][0] - geo_poly[pt][0]) < eps, (
+                f"bitmap {i} point {pt} x mismatch"
+            )
+            assert abs(full_poly[pt][1] - geo_poly[pt][1]) < eps, (
+                f"bitmap {i} point {pt} y mismatch"
+            )
+
+    pdf_doc.unload()
+
+
+def test_bitmap_no_materialization_has_no_image():
+    """materialize_bitmap_bytes=False produces placeholder resources with image=None."""
+    from docling_core.types.doc.base import ImageRefMode
+
+    parser = DoclingPdfParser(loglevel="fatal")
+    pdf_doc = parser.load(path_or_stream=BITMAP_PDF, lazy=True)
+
+    config = _make_bitmap_config()
+    config.materialize_bitmap_bytes = False
+
+    page = pdf_doc.get_page(1, config=config)
+    assert len(page.bitmap_resources) > 0, "test PDF must contain bitmaps"
+
+    for bm in page.bitmap_resources:
+        assert bm.image is None, (
+            "image must be None when materialize_bitmap_bytes=False"
+        )
+        assert bm.mode == ImageRefMode.PLACEHOLDER, (
+            "mode must be PLACEHOLDER when materialize_bitmap_bytes=False"
+        )
+
+
+def test_bitmap_materialization_cache_false_then_true():
+    """Requesting False then True for the same page returns the correct result each time."""
+    from docling_core.types.doc.base import ImageRefMode
+
+    parser = DoclingPdfParser(loglevel="fatal")
+    pdf_doc = parser.load(path_or_stream=BITMAP_PDF, lazy=True)
+
+    config_geo = _make_bitmap_config()
+    config_geo.materialize_bitmap_bytes = False
+
+    config_full = _make_bitmap_config()
+    config_full.materialize_bitmap_bytes = True
+
+    page_geo = pdf_doc.get_page(1, config=config_geo)
+    page_full = pdf_doc.get_page(1, config=config_full)
+
+    for bm in page_geo.bitmap_resources:
+        assert bm.image is None
+        assert bm.mode == ImageRefMode.PLACEHOLDER
+
+    assert any(bm.image is not None for bm in page_full.bitmap_resources), (
+        "at least one bitmap should be embedded when materialize_bitmap_bytes=True"
+    )
+
+    pdf_doc.unload()
+
+
+def test_bitmap_materialization_cache_true_then_false():
+    """Requesting True then False for the same page returns the correct result each time."""
+    from docling_core.types.doc.base import ImageRefMode
+
+    parser = DoclingPdfParser(loglevel="fatal")
+    pdf_doc = parser.load(path_or_stream=BITMAP_PDF, lazy=True)
+
+    config_full = _make_bitmap_config()
+    config_full.materialize_bitmap_bytes = True
+
+    config_geo = _make_bitmap_config()
+    config_geo.materialize_bitmap_bytes = False
+
+    page_full = pdf_doc.get_page(1, config=config_full)
+    page_geo = pdf_doc.get_page(1, config=config_geo)
+
+    assert any(bm.image is not None for bm in page_full.bitmap_resources), (
+        "at least one bitmap should be embedded when materialize_bitmap_bytes=True"
+    )
+
+    for bm in page_geo.bitmap_resources:
+        assert bm.image is None
+        assert bm.mode == ImageRefMode.PLACEHOLDER
+
+    pdf_doc.unload()

--- a/tests/test_threaded_parse.py
+++ b/tests/test_threaded_parse.py
@@ -309,3 +309,58 @@ def test_threaded_unload_during_active_iteration_raises():
 
     with pytest.raises(RuntimeError, match="threaded iteration is active"):
         parser.unload(key)
+
+
+BITMAP_PDF = "tests/data/regression/annots_01.pdf"
+
+
+def _make_bitmap_config() -> DecodePageConfig:
+    config = DecodePageConfig()
+    config.keep_bitmaps = True
+    config.do_sanitization = False
+    return config
+
+
+def test_threaded_bitmap_no_materialization_preserves_geometry():
+    """Threaded path: geometry matches between full and placeholder-only modes."""
+    from docling_core.types.doc.base import ImageRefMode
+
+    config_full = _make_bitmap_config()
+    config_full.materialize_bitmap_bytes = True
+
+    config_geo = _make_bitmap_config()
+    config_geo.materialize_bitmap_bytes = False
+
+    def _get_page1(decode_config: DecodePageConfig) -> "SegmentedPdfPage":
+        parser = DoclingThreadedPdfParser(
+            parser_config=ThreadedPdfParserConfig(loglevel="fatal", threads=2),
+            decode_config=decode_config,
+        )
+        parser.load(BITMAP_PDF)
+        return next(
+            r.get_page()
+            for r in parser.iterate_results()
+            if r.success and r.page_number == 1
+        )
+
+    page_full = _get_page1(config_full)
+    page_geo = _get_page1(config_geo)
+
+    assert len(page_full.bitmap_resources) > 0, "test PDF must contain bitmaps"
+    assert len(page_full.bitmap_resources) == len(page_geo.bitmap_resources)
+
+    eps = 1e-3
+    for i, (full, geo) in enumerate(
+        zip(page_full.bitmap_resources, page_geo.bitmap_resources)
+    ):
+        full_poly = full.rect.to_polygon()
+        geo_poly = geo.rect.to_polygon()
+        for pt in range(4):
+            assert abs(full_poly[pt][0] - geo_poly[pt][0]) < eps
+            assert abs(full_poly[pt][1] - geo_poly[pt][1]) < eps
+
+    for bm in page_geo.bitmap_resources:
+        assert bm.image is None
+        assert bm.mode == ImageRefMode.PLACEHOLDER
+
+    assert any(bm.image is not None for bm in page_full.bitmap_resources)


### PR DESCRIPTION
## Summary

- Add `materialize_bitmap_bytes: bool = True` to `DecodePageConfig` (C++ struct, consumed Python-side only). When `False`, `bitmap_resources` is populated with geometry but byte extraction is skipped — `BitmapResource.image` is `None`, `mode` is `PLACEHOLDER`.
- Widen `PdfDocument._pages` cache key from `int` → `tuple[int, bool]` to prevent a placeholder-cached page from satisfying a materialized request.
- `PageParseResult` receives `decode_config` at construction; `get_page()` reads `config.materialize_bitmap_bytes` — consistent with the non-threaded path, no separate argument.
- Add `__copy__` / `__deepcopy__` to the `DecodePageConfig` pybind binding; remove the hand-rolled `_copy_decode_config` function. New C++ fields are automatically covered by `copy.copy()`.