### PR TITLE
feat: refactoring the parsing of XObjects

### DIFF
--- a/app/parse.cpp
+++ b/app/parse.cpp
@@ -208,15 +208,9 @@ int main(int argc, char* argv[]) {
       parser.parse(config_file, page_config);
 
       double total_time = timer.get_time();
-      std::cout << "\ntimings:\n";
-      for(const auto& [key, val] : parser.get_timings())
-        {
-          if(pdflib::pdf_timings::is_static_key(key))
-            {
-              std::cout << "  " << std::setw(48) << std::left << key << val << " [sec]\n";
-            }
-        }
-      std::cout << std::setw(48) << std::left << "  total-time" << total_time << " [sec]" << std::endl;
+      std::cout << "\ntimings:\n"
+                << pdflib::pdf_timings::format_tree_table(parser.get_timings(), total_time)
+                << std::endl;
 
       return 0;
     }
@@ -267,15 +261,9 @@ int main(int argc, char* argv[]) {
       parser.parse(config, page_config);
 
       double total_time = timer.get_time();
-      std::cout << "\ntimings:\n";
-      for(const auto& [key, val] : parser.get_timings())
-        {
-          if(pdflib::pdf_timings::is_static_key(key))
-            {
-              std::cout << "  " << std::setw(48) << std::left << key << val << " [sec]\n";
-            }
-        }
-      std::cout << std::setw(48) << std::left << "  total-time" << total_time << " [sec]" << std::endl;
+      std::cout << "\ntimings:\n"
+                << pdflib::pdf_timings::format_tree_table(parser.get_timings(), total_time)
+                << std::endl;
 
       if (result.count("print-cells")) {
         std::string mode = result["print-cells"].as<std::string>();

--- a/src/parse/pdf_decoders/page.h
+++ b/src/parse/pdf_decoders/page.h
@@ -600,21 +600,41 @@ namespace pdflib
 
     int cnt = 0;
 
+    // Split decode_contents into: page content-stream tokenization
+    // (content_decode_total) vs. operator-execution self-time
+    // (interprete_ops_total). The latter is the interpretation wall time minus
+    // the sub-work attributed to other buckets (resource set(), parse_stream,
+    // do_image, do_form machinery) while interpreting -- see note_attributed().
+    double interprete_seconds = 0.0;
+    double attributed_before  = timings.attributed_total();
+
     std::vector<qpdf_stream_instruction> parameters;
     for(auto content:contents)
       {
         LOG_S(INFO) << "--------------- start decoding content stream (" << (cnt++) << ")... ---------------";
 
-        stream_decoder.decode(content);
+        {
+          utils::timer content_decode_timer;
+          stream_decoder.decode(content);
+          timings.add_timing(pdf_timings::KEY_CONTENT_DECODE_TOTAL, content_decode_timer.get_time());
+        }
         //stream_decoder.print();
 
-        stream_decoder.interprete(parameters);
+        {
+          utils::timer interprete_timer;
+          stream_decoder.interprete(parameters);
+          interprete_seconds += interprete_timer.get_time();
+        }
 
         if(parameters.size()>0)
           {
             LOG_S(WARNING) << "stream is ending with non-zero number of parameters";
           }
       }
+
+    double attributed_during = timings.attributed_total() - attributed_before;
+    timings.add_timing(pdf_timings::KEY_INTERPRETE_OPS_TOTAL,
+                       interprete_seconds - attributed_during);
   }
 
   void pdf_decoder<PAGE>::load_acroform_dr_fonts()

--- a/src/parse/pdf_decoders/stream.h
+++ b/src/parse/pdf_decoders/stream.h
@@ -354,7 +354,10 @@ namespace pdflib
     LOG_S(INFO) << "Do_Image: image with `" << xobj_name << "`";
 
     pdf_resource<PAGE_XOBJECT_IMAGE>& xobj = page_xobjects->get_image(xobj_name);
+
+    utils::timer do_image_timer;
     current_bitmap_state().Do_image(xobj);
+    timings.add_timing(pdf_timings::KEY_DO_IMAGE_TOTAL, do_image_timer.get_time());
   }
 
   void pdf_decoder<STREAM>::do_form(const std::string& xobj_name,
@@ -409,7 +412,9 @@ namespace pdflib
       current_global_state().cm(xobj.get_matrix());
 
       {
+        utils::timer parse_stream_timer;
         std::vector<qpdf_stream_instruction> insts = xobj.parse_stream();
+        timings.add_timing(pdf_timings::KEY_PARSE_STREAM_TOTAL, parse_stream_timer.get_time());
 
         pdf_decoder<STREAM> new_stream(config,
 

--- a/src/parse/pdf_decoders/stream.h
+++ b/src/parse/pdf_decoders/stream.h
@@ -357,13 +357,25 @@ namespace pdflib
 
     utils::timer do_image_timer;
     current_bitmap_state().Do_image(xobj);
-    timings.add_timing(pdf_timings::KEY_DO_IMAGE_TOTAL, do_image_timer.get_time());
+    double do_image_seconds = do_image_timer.get_time();
+    timings.add_timing(pdf_timings::KEY_DO_IMAGE_TOTAL, do_image_seconds);
+    timings.note_attributed(do_image_seconds);
   }
 
   void pdf_decoder<STREAM>::do_form(const std::string& xobj_name,
                                     const xobject_subtype_name& xobj_subtype)
   {
     LOG_S(INFO) << "Do_Form: XObject with name `" << xobj_name << "`";
+
+    // Time the whole call; the "machinery" cost (child-resource allocation,
+    // graphics-state copies via q()/Q(), stack copy in update_stack(), ...) is
+    // derived as: total - set() - parse_stream() - nested interprete(). The
+    // subtracted parts are bucketed under their own keys, so this residual is
+    // disjoint from them.
+    utils::timer do_form_timer;
+    double set_seconds          = 0.0;
+    double parse_stream_seconds = 0.0;
+    double interprete_seconds   = 0.0;
 
     pdf_resource<PAGE_XOBJECT_FORM>& xobj = page_xobjects->get_form(xobj_name);
 
@@ -373,11 +385,11 @@ namespace pdflib
       		<< bbox.at(1) << ", "
       		<< bbox.at(2) << ", "
       		<< bbox.at(3) << "]";
-    
+
     // check if (1) we keep data outside the page_boundary and
     // (2) if bbox is outside of page_boundary
     // please implement
-    
+
     // create child resources with parent link (no deep copy)
     auto page_fonts_    = std::make_shared<pdf_resource<PAGE_FONTS>>(page_fonts);
     auto page_grphs_    = std::make_shared<pdf_resource<PAGE_GRPHS>>(page_grphs);
@@ -385,6 +397,8 @@ namespace pdflib
 
     // parse the resources of the xobject into the child resources
     {
+      utils::timer set_timer;
+
       if(xobj.has_fonts())
         {
           QPDFObjectHandle xobj_fonts = xobj.get_fonts();
@@ -402,6 +416,8 @@ namespace pdflib
           QPDFObjectHandle xobj_xobjects = xobj.get_xobjects();
           page_xobjects_->set(xobj_xobjects, timings);
         }
+
+      set_seconds = set_timer.get_time();
     }
 
     {
@@ -414,7 +430,9 @@ namespace pdflib
       {
         utils::timer parse_stream_timer;
         std::vector<qpdf_stream_instruction> insts = xobj.parse_stream();
-        timings.add_timing(pdf_timings::KEY_PARSE_STREAM_TOTAL, parse_stream_timer.get_time());
+        parse_stream_seconds = parse_stream_timer.get_time();
+        timings.add_timing(pdf_timings::KEY_PARSE_STREAM_TOTAL, parse_stream_seconds);
+        timings.note_attributed(parse_stream_seconds);
 
         pdf_decoder<STREAM> new_stream(config,
 
@@ -430,12 +448,16 @@ namespace pdflib
                                        instructions,
 
                                        timings);
-	
+
         bool updated_stack = new_stream.update_stack(stack, stack_count);
 
         // copy the stack
         std::vector<qpdf_stream_instruction> parameters;
-        new_stream.interprete(insts, parameters);
+        {
+          utils::timer interprete_timer;
+          new_stream.interprete(insts, parameters);
+          interprete_seconds = interprete_timer.get_time();
+        }
 
         if(updated_stack)
           {
@@ -448,10 +470,16 @@ namespace pdflib
             unknown_operators.insert(item);
           }
       }
-      
+
       // pop-back the stack
       this->Q();
     }
+
+    // residual = state copies, child-resource allocation, stack handling, ...
+    double machinery_seconds = do_form_timer.get_time()
+                             - set_seconds - parse_stream_seconds - interprete_seconds;
+    timings.add_timing(pdf_timings::KEY_DO_FORM_MACHINERY, machinery_seconds);
+    timings.note_attributed(machinery_seconds);
 
     LOG_S(INFO) << "ending the execution of FORM XObject with name `" << xobj_name << "`";
 

--- a/src/parse/pdf_resources/page_font.h
+++ b/src/parse/pdf_resources/page_font.h
@@ -684,7 +684,7 @@ namespace pdflib
       qpdf_font = qpdf_font_;
 
       double font_time = font_timer.get_time();
-      timings.add_timing(pdf_timings::PREFIX_DECODE_FONT + font_key + " init font-copy", font_time);            
+      timings.add_timing(pdf_timings::KEY_FONT_INIT_COPY, font_time);
     }
     
     {
@@ -707,7 +707,7 @@ namespace pdflib
       init_char_widths();
 
       double font_time = font_timer.get_time();
-      timings.add_timing(pdf_timings::PREFIX_DECODE_FONT + font_key + " init font-metrics", font_time);      
+      timings.add_timing(pdf_timings::KEY_FONT_INIT_METRICS, font_time);
     }
     
     {
@@ -716,7 +716,7 @@ namespace pdflib
       init_cmap(timings);
 
       double font_time = font_timer.get_time();
-      timings.add_timing(pdf_timings::PREFIX_DECODE_FONT + font_key + " font-cmap", font_time);
+      timings.add_timing(pdf_timings::KEY_FONT_CMAP, font_time);
     }
 
     {
@@ -725,8 +725,8 @@ namespace pdflib
       init_cmap_resource();
 
       double font_time = font_timer.get_time();
-      timings.add_timing(pdf_timings::PREFIX_DECODE_FONT + font_key + " font-cmap-resources", font_time);
-    }    
+      timings.add_timing(pdf_timings::KEY_FONT_CMAP_RESOURCES, font_time);
+    }
     
     LOG_S(INFO) << __FUNCTION__ << "\t cmap-init: " << cmap_initialized;
     LOG_S(INFO) << __FUNCTION__ << "\t cmap-size: " << cmap_numb_to_char.size();
@@ -741,7 +741,7 @@ namespace pdflib
       init_space_index();
 
       double font_time = font_timer.get_time();
-      timings.add_timing(pdf_timings::PREFIX_DECODE_FONT + font_key + " font-chars", font_time);      
+      timings.add_timing(pdf_timings::KEY_FONT_CHARS, font_time);
     }
     
     unknown_numbs.clear();
