### PR TITLE
feat: LRU cache eviction for PDF page decoders

### DIFF
--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -275,6 +275,7 @@ PYBIND11_MODULE(pdf_parsers, m) {
         max_num_lines (int): Maximum number of lines to keep (-1 means no cap) [default=-1].
         max_num_bitmaps (int): Maximum number of bitmaps to keep (-1 means no cap) [default=-1].
         min_visible_clip_extent (float): Minimum clip width/height treated as a usable image clip [default=1e-3].
+        max_cached_pages (int): Maximum number of page decoders in the LRU cache (-1 means no cap) [default=32].
         keep_glyphs (bool): If true, keep GLYPH<...> fallback strings in output; if false, replace them with a space [default=false].
         keep_qpdf_warnings (bool): If true, QPDF warnings are emitted; if false, they are suppressed [default=false].
     )")
@@ -287,6 +288,7 @@ PYBIND11_MODULE(pdf_parsers, m) {
     .def_readwrite("max_num_lines", &pdflib::decode_config::max_num_lines)
     .def_readwrite("max_num_bitmaps", &pdflib::decode_config::max_num_bitmaps)
     .def_readwrite("min_visible_clip_extent", &pdflib::decode_config::min_visible_clip_extent)
+    .def_readwrite("max_cached_pages", &pdflib::decode_config::max_cached_pages)
     .def_readwrite("create_word_cells", &pdflib::decode_config::create_word_cells)
     .def_readwrite("create_line_cells", &pdflib::decode_config::create_line_cells)
     .def_readwrite("enforce_same_font", &pdflib::decode_config::enforce_same_font)

--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -261,6 +261,7 @@ class DecodeConfig(BaseModel):
     max_num_lines: int = -1
     max_num_bitmaps: int = -1
     min_visible_clip_extent: float = 1e-3
+    max_cached_pages: int = 32
     do_thread_safe: bool = True
     release_native_memory_every_n_pages: int = 0
     keep_glyphs: bool = False
@@ -291,6 +292,7 @@ def _compile_decode_config(
     cpp.max_num_lines = decode_config.max_num_lines
     cpp.max_num_bitmaps = decode_config.max_num_bitmaps
     cpp.min_visible_clip_extent = decode_config.min_visible_clip_extent
+    cpp.max_cached_pages = decode_config.max_cached_pages
     cpp.do_thread_safe = decode_config.do_thread_safe
     cpp.release_native_memory_every_n_pages = (
         decode_config.release_native_memory_every_n_pages

--- a/src/parse/config.h
+++ b/src/parse/config.h
@@ -22,6 +22,9 @@ namespace pdflib
     int max_num_bitmaps = -1; // -1 means no cap
     double min_visible_clip_extent = DEFAULT_MIN_VISIBLE_CLIP_EXTENT;
 
+    // max pages held in decoder_pages cache
+    int max_cached_pages = 32;
+
     bool create_word_cells = true;
     bool create_line_cells = true;
     bool enforce_same_font = true;      // word & line cell creation
@@ -70,6 +73,7 @@ namespace pdflib
     j["max_num_lines"] = max_num_lines;
     j["max_num_bitmaps"] = max_num_bitmaps;
     j["min_visible_clip_extent"] = min_visible_clip_extent;
+    j["max_cached_pages"] = max_cached_pages;
 
     j["create_word_cells"] = create_word_cells;
     j["create_line_cells"] = create_line_cells;
@@ -104,6 +108,7 @@ namespace pdflib
     if(j.count("max_num_lines")) { max_num_lines = j["max_num_lines"]; }
     if(j.count("max_num_bitmaps")) { max_num_bitmaps = j["max_num_bitmaps"]; }
     if(j.count("min_visible_clip_extent")) { min_visible_clip_extent = j["min_visible_clip_extent"]; }
+    if(j.count("max_cached_pages")) { max_cached_pages = j["max_cached_pages"]; }
 
     if(j.count("create_word_cells")) { create_word_cells = j["create_word_cells"]; }
     if(j.count("create_line_cells")) { create_line_cells = j["create_line_cells"]; }
@@ -165,6 +170,7 @@ namespace pdflib
        << std::setw(48) << "max_num_lines" << max_num_lines << "\n"
        << std::setw(48) << "max_num_bitmaps" << max_num_bitmaps << "\n"
        << std::setw(48) << "min_visible_clip_extent" << min_visible_clip_extent << "\n"
+       << std::setw(48) << "max_cached_pages" << max_cached_pages << "\n"
        << std::setw(48) << "create_word_cells" << (create_word_cells ? "true" : "false") << "\n"
        << std::setw(48) << "create_line_cells" << (create_line_cells ? "true" : "false") << "\n"
        << std::setw(48) << "enforce_same_font" << (enforce_same_font ? "true" : "false") << "\n"

--- a/src/parse/pdf_decoders/document.h
+++ b/src/parse/pdf_decoders/document.h
@@ -89,6 +89,24 @@ namespace pdflib
 
     // New: Persistent page decoders for typed API
     std::map<int, page_decoder_ptr> page_decoders;
+    std::list<int> page_access_order;
+    size_t max_cached_pages = 16;
+
+    void update_page_access(int page_number) {
+      // Remove from current position if exists
+      page_access_order.remove(page_number);
+      // Add to back (most recently used)
+      page_access_order.push_back(page_number);
+    }
+    
+    void evict_lru_page() {
+        if (!page_access_order.empty()) {
+            int lru_page = page_access_order.front();
+            page_access_order.pop_front();
+            page_decoders.erase(lru_page);
+            LOG_S(INFO) << "Evicted LRU page " << lru_page << " from cache";
+        }
+      }
   };
 
   pdf_decoder<DOCUMENT>::pdf_decoder():
@@ -450,6 +468,9 @@ namespace pdflib
 
     // Store in cache
     page_decoders[page_number] = page_decoder;
+    update_page_access(page_number);
+    // LRU eviction if cache exceeds limit
+    if(page_decoders.size() > max_cached_pages) evict_lru_page(); 
 
     std::stringstream ss;
     ss << pdf_timings::PREFIX_DECODE_PAGE << page_number;
@@ -463,6 +484,7 @@ namespace pdflib
     if(page_decoders.count(page_number) > 0)
       {
         page_decoders.erase(page_number);
+        page_access_order.remove(page_number); 
         LOG_S(INFO) << "unloaded page decoder for page: " << page_number;
       }
 
@@ -472,6 +494,7 @@ namespace pdflib
   bool pdf_decoder<DOCUMENT>::unload_pages()
   {
     page_decoders.clear();
+    page_access_order.clear();
     LOG_S(INFO) << "unloaded all page decoders";
 
     return true;

--- a/src/parse/pdf_decoders/document.h
+++ b/src/parse/pdf_decoders/document.h
@@ -90,7 +90,6 @@ namespace pdflib
     // New: Persistent page decoders for typed API
     std::map<int, page_decoder_ptr> page_decoders;
     std::list<int> page_access_order;
-    size_t max_cached_pages = 16;
 
     void update_page_access(int page_number) {
       // Remove from current position if exists
@@ -469,8 +468,12 @@ namespace pdflib
     // Store in cache
     page_decoders[page_number] = page_decoder;
     update_page_access(page_number);
+
     // LRU eviction if cache exceeds limit
-    if(page_decoders.size() > max_cached_pages) evict_lru_page(); 
+    if((config.max_cached_pages >= 0) and (page_decoders.size() > static_cast<size_t>(config.max_cached_pages)))
+      {
+        evict_lru_page(); 
+      }
 
     std::stringstream ss;
     ss << pdf_timings::PREFIX_DECODE_PAGE << page_number;


### PR DESCRIPTION
## Description

This PR adds a Least Recently Used cache eviction policy for pdf page decoders, preventing unbounded memory growth when processing many large PDF documents in succession. This resolves the bug described in this [comment](https://github.com/docling-project/docling-serve/issues/366#issuecomment-4728834016) on [docling-serve issue #366](https://github.com/docling-project/docling-serve/issues/366).

## Fix

Replacing unbounded page decoder accumulation with an LRU-bounded cache of max 16 live page decoders eliminated the observed steady RSS growth when converting many large PDFs in succession.

Before:
<img width="3240" height="1440" alt="before-res_chronological_rss_lines" src="https://github.com/user-attachments/assets/6899cfb7-770b-48c5-99d0-c9d08786cf5a" />

After:
<img width="3240" height="1440" alt="after-res_chronological_rss_lines" src="https://github.com/user-attachments/assets/c6f9e69b-92b9-4348-adae-b9825696f71c" />

## Testing

The script below was ran within a docling dev environment with the locally edited docling-parse dependency installed. A folder of real-world, diverse pdfs of varying sizes ~1 MB - ~20 MB was used. This was done on a Macbook pro m4 36 GB.
[check_mem.py](https://github.com/user-attachments/files/29351744/check_mem.py)