@@ -1837,12 +1837,14 @@ namespace pdflib
 	      //decoder.print();
 
 	      double font_time = font_timer.get_time();
-	      timings.add_timing(pdf_timings::PREFIX_DECODE_FONT + font_key + " font-cmap-stream-decode", font_time);	      
+	      timings.add_timing(pdf_timings::KEY_FONT_CMAP_STREAM_DECODE, font_time);
 	    }
-	    
+
 	    // interprete the stream
 	    {
-	      std::string key_root = pdf_timings::PREFIX_DECODE_FONT + font_key;
+	      // empty key_root => cmap timings aggregate into the static
+	      // cmap-parse-* keys (rather than per-font dynamic keys)
+	      std::string key_root = "";
 
 	      cmap_parser parser;
 	      parser.parse(stream, timings, key_root);

--- a/src/parse/pdf_resources/page_fonts.h
+++ b/src/parse/pdf_resources/page_fonts.h
@@ -162,6 +162,7 @@ namespace pdflib
       }
 
     timings.add_timing(pdf_timings::KEY_DECODE_FONTS_TOTAL, total_font_time);
+    timings.note_attributed(total_font_time);
   }
 
 }

--- a/src/parse/pdf_resources/page_fonts.h
+++ b/src/parse/pdf_resources/page_fonts.h
@@ -157,7 +157,8 @@ namespace pdflib
 
 	double font_time = font_timer.get_time();
 	total_font_time += font_time;
-	timings.add_timing(pdf_timings::PREFIX_DECODE_FONT + key, font_time);
+	// per-font (dynamic) timing disabled for now; only the total is reported
+	//timings.add_timing(pdf_timings::PREFIX_DECODE_FONT + key, font_time);
       }
 
     timings.add_timing(pdf_timings::KEY_DECODE_FONTS_TOTAL, total_font_time);

--- a/src/parse/pdf_resources/page_grph.h
+++ b/src/parse/pdf_resources/page_grph.h
@@ -25,7 +25,9 @@ namespace pdflib
     nlohmann::json val;
   };
   
-  pdf_resource<PAGE_GRPH>::pdf_resource()
+  pdf_resource<PAGE_GRPH>::pdf_resource():
+    key(""),
+    val(nullptr)
   {}
   
   pdf_resource<PAGE_GRPH>::~pdf_resource()
@@ -40,9 +42,11 @@ namespace pdflib
 				    QPDFObjectHandle qpdf_grph)
   {
     key = key_;
-    val = to_json(qpdf_grph);
 
-    LOG_S(INFO) << key << ": " << val.dump(2);
+    // FIXME: skipping for now as there is no use ...
+    // val = to_json(qpdf_grph); 
+
+    //LOG_S(INFO) << key << ": " << val.dump(2);
   }
 
 }

--- a/src/parse/pdf_resources/page_grphs.h
+++ b/src/parse/pdf_resources/page_grphs.h
@@ -124,7 +124,7 @@ namespace pdflib
                                      pdf_timings& timings)
   {
     LOG_S(INFO) << __FUNCTION__;
-
+    
     double total_grph_time = 0.0;
 
     for(auto& key : qpdf_grphs.getKeys())
@@ -150,6 +150,7 @@ namespace pdflib
       }
 
     timings.add_timing(pdf_timings::KEY_DECODE_GRPHS_TOTAL, total_grph_time);
+    timings.note_attributed(total_grph_time);
   }
 
 }

--- a/src/parse/pdf_resources/page_grphs.h
+++ b/src/parse/pdf_resources/page_grphs.h
@@ -145,7 +145,8 @@ namespace pdflib
 
 	double grph_time = grph_timer.get_time();
 	total_grph_time += grph_time;
-	timings.add_timing(pdf_timings::PREFIX_DECODE_GRPH + key, grph_time);
+	// per-grph (dynamic) timing disabled for now; only the total is reported
+	//timings.add_timing(pdf_timings::PREFIX_DECODE_GRPH + key, grph_time);
       }
 
     timings.add_timing(pdf_timings::KEY_DECODE_GRPHS_TOTAL, total_grph_time);

--- a/src/parse/pdf_resources/page_xobject_form.h
+++ b/src/parse/pdf_resources/page_xobject_form.h
@@ -85,7 +85,7 @@ namespace pdflib
   void pdf_resource<PAGE_XOBJECT_FORM>::set(std::string      xobject_key_,
                                              QPDFObjectHandle qpdf_xobject_)
   {
-    LOG_S(INFO) << __FUNCTION__ << ": " << xobject_key_;
+    // LOG_S(INFO) << __FUNCTION__ << ": " << xobject_key_;
 
     xobject_key  = xobject_key_;
     qpdf_xobject = qpdf_xobject_;
@@ -95,7 +95,7 @@ namespace pdflib
 
   void pdf_resource<PAGE_XOBJECT_FORM>::parse()
   {
-    LOG_S(INFO) << __FUNCTION__;
+    // LOG_S(INFO) << __FUNCTION__;
 
     qpdf_xobject_dict = qpdf_xobject.getDict();
 
@@ -138,7 +138,7 @@ namespace pdflib
 	return qpdf_xobject_dict.getKey(RESOURCES_KEY).getKey(FONTS_KEY);
       }
 
-    LOG_S(WARNING) << "no '/Font' key detected in xobject dict";
+    // LOG_S(WARNING) << "no '/Font' key detected in xobject dict";
     return QPDFObjectHandle::newNull();
   }
 
@@ -149,7 +149,7 @@ namespace pdflib
 	return qpdf_xobject_dict.getKey(RESOURCES_KEY).getKey(GRPHS_KEY);
       }
 
-    LOG_S(WARNING) << "no '/ExtGState' key detected in xobject dict";
+    // LOG_S(WARNING) << "no '/ExtGState' key detected in xobject dict";
     return QPDFObjectHandle::newNull();
   }
 
@@ -160,7 +160,7 @@ namespace pdflib
 	return qpdf_xobject_dict.getKey(RESOURCES_KEY).getKey(XOBJS_KEY);
       }
 
-    LOG_S(WARNING) << "no '/XObject' key detected in xobject dict";
+    // LOG_S(WARNING) << "no '/XObject' key detected in xobject dict";
     return QPDFObjectHandle::newNull();
   }
 
@@ -180,8 +180,8 @@ namespace pdflib
       {
         std::stringstream ss;
         ss << "encountered an error: " << exc.what();
-
         LOG_S(ERROR) << ss.str();
+	
         throw std::logic_error(ss.str());
       }
 
@@ -190,7 +190,7 @@ namespace pdflib
 
   void pdf_resource<PAGE_XOBJECT_FORM>::parse_matrix()
   {
-    LOG_S(INFO) << __FUNCTION__;
+    // LOG_S(INFO) << __FUNCTION__;
     
     matrix = {1., 0., 0., 1., 0., 0.};
 
@@ -203,7 +203,7 @@ namespace pdflib
         if(matrix.size()!=qpdf_matrix.getArrayNItems())
           {
             std::string message = "matrix.size()!=qpdf_matrix.getArrayNItems()";
-            LOG_S(ERROR) << message;
+	    LOG_S(ERROR) << message;
             throw std::logic_error(message);
           }
 
@@ -216,9 +216,9 @@ namespace pdflib
               }
             else
               {
-                LOG_S(WARNING) << "'/Matrix'[" << l << "] is not a number (type: "
-                               << num.getTypeName() << "), keeping identity default "
-                               << matrix[l];
+                //LOG_S(WARNING) << "'/Matrix'[" << l << "] is not a number (type: "
+		//<< num.getTypeName() << "), keeping identity default "
+		//<< matrix[l];
               }
           }
 
@@ -232,13 +232,13 @@ namespace pdflib
       }
     else
       {
-        LOG_S(WARNING) << "no '/Matrix' key detected";
+        // LOG_S(WARNING) << "no '/Matrix' key detected";
       }
   }
 
   void pdf_resource<PAGE_XOBJECT_FORM>::parse_bbox()
   {
-    LOG_S(INFO) << __FUNCTION__;
+    // LOG_S(INFO) << __FUNCTION__;
     
     bbox = {0., 0., 0., 0.};
 
@@ -270,15 +270,15 @@ namespace pdflib
               }
           }
 
-	LOG_S(INFO) << "bbox: ["
-		    << bbox.at(0) << ", "
-		    << bbox.at(1) << ", "
-		    << bbox.at(2) << ", "
-		    << bbox.at(3) << "]";		
+	    //LOG_S(INFO) << "bbox: ["
+	    // << bbox.at(0) << ", "
+	    // << bbox.at(1) << ", "
+	    // << bbox.at(2) << ", "
+	    // << bbox.at(3) << "]";		
       }
     else
       {
-        LOG_S(ERROR) << "no '/BBox' key detected and it is required!";
+	LOG_S(ERROR) << "no '/BBox' key detected and it is required!";
       }
   }
 

--- a/src/parse/pdf_resources/page_xobject_form.h
+++ b/src/parse/pdf_resources/page_xobject_form.h
@@ -99,8 +99,15 @@ namespace pdflib
     LOG_S(INFO) << __FUNCTION__;
 
     {
+      utils::timer parse_timer;
+
       qpdf_xobject_dict = qpdf_xobject.getDict();
+      LOG_S(INFO) << __FUNCTION__ << ": getDict took " << parse_timer.get_time(utils::MILLI_SEC) << " ms";
+
+      parse_timer.reset();
       json_xobject_dict = to_json(qpdf_xobject_dict);
+      LOG_S(INFO) << __FUNCTION__ << ": to_json(qpdf_xobject_dict) took " << parse_timer.get_time(utils::MILLI_SEC)
+		  << " ms (recursively serialises the whole xobject dict + nested /Resources just to read /Matrix and /BBox)";
     }
 
     parse_matrix();

--- a/src/parse/pdf_resources/page_xobject_form.h
+++ b/src/parse/pdf_resources/page_xobject_form.h
@@ -54,7 +54,6 @@ namespace pdflib
     QPDFObjectHandle qpdf_xobject;
 
     QPDFObjectHandle qpdf_xobject_dict;
-    nlohmann::json   json_xobject_dict;
 
     std::string xobject_key;
 
@@ -98,17 +97,7 @@ namespace pdflib
   {
     LOG_S(INFO) << __FUNCTION__;
 
-    {
-      utils::timer parse_timer;
-
-      qpdf_xobject_dict = qpdf_xobject.getDict();
-      LOG_S(INFO) << __FUNCTION__ << ": getDict took " << parse_timer.get_time(utils::MILLI_SEC) << " ms";
-
-      parse_timer.reset();
-      json_xobject_dict = to_json(qpdf_xobject_dict);
-      LOG_S(INFO) << __FUNCTION__ << ": to_json(qpdf_xobject_dict) took " << parse_timer.get_time(utils::MILLI_SEC)
-		  << " ms (recursively serialises the whole xobject dict + nested /Resources just to read /Matrix and /BBox)";
-    }
+    qpdf_xobject_dict = qpdf_xobject.getDict();
 
     parse_matrix();
     parse_bbox();
@@ -205,21 +194,32 @@ namespace pdflib
     
     matrix = {1., 0., 0., 1., 0., 0.};
 
-    std::vector<std::string> keys = {"/Matrix"};
-    if(utils::json::has(keys, json_xobject_dict))
+    // Read the '/Matrix' array directly off the qpdf dict instead of going
+    // through a full recursive to_json of the xobject dict.
+    if(qpdf_xobject_dict.hasKey("/Matrix") and qpdf_xobject_dict.getKey("/Matrix").isArray())
       {
-        nlohmann::json json_matrix = utils::json::get(keys, json_xobject_dict);
+        QPDFObjectHandle qpdf_matrix = qpdf_xobject_dict.getKey("/Matrix");
 
-        if(matrix.size()!=json_matrix.size())
+        if(matrix.size()!=qpdf_matrix.getArrayNItems())
           {
-            std::string message = "matrix.size()!=json_matrix.size()";
+            std::string message = "matrix.size()!=qpdf_matrix.getArrayNItems()";
             LOG_S(ERROR) << message;
             throw std::logic_error(message);
           }
 
         for(int l=0; l<matrix.size(); l++)
           {
-            matrix[l] = json_matrix[l].get<double>();
+            QPDFObjectHandle num = qpdf_matrix.getArrayItem(l);
+            if(num.isNumber())
+              {
+                matrix[l] = utils::numeric::locale_safe_numeric_value(num);
+              }
+            else
+              {
+                LOG_S(WARNING) << "'/Matrix'[" << l << "] is not a number (type: "
+                               << num.getTypeName() << "), keeping identity default "
+                               << matrix[l];
+              }
           }
 
 	LOG_S(INFO) << "matrix: ["
@@ -242,21 +242,32 @@ namespace pdflib
     
     bbox = {0., 0., 0., 0.};
 
-    std::vector<std::string> keys = {"/BBox"};
-    if(utils::json::has(keys, json_xobject_dict))
+    // Read the '/BBox' array directly off the qpdf dict instead of going
+    // through a full recursive to_json of the xobject dict.
+    if(qpdf_xobject_dict.hasKey("/BBox") and qpdf_xobject_dict.getKey("/BBox").isArray())
       {
-        nlohmann::json json_bbox = utils::json::get(keys, json_xobject_dict);
+        QPDFObjectHandle qpdf_bbox = qpdf_xobject_dict.getKey("/BBox");
 
-        if(bbox.size()!=json_bbox.size())
+        if(bbox.size()!=qpdf_bbox.getArrayNItems())
           {
-            std::string message = "bbox.size()!=json_bbox.size()";
+            std::string message = "bbox.size()!=qpdf_bbox.getArrayNItems()";
             LOG_S(ERROR) << message;
             throw std::logic_error(message);
           }
 
         for(int l=0; l<bbox.size(); l++)
           {
-            bbox[l] = json_bbox[l].get<double>();
+            QPDFObjectHandle num = qpdf_bbox.getArrayItem(l);
+            if(num.isNumber())
+              {
+                bbox[l] = utils::numeric::locale_safe_numeric_value(num);
+              }
+            else
+              {
+                LOG_S(ERROR) << "'/BBox'[" << l << "] is not a number (type: "
+                             << num.getTypeName() << "), keeping default "
+                             << bbox[l] << " (bbox is required!)";
+              }
           }
 
 	LOG_S(INFO) << "bbox: ["

--- a/src/parse/pdf_resources/page_xobjects.h
+++ b/src/parse/pdf_resources/page_xobjects.h
@@ -166,8 +166,15 @@ namespace pdflib
 	return XOBJECT_UNKNOWN;
       }
     
-    QPDFObjectHandle dict = qpdf_obj.getDict(); // only works on a stream! 
+    utils::timer subtype_timer;
+
+    QPDFObjectHandle dict = qpdf_obj.getDict(); // only works on a stream!
+    LOG_S(INFO) << __FUNCTION__ << ": getDict took " << subtype_timer.get_time(utils::MILLI_SEC) << " ms";
+
+    subtype_timer.reset();
     nlohmann::json json_dict = to_json(dict);
+    LOG_S(INFO) << __FUNCTION__ << ": to_json(dict) took " << subtype_timer.get_time(utils::MILLI_SEC)
+		<< " ms (recursively serialises the whole xobject dict just to read /Subtype)";
 
     if(json_dict.count("/Subtype"))
       {

--- a/src/parse/pdf_resources/page_xobjects.h
+++ b/src/parse/pdf_resources/page_xobjects.h
@@ -287,6 +287,7 @@ namespace pdflib
       }
 
     timings.add_timing(pdf_timings::KEY_DECODE_XOBJECTS_TOTAL, total_xobject_time);
+    timings.note_attributed(total_xobject_time);
   }
 
 }

--- a/src/parse/pdf_resources/page_xobjects.h
+++ b/src/parse/pdf_resources/page_xobjects.h
@@ -282,7 +282,8 @@ namespace pdflib
 
 	double xobject_time = xobject_timer.get_time();
 	total_xobject_time += xobject_time;
-	timings.add_timing(pdf_timings::PREFIX_DECODE_XOBJECT + key, xobject_time);
+	// per-xobject (dynamic) timing disabled for now; only the total is reported
+	//timings.add_timing(pdf_timings::PREFIX_DECODE_XOBJECT + key, xobject_time);
       }
 
     timings.add_timing(pdf_timings::KEY_DECODE_XOBJECTS_TOTAL, total_xobject_time);

--- a/src/parse/pdf_resources/page_xobjects.h
+++ b/src/parse/pdf_resources/page_xobjects.h
@@ -166,32 +166,31 @@ namespace pdflib
 	return XOBJECT_UNKNOWN;
       }
     
-    utils::timer subtype_timer;
-
     QPDFObjectHandle dict = qpdf_obj.getDict(); // only works on a stream!
-    LOG_S(INFO) << __FUNCTION__ << ": getDict took " << subtype_timer.get_time(utils::MILLI_SEC) << " ms";
 
-    subtype_timer.reset();
-    nlohmann::json json_dict = to_json(dict);
-    LOG_S(INFO) << __FUNCTION__ << ": to_json(dict) took " << subtype_timer.get_time(utils::MILLI_SEC)
-		<< " ms (recursively serialises the whole xobject dict just to read /Subtype)";
-
-    if(json_dict.count("/Subtype"))
+    // Read only the '/Subtype' key directly instead of recursively serialising
+    // the whole xobject dict (including nested /Resources) into json.
+    std::string subtype = "";
+    if(dict.hasKey("/Subtype") and dict.getKey("/Subtype").isName())
       {
-        std::string subtype = json_dict["/Subtype"].get<std::string>();
+        subtype = dict.getKey("/Subtype").getName();
+      }
+    else if(dict.hasKey("/Subtype") and dict.getKey("/Subtype").isString())
+      {
+        subtype = dict.getKey("/Subtype").getUTF8Value();
+      }
 
-        if(subtype=="/Image")
-          {
-            return XOBJECT_IMAGE;
-          }
-        else if(subtype=="/Form")
-          {
-            return XOBJECT_FORM;
-          }
-        else if(subtype=="/PS")
-          {
-            return XOBJECT_POSTSCRIPT;
-          }
+    if(subtype=="/Image")
+      {
+        return XOBJECT_IMAGE;
+      }
+    else if(subtype=="/Form")
+      {
+        return XOBJECT_FORM;
+      }
+    else if(subtype=="/PS")
+      {
+        return XOBJECT_POSTSCRIPT;
       }
 
     LOG_S(ERROR) << "unknown XObject subtype";

--- a/src/parse/utils/pdf_timings.h
+++ b/src/parse/utils/pdf_timings.h
@@ -65,8 +65,21 @@ namespace pdflib
     // Form xobject stream decompression + tokenization (do_form -> parse_stream)
     static const std::string KEY_PARSE_STREAM_TOTAL;
 
+    // Form xobject machinery: child-resource allocation, graphics-state copies
+    // (q()/Q()), stack copy (update_stack) -- i.e. do_form cost that is NOT
+    // resource-parsing, stream-decoding or nested interpretation.
+    static const std::string KEY_DO_FORM_MACHINERY;
+
     // Image xobject drawing/extraction (do_image -> Do_image)
     static const std::string KEY_DO_IMAGE_TOTAL;
+
+    // Top-level page content-stream tokenization (decode_contents -> decode)
+    static const std::string KEY_CONTENT_DECODE_TOTAL;
+
+    // Operator-execution self-time: time spent interpreting operators across
+    // all (recursion) levels, excluding the sub-work bucketed under the keys
+    // above. Derived as a residual in decode_contents.
+    static const std::string KEY_INTERPRETE_OPS_TOTAL;
 
     // Grphs timing keys
     static const std::string KEY_DECODE_GRPHS_TOTAL;
@@ -151,6 +164,21 @@ namespace pdflib
      */
     static std::string format_tree_table(const std::unordered_map<std::string, double>& sums,
                                           double total_time = -1.0);
+
+    /**
+     * @brief Accountancy used to derive operator self-time.
+     *
+     * Bucketed sub-tasks that run *inside* the interpretation loop
+     * (resource set(), parse_stream, do_image, do_form machinery) call
+     * note_attributed() with their measured duration. decode_contents reads
+     * attributed_total() before/after interpreting to compute the
+     * operator-execution self-time as: interprete_total - attributed_delta.
+     *
+     * This works because a single pdf_timings instance is threaded by
+     * reference through the page decoder and all (recursive) stream decoders.
+     */
+    void   note_attributed(double seconds);
+    double attributed_total() const;
 
     pdf_timings();
     ~pdf_timings();
@@ -248,6 +276,9 @@ namespace pdflib
      *        that children appear under their parent in a sensible order.
      */
     static const std::vector<std::pair<std::string, std::string>>& get_containment_pairs();
+
+    // running total of time attributed to bucketed sub-tasks
+    double attributed_seconds_ = 0.0;
 
     std::unordered_map<std::string, std::vector<double>> timings_;
   };
@@ -398,7 +429,10 @@ namespace pdflib
   const std::string pdf_timings::KEY_FONT_CHARS = "font: font-chars";
   const std::string pdf_timings::KEY_DECODE_XOBJECTS_TOTAL = "decode_xobjects_total";
   const std::string pdf_timings::KEY_PARSE_STREAM_TOTAL = "parse_stream_total";
+  const std::string pdf_timings::KEY_DO_FORM_MACHINERY = "do_form_machinery_total";
   const std::string pdf_timings::KEY_DO_IMAGE_TOTAL = "do_image_total";
+  const std::string pdf_timings::KEY_CONTENT_DECODE_TOTAL = "content_decode_total";
+  const std::string pdf_timings::KEY_INTERPRETE_OPS_TOTAL = "interprete_ops_total";
   const std::string pdf_timings::KEY_DECODE_GRPHS_TOTAL = "decode_grphs_total";
 
   // Additional decode_page step keys
@@ -455,7 +489,10 @@ namespace pdflib
       KEY_CMAP_PARSE_ENDCODESPACERANGE,
       KEY_DECODE_XOBJECTS_TOTAL,
       KEY_PARSE_STREAM_TOTAL,
+      KEY_DO_FORM_MACHINERY,
       KEY_DO_IMAGE_TOTAL,
+      KEY_CONTENT_DECODE_TOTAL,
+      KEY_INTERPRETE_OPS_TOTAL,
       KEY_DECODE_GRPHS_TOTAL,
       KEY_TO_JSON_PAGE,
       KEY_EXTRACT_ANNOTS_JSON,
@@ -529,10 +566,13 @@ namespace pdflib
       {KEY_SANITISE_CONTENTS,              KEY_DECODE_PAGE},
 
       // --- decode_contents sub-timings ---
+      {KEY_CONTENT_DECODE_TOTAL,           KEY_DECODE_CONTENTS},
+      {KEY_INTERPRETE_OPS_TOTAL,           KEY_DECODE_CONTENTS},
       {KEY_DECODE_XOBJECTS_TOTAL,          KEY_DECODE_CONTENTS},
       {KEY_DECODE_GRPHS_TOTAL,             KEY_DECODE_CONTENTS},
       {KEY_DECODE_FONTS_TOTAL,             KEY_DECODE_CONTENTS},
       {KEY_PARSE_STREAM_TOTAL,             KEY_DECODE_CONTENTS},
+      {KEY_DO_FORM_MACHINERY,              KEY_DECODE_CONTENTS},
       {KEY_DO_IMAGE_TOTAL,                 KEY_DECODE_CONTENTS},
 
       // --- sanitise_contents sub-timings ---
@@ -554,6 +594,16 @@ namespace pdflib
       {KEY_CMAP_PARSE_ENDCODESPACERANGE,   KEY_CMAP_PARSE_TOTAL},
     };
     return pairs;
+  }
+
+  void pdf_timings::note_attributed(double seconds)
+  {
+    attributed_seconds_ += seconds;
+  }
+
+  double pdf_timings::attributed_total() const
+  {
+    return attributed_seconds_;
   }
 
   std::string pdf_timings::get_parent_key(const std::string& key)

--- a/src/parse/utils/pdf_timings.h
+++ b/src/parse/utils/pdf_timings.h
@@ -5,7 +5,12 @@
 
 #include <string>
 #include <vector>
+#include <utility>
 #include <numeric>
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <iomanip>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -46,8 +51,22 @@ namespace pdflib
     // Font timing keys
     static const std::string KEY_DECODE_FONTS_TOTAL;
 
+    // Font sub-timing categories (aggregated across all fonts)
+    static const std::string KEY_FONT_INIT_COPY;
+    static const std::string KEY_FONT_INIT_METRICS;
+    static const std::string KEY_FONT_CMAP;
+    static const std::string KEY_FONT_CMAP_STREAM_DECODE;
+    static const std::string KEY_FONT_CMAP_RESOURCES;
+    static const std::string KEY_FONT_CHARS;
+
     // XObject timing keys
     static const std::string KEY_DECODE_XOBJECTS_TOTAL;
+
+    // Form xobject stream decompression + tokenization (do_form -> parse_stream)
+    static const std::string KEY_PARSE_STREAM_TOTAL;
+
+    // Image xobject drawing/extraction (do_image -> Do_image)
+    static const std::string KEY_DO_IMAGE_TOTAL;
 
     // Grphs timing keys
     static const std::string KEY_DECODE_GRPHS_TOTAL;
@@ -89,6 +108,49 @@ namespace pdflib
      * @return Keys in the same order as they appear in decode_page.
      */
     static const std::vector<std::string>& get_decode_page_keys();
+
+    /**
+     * @brief Get the parent timing key under which `key` is accounted.
+     *
+     * Returns the key that `key` is a sub-timing of (e.g.
+     * KEY_DECODE_XOBJECTS_TOTAL -> KEY_DECODE_CONTENTS), or "" when `key`
+     * is a top-level (root) key. Handles both static keys and dynamic
+     * per-item keys (e.g. "decode_xobject: /Tr1624" -> decode_xobjects_total).
+     *
+     * NOTE: the *_total keys (fonts/xobjects/grphs) are physically
+     * accumulated across decode_resources, decode_contents and decode_annots.
+     * For a single-parent tree they are attributed to their typically
+     * dominant parent, decode_contents.
+     */
+    static std::string get_parent_key(const std::string& key);
+
+    /**
+     * @brief Get the canonical containment tree of timing keys.
+     *
+     * Maps a parent key to its ordered list of child keys. The synthetic
+     * root "" holds the top-level keys. Intended for rendering a nested
+     * (tree-shaped) timings table.
+     */
+    static const std::unordered_map<std::string, std::vector<std::string>>& get_key_tree();
+
+    /**
+     * @brief Render the timings as a nested tree table.
+     *
+     * Produces a table where:
+     *   - each tree level is its own column (L0, L1, ... Ln),
+     *   - "time[s]" is the summed time accounted to that key,
+     *   - "%branch" is the key's share within its branch, i.e. relative to
+     *     the sum of all siblings sharing the same parent.
+     *
+     * Keys present in `sums` but unknown to the tree are listed at the top
+     * level so nothing is silently dropped.
+     *
+     * @param sums       key -> summed time (e.g. from to_sum_map()).
+     * @param total_time optional wall-clock total appended as a final row
+     *                   (pass a negative value to omit it).
+     */
+    static std::string format_tree_table(const std::unordered_map<std::string, double>& sums,
+                                          double total_time = -1.0);
 
     pdf_timings();
     ~pdf_timings();
@@ -180,6 +242,13 @@ namespace pdflib
     std::unordered_map<std::string, double> get_dynamic_timings() const;
 
   private:
+    /**
+     * @brief Canonical (child, parent) containment pairs; single source of
+     *        truth for both get_parent_key() and get_key_tree(). Ordered so
+     *        that children appear under their parent in a sensible order.
+     */
+    static const std::vector<std::pair<std::string, std::string>>& get_containment_pairs();
+
     std::unordered_map<std::string, std::vector<double>> timings_;
   };
 
@@ -321,7 +390,15 @@ namespace pdflib
   const std::string pdf_timings::KEY_CREATE_LINE_CELLS = "create_line_cells";
 
   const std::string pdf_timings::KEY_DECODE_FONTS_TOTAL = "decode_fonts_total";
+  const std::string pdf_timings::KEY_FONT_INIT_COPY = "font: init-copy";
+  const std::string pdf_timings::KEY_FONT_INIT_METRICS = "font: init-metrics";
+  const std::string pdf_timings::KEY_FONT_CMAP = "font: font-cmap";
+  const std::string pdf_timings::KEY_FONT_CMAP_STREAM_DECODE = "font: font-cmap-stream-decode";
+  const std::string pdf_timings::KEY_FONT_CMAP_RESOURCES = "font: font-cmap-resources";
+  const std::string pdf_timings::KEY_FONT_CHARS = "font: font-chars";
   const std::string pdf_timings::KEY_DECODE_XOBJECTS_TOTAL = "decode_xobjects_total";
+  const std::string pdf_timings::KEY_PARSE_STREAM_TOTAL = "parse_stream_total";
+  const std::string pdf_timings::KEY_DO_IMAGE_TOTAL = "do_image_total";
   const std::string pdf_timings::KEY_DECODE_GRPHS_TOTAL = "decode_grphs_total";
 
   // Additional decode_page step keys
@@ -345,11 +422,11 @@ namespace pdflib
   const std::string pdf_timings::PREFIX_DECODING_PAGE = "decoding page ";
   const std::string pdf_timings::PREFIX_DECODE_PAGE = "decode_page ";
 
-  // CMap parsing timing keys
-  const std::string pdf_timings::KEY_CMAP_PARSE_TOTAL = " cmap-parse-total";
-  const std::string pdf_timings::KEY_CMAP_PARSE_ENDBFCHAR = " cmap-parse-endbfchar";
-  const std::string pdf_timings::KEY_CMAP_PARSE_ENDBFRANGE = " cmap-parse-endbfrange";
-  const std::string pdf_timings::KEY_CMAP_PARSE_ENDCODESPACERANGE = " cmap-parse-endcodespacerange";
+  // CMap parsing timing keys (aggregated across all fonts)
+  const std::string pdf_timings::KEY_CMAP_PARSE_TOTAL = "cmap-parse-total";
+  const std::string pdf_timings::KEY_CMAP_PARSE_ENDBFCHAR = "cmap-parse-endbfchar";
+  const std::string pdf_timings::KEY_CMAP_PARSE_ENDBFRANGE = "cmap-parse-endbfrange";
+  const std::string pdf_timings::KEY_CMAP_PARSE_ENDCODESPACERANGE = "cmap-parse-endcodespacerange";
 
   const std::unordered_set<std::string>& pdf_timings::get_static_keys()
   {
@@ -366,7 +443,19 @@ namespace pdflib
       KEY_CREATE_WORD_CELLS,
       KEY_CREATE_LINE_CELLS,
       KEY_DECODE_FONTS_TOTAL,
+      KEY_FONT_INIT_COPY,
+      KEY_FONT_INIT_METRICS,
+      KEY_FONT_CMAP,
+      KEY_FONT_CMAP_STREAM_DECODE,
+      KEY_FONT_CMAP_RESOURCES,
+      KEY_FONT_CHARS,
+      KEY_CMAP_PARSE_TOTAL,
+      KEY_CMAP_PARSE_ENDBFCHAR,
+      KEY_CMAP_PARSE_ENDBFRANGE,
+      KEY_CMAP_PARSE_ENDCODESPACERANGE,
       KEY_DECODE_XOBJECTS_TOTAL,
+      KEY_PARSE_STREAM_TOTAL,
+      KEY_DO_IMAGE_TOTAL,
       KEY_DECODE_GRPHS_TOTAL,
       KEY_TO_JSON_PAGE,
       KEY_EXTRACT_ANNOTS_JSON,
@@ -405,6 +494,236 @@ namespace pdflib
       KEY_SANITISE_CONTENTS
     };
     return decode_page_keys;
+  }
+
+  const std::vector<std::pair<std::string, std::string>>& pdf_timings::get_containment_pairs()
+  {
+    // (child, parent) pairs. Parent "" denotes a top-level (root) key.
+    //
+    // The *_total keys (fonts/xobjects/grphs) are physically accumulated
+    // across decode_resources, decode_contents and decode_annots; for a
+    // single-parent tree they are attributed to decode_contents, which is
+    // their dominant parent in practice.
+    static const std::vector<std::pair<std::string, std::string>> pairs = {
+      // --- document loading ---
+      {KEY_PROCESS_DOCUMENT_FROM_FILE,     ""},
+      {KEY_PROCESS_DOCUMENT_FROM_BYTESIO,  KEY_PROCESS_DOCUMENT_FROM_FILE},
+      {KEY_QPDF_PROCESS,                   KEY_PROCESS_DOCUMENT_FROM_BYTESIO},
+      {KEY_QPDF_BUILD_THREAD_SAFE_BUFFER,  KEY_PROCESS_DOCUMENT_FROM_BYTESIO},
+      {KEY_EXTRACT_DOC_ANNOTATIONS,        KEY_PROCESS_DOCUMENT_FROM_BYTESIO},
+
+      // --- page decoding ---
+      {KEY_DECODE_DOCUMENT,                ""},
+      {KEY_PROCESS_DOCUMENT_COMPONENTS,    KEY_DECODE_DOCUMENT},
+      {KEY_DECODE_PAGE,                    KEY_DECODE_DOCUMENT},
+
+      {KEY_TO_JSON_PAGE,                   KEY_DECODE_PAGE},
+      {KEY_EXTRACT_ANNOTS_JSON,            KEY_DECODE_PAGE},
+      {KEY_DECODE_DIMENSIONS,              KEY_DECODE_PAGE},
+      {KEY_DECODE_RESOURCES,               KEY_DECODE_PAGE},
+      {KEY_DECODE_CONTENTS,                KEY_DECODE_PAGE},
+      {KEY_DECODE_ANNOTS,                  KEY_DECODE_PAGE},
+      {KEY_ROTATE_CONTENTS,                KEY_DECODE_PAGE},
+      {KEY_SANITIZE_ORIENTATION,           KEY_DECODE_PAGE},
+      {KEY_SANITIZE_CELLS,                 KEY_DECODE_PAGE},
+      {KEY_SANITISE_CONTENTS,              KEY_DECODE_PAGE},
+
+      // --- decode_contents sub-timings ---
+      {KEY_DECODE_XOBJECTS_TOTAL,          KEY_DECODE_CONTENTS},
+      {KEY_DECODE_GRPHS_TOTAL,             KEY_DECODE_CONTENTS},
+      {KEY_DECODE_FONTS_TOTAL,             KEY_DECODE_CONTENTS},
+      {KEY_PARSE_STREAM_TOTAL,             KEY_DECODE_CONTENTS},
+      {KEY_DO_IMAGE_TOTAL,                 KEY_DECODE_CONTENTS},
+
+      // --- sanitise_contents sub-timings ---
+      {KEY_CREATE_WORD_CELLS,              KEY_SANITISE_CONTENTS},
+      {KEY_CREATE_LINE_CELLS,              KEY_SANITISE_CONTENTS},
+
+      // --- font sub-timings (aggregated across fonts) ---
+      {KEY_FONT_INIT_COPY,                 KEY_DECODE_FONTS_TOTAL},
+      {KEY_FONT_INIT_METRICS,              KEY_DECODE_FONTS_TOTAL},
+      {KEY_FONT_CMAP,                      KEY_DECODE_FONTS_TOTAL},
+      {KEY_FONT_CMAP_STREAM_DECODE,        KEY_FONT_CMAP},
+      {KEY_FONT_CMAP_RESOURCES,            KEY_DECODE_FONTS_TOTAL},
+      {KEY_FONT_CHARS,                     KEY_DECODE_FONTS_TOTAL},
+
+      // --- font cmap parsing sub-timings (live under font: font-cmap) ---
+      {KEY_CMAP_PARSE_TOTAL,               KEY_FONT_CMAP},
+      {KEY_CMAP_PARSE_ENDBFCHAR,           KEY_CMAP_PARSE_TOTAL},
+      {KEY_CMAP_PARSE_ENDBFRANGE,          KEY_CMAP_PARSE_TOTAL},
+      {KEY_CMAP_PARSE_ENDCODESPACERANGE,   KEY_CMAP_PARSE_TOTAL},
+    };
+    return pairs;
+  }
+
+  std::string pdf_timings::get_parent_key(const std::string& key)
+  {
+    // Dynamic per-item keys roll up into their corresponding *_total parent.
+    auto starts_with = [&key](const std::string& prefix)
+      {
+        return key.size()>=prefix.size() and key.compare(0, prefix.size(), prefix)==0;
+      };
+
+    if(starts_with(PREFIX_DECODE_FONT))    { return KEY_DECODE_FONTS_TOTAL; }
+    if(starts_with(PREFIX_DECODE_XOBJECT)) { return KEY_DECODE_XOBJECTS_TOTAL; }
+    if(starts_with(PREFIX_DECODE_GRPH))    { return KEY_DECODE_GRPHS_TOTAL; }
+
+    static const std::unordered_map<std::string, std::string> parent_of = []
+      {
+        std::unordered_map<std::string, std::string> m;
+        for(const auto& pair : get_containment_pairs())
+          {
+            m[pair.first] = pair.second;
+          }
+        return m;
+      }();
+
+    auto itr = parent_of.find(key);
+    return itr!=parent_of.end() ? itr->second : std::string();
+  }
+
+  const std::unordered_map<std::string, std::vector<std::string>>& pdf_timings::get_key_tree()
+  {
+    static const std::unordered_map<std::string, std::vector<std::string>> tree = []
+      {
+        std::unordered_map<std::string, std::vector<std::string>> t;
+        for(const auto& pair : get_containment_pairs())
+          {
+            t[pair.second].push_back(pair.first); // parent -> child (ordered)
+          }
+        return t;
+      }();
+    return tree;
+  }
+
+  std::string pdf_timings::format_tree_table(const std::unordered_map<std::string, double>& sums,
+                                             double total_time)
+  {
+    const auto& tree = get_key_tree();
+
+    auto sum_of = [&sums](const std::string& key) -> double
+      {
+        auto itr = sums.find(key);
+        return itr!=sums.end() ? itr->second : 0.0;
+      };
+
+    auto children_of = [&tree](const std::string& key) -> const std::vector<std::string>*
+      {
+        auto itr = tree.find(key);
+        return itr!=tree.end() ? &itr->second : nullptr;
+      };
+
+    // A node is shown if it -- or any of its descendants -- has a measured time.
+    std::function<bool(const std::string&)> has_data =
+      [&](const std::string& key) -> bool
+      {
+        if(sums.find(key)!=sums.end()) { return true; }
+        if(const auto* ch = children_of(key))
+          {
+            for(const auto& c : *ch) { if(has_data(c)) { return true; } }
+          }
+        return false;
+      };
+
+    // Collect rows in depth-first (tree) order: (depth, key).
+    std::vector<std::pair<int, std::string>> rows;
+    std::function<void(const std::string&, int)> dfs =
+      [&](const std::string& key, int depth) -> void
+      {
+        if(const auto* ch = children_of(key))
+          {
+            for(const auto& c : *ch)
+              {
+                if(not has_data(c)) { continue; }
+                rows.push_back({depth, c});
+                dfs(c, depth+1);
+              }
+          }
+      };
+    dfs("", 0);
+
+    // Static keys present in sums but unknown to the tree: surface them at top
+    // level so a measured timing is never silently dropped. Dynamic per-item
+    // keys (e.g. "decode_xobject: /Tr123" or "decode_page 0") are intentionally
+    // skipped here -- they are not part of the static tree.
+    {
+      static const std::unordered_set<std::string> known = []
+        {
+          std::unordered_set<std::string> s;
+          for(const auto& pair : get_containment_pairs()) { s.insert(pair.first); }
+          return s;
+        }();
+      for(const auto& kv : sums)
+        {
+          if(is_static_key(kv.first) and known.find(kv.first)==known.end())
+            {
+              rows.push_back({0, kv.first});
+            }
+        }
+    }
+
+    // %branch = node time / sum of sibling times (children sharing a parent).
+    auto branch_pct = [&](const std::string& key) -> double
+      {
+        std::string parent = get_parent_key(key);
+        double denom = 0.0;
+        if(const auto* ch = children_of(parent))
+          {
+            for(const auto& c : *ch) { if(has_data(c)) { denom += sum_of(c); } }
+          }
+        return denom>0.0 ? 100.0*sum_of(key)/denom : 0.0;
+      };
+
+    // Per-level column widths, sized to their content.
+    int max_depth = 0;
+    for(const auto& r : rows) { max_depth = std::max(max_depth, r.first); }
+
+    std::vector<size_t> width(max_depth+1, 4);
+    for(const auto& r : rows) { width[r.first] = std::max(width[r.first], r.second.size()); }
+
+    const int time_w = 14;
+    const int pct_w  = 10;
+
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(6);
+
+    // header
+    for(int d=0; d<=max_depth; d++)
+      {
+        ss << std::left << std::setw((int)width[d]+2) << ("L"+std::to_string(d));
+      }
+    ss << std::right << std::setw(time_w) << "time[s]"
+       << std::setw(pct_w) << "%branch" << "\n";
+
+    // rows
+    for(const auto& r : rows)
+      {
+        int depth = r.first;
+        const std::string& key = r.second;
+
+        for(int d=0; d<=max_depth; d++)
+          {
+            ss << std::left << std::setw((int)width[d]+2) << (d==depth ? key : std::string());
+          }
+
+        ss << std::right << std::setw(time_w) << sum_of(key);
+
+        std::stringstream pct;
+        pct << std::fixed << std::setprecision(1) << branch_pct(key) << "%";
+        ss << std::setw(pct_w) << pct.str() << "\n";
+      }
+
+    // wall-clock total
+    if(total_time>=0.0)
+      {
+        size_t name_span = 0;
+        for(int d=0; d<=max_depth; d++) { name_span += width[d]+2; }
+
+        ss << std::left << std::setw((int)name_span) << "total-time (wall clock)"
+           << std::right << std::setw(time_w) << total_time << "\n";
+      }
+
+    return ss.str();
   }
 
 }


### PR DESCRIPTION
resolves: https://github.com/docling-project/docling/issues/2109
supercedes: https://github.com/docling-project/docling-parse/pull/279

**Problem**

Currently, we have a very expensive `to_json`part in XObject parsing (eg page 2 in https://arxiv.org/pdf/2508.13113),

```
  2026-06-24 11:40:29.776 ( 160.993s) [main thread     ]        page_xobjects.h:212   INFO| decoding xobject:
  /Tr1624    282/2301
  2026-06-24 11:40:29.776 ( 160.993s) [main thread     ]        page_xobjects.h:161   INFO| detect_subtype: stream
  2026-06-24 11:40:29.806 ( 161.022s) [main thread     ]    page_xobject_form.h:89    INFO| set: /Tr1624
  2026-06-24 11:40:29.806 ( 161.022s) [main thread     ]    page_xobject_form.h:99    INFO| parse
  2026-06-24 11:40:29.834 ( 161.051s) [main thread     ]    page_xobject_form.h:197   INFO| parse_matrix
  2026-06-24 11:40:29.835 ( 161.052s) [main thread     ]    page_xobject_form.h:228   WARN| no '/Matrix' key
  detected
  2026-06-24 11:40:29.835 ( 161.052s) [main thread     ]    page_xobject_form.h:234   INFO| parse_bbox
  2026-06-24 11:40:29.836 ( 161.053s) [main thread     ]    page_xobject_form.h:255   INFO| bbox: [720.85,
  160.866, 726.378, 166.395]
  2026-06-24 11:40:29.837 ( 161.053s) [main thread     ]        page_xobjects.h:212   INFO| decoding xobject:
  /Tr1627    283/2301 
```

with the current optimization, the rendering of the page 2 takes ~26sec,

```
./render.exe -i ../2508.13113v2.pdf -p 1 --scale 2 --draw-text-bbox -l fatal  

26.46s user 0.15s system 97% cpu 27.335 total
```

**Scaling**

```sh
uv run python ./perf/run_scaling.py --other "" --threads "1,2,4,8,12" --materialize-line-cells true

Benchmark: 753 documents, 54584 total pages
Mode: render
Thread counts to test: [1, 2, 4, 8, 12]
Max concurrent results: 64
Other backends: (none)
Render scale: 1.0

Decode config:
parameter                                       value
--------------------------------------------  -------
do_sanitization                                  1
enforce_same_font                                1
horizontal_cell_tolerance                        1
word_space_width_factor_for_merge                0.33
line_space_width_factor_for_merge                1
line_space_width_factor_for_merge_with_space     0.33
max_num_lines                                   -1
max_num_bitmaps                                 -1
do_thread_safe                                   1
release_native_memory_every_n_pages              0
keep_glyphs                                      0
keep_qpdf_warnings                               0

Content config:
parameter                   value
------------------------  -------
char_cells_content_level        1
word_cells_content_level        0
line_cells_content_level        2
shapes_content_level            0
bitmaps_content_level           0
include_bitmap_bytes            0

Render config:
parameter                   value
------------------------  -------
render_text                  1
draw_text_bbox               0
draw_text_basepoint          0
fit_glyph_bbox_to_target     0
resolve_fonts                1
font_similarity_cutoff       0.75
scale                        1
canvas_width                -1
canvas_height               -1


backend             threads    wall_time (s)  vs threaded(1)      pages/sec    ms/page
----------------  ---------  ---------------  ----------------  -----------  ---------
docling threaded          1          878.863  1.00x                    62.1      16.1
docling threaded          2          458.405  1.92x                   119.1       8.4
docling threaded          4          240.48   3.65x                   227         4.41
docling threaded          8          152.4    5.77x                   358.2       2.79
docling threaded         12          138.449  6.35x                   394.3       2.54
```
