### PR TITLE
feat: attack embedded fonts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,6 +25,10 @@ jobs:
           uv sync --frozen --all-extras
           ls -l
           ls -l docling_parse
+          # setuptools' editable_wheel demotes native build failures to a
+          # warning, leaving an importable package without the extension;
+          # fail loudly here instead of at pytest collection.
+          ls docling_parse/pdf_parsers*.so
       - name: Run styling check
         run: |
           uv run pre-commit run --all-files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,10 +113,11 @@ include(cmake/extlib_lcms2.cmake)
 # include(cmake/extlib_qpdf_v11.cmake)
 include(cmake/extlib_qpdf_v12.cmake)
 include(cmake/extlib_blend2d.cmake)
+include(cmake/extlib_freetype.cmake)
 include(cmake/extlib_pdfium_jbig2.cmake)
 
 # aggregate the targets created by the dependencies
-set(DEPENDENCIES qpdf jpeg openjpeg lcms2 utf8 json loguru cxxopts blend2d pdfium_jbig2)
+set(DEPENDENCIES qpdf jpeg openjpeg lcms2 utf8 json loguru cxxopts blend2d freetype pdfium_jbig2)
 
 # ************************
 # *** libraries        ***

--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -93,6 +93,7 @@ namespace
       row["base_x0"] = instr.get_base_x0();
       row["base_y0"] = instr.get_base_y0();
       row["char_code"] = instr.get_char_code();
+      row["glyph_name"] = instr.get_glyph_name();
       // Embedded font metadata only — never the raw font bytes.
       row["has_embedded_font"] = instr.has_embedded_font();
       if(instr.has_embedded_font())

--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -92,6 +92,21 @@ namespace
       row["font_descent_norm"] = instr.get_font_descent_norm();
       row["base_x0"] = instr.get_base_x0();
       row["base_y0"] = instr.get_base_y0();
+      row["char_code"] = instr.get_char_code();
+      // Embedded font metadata only — never the raw font bytes.
+      row["has_embedded_font"] = instr.has_embedded_font();
+      if(instr.has_embedded_font())
+        {
+          const auto& blob = instr.get_embedded_font();
+          pybind11::dict embedded;
+          embedded["source_key"] = blob->get_source_key();
+          embedded["format"] = pdflib::to_string(blob->get_format());
+          embedded["byte_size"] = blob->byte_size();
+          embedded["cache_key"] = blob->get_cache_key();
+          embedded["is_cid_font"] = blob->get_is_cid_font();
+          embedded["cid_to_gid_identity"] = blob->get_cid_to_gid_identity();
+          row["embedded_font"] = embedded;
+        }
       row["quad"] = make_quad_dict(
         instr.get_r_x0(), instr.get_r_y0(),
         instr.get_r_x1(), instr.get_r_y1(),
@@ -298,6 +313,7 @@ PYBIND11_MODULE(pdf_parsers, m) {
     .def_readwrite("release_native_memory_every_n_pages", &pdflib::decode_config::release_native_memory_every_n_pages)
     .def_readwrite("keep_glyphs", &pdflib::decode_config::keep_glyphs)
     .def_readwrite("keep_qpdf_warnings", &pdflib::decode_config::keep_qpdf_warnings)
+    .def_readwrite("extract_font_programs", &pdflib::decode_config::extract_font_programs)
     .def("__copy__", [](const pdflib::decode_config& self) { return self; })
     .def("__deepcopy__", [](const pdflib::decode_config& self, pybind11::dict) { return self; });
 
@@ -1050,6 +1066,7 @@ PYBIND11_MODULE(pdf_parsers, m) {
         draw_text_basepoint (bool): Draw the text baseline origin as a small red dot [default=false].
         fit_glyph_bbox_to_target (bool): Uniformly rescale measured glyph outlines so the rendered bbox fits inside the target glyph bbox, with either width or height matching exactly [default=false].
         resolve_fonts (bool): Resolve PDF font names to system fonts [default=true].
+        use_embedded_fonts (bool): Prefer embedded font programs over system font resolution when the PDF provides them and they are loadable [default=true].
         font_similarity_cutoff (float): Minimum Jaccard similarity for fuzzy font matching; candidates below this threshold fall back to the default font [default=0.25].
         scale (float): Target render scale in multiples of the PDF page size; -1 disables scale-based sizing [default=-1].
         canvas_width (int): Target canvas width in pixels; -1 means use PDF page size [default=-1].
@@ -1061,6 +1078,7 @@ PYBIND11_MODULE(pdf_parsers, m) {
     .def_readwrite("draw_text_basepoint",     &pdflib::render_config::draw_text_basepoint)
     .def_readwrite("fit_glyph_bbox_to_target",&pdflib::render_config::fit_glyph_bbox_to_target)
     .def_readwrite("resolve_fonts",           &pdflib::render_config::resolve_fonts)
+    .def_readwrite("use_embedded_fonts",      &pdflib::render_config::use_embedded_fonts)
     .def_readwrite("font_similarity_cutoff",  &pdflib::render_config::font_similarity_cutoff)
     .def_readwrite("scale",                   &pdflib::render_config::scale)
     .def_readwrite("canvas_width",            &pdflib::render_config::canvas_width)

--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -1066,7 +1066,7 @@ PYBIND11_MODULE(pdf_parsers, m) {
         draw_text_basepoint (bool): Draw the text baseline origin as a small red dot [default=false].
         fit_glyph_bbox_to_target (bool): Uniformly rescale measured glyph outlines so the rendered bbox fits inside the target glyph bbox, with either width or height matching exactly [default=false].
         resolve_fonts (bool): Resolve PDF font names to system fonts [default=true].
-        use_embedded_fonts (bool): Prefer embedded font programs over system font resolution when the PDF provides them and they are loadable [default=true].
+        use_embedded_fonts (bool): Prefer embedded font programs (TrueType/OpenType via Blend2D, Type 1/CFF via FreeType outlines) over system font resolution [default=true].
         font_similarity_cutoff (float): Minimum Jaccard similarity for fuzzy font matching; candidates below this threshold fall back to the default font [default=0.25].
         scale (float): Target render scale in multiples of the PDF page size; -1 disables scale-based sizing [default=-1].
         canvas_width (int): Target canvas width in pixels; -1 means use PDF page size [default=-1].

--- a/app/render.cpp
+++ b/app/render.cpp
@@ -239,6 +239,7 @@ int main(int argc, char* argv[])
         ("line-space-factor-with-space", "Space-width factor for line merging with space (default: 0.33)", cxxopts::value<double>())
         ("keep-glyphs",        "Keep unmapped GLYPH<...> tokens (default: false)",          cxxopts::value<bool>()->implicit_value("true"))
         ("keep-qpdf-warnings", "Emit QPDF warnings (default: false)",                       cxxopts::value<bool>()->implicit_value("true"))
+        ("extract-font-programs", "Extract embedded font programs for rendering (default: true)", cxxopts::value<bool>()->implicit_value("true"))
         ("populate-json",      "Populate JSON objects during decode (default: false)",       cxxopts::value<bool>()->implicit_value("true"))
         ("export-bitmaps",     "Export decoded bitmap payloads encountered on each page (default: false)",
                                cxxopts::value<bool>()->default_value("false"))
@@ -306,6 +307,9 @@ int main(int argc, char* argv[])
       if (result.count("line-space-factor-with-space")) { page_config.line_space_width_factor_for_merge_with_space = result["line-space-factor-with-space"].as<double>(); }
       if (result.count("keep-glyphs"))              { page_config.keep_glyphs               = result["keep-glyphs"].as<bool>(); }
       if (result.count("keep-qpdf-warnings"))       { page_config.keep_qpdf_warnings        = result["keep-qpdf-warnings"].as<bool>(); }
+      // This app always renders, so embedded font extraction defaults to on.
+      page_config.extract_font_programs = true;
+      if (result.count("extract-font-programs"))    { page_config.extract_font_programs     = result["extract-font-programs"].as<bool>(); }
       if (result.count("populate-json"))            { page_config.populate_json_objects      = result["populate-json"].as<bool>(); }
       bool export_bitmaps = result["export-bitmaps"].as<bool>();
       bool export_page_pdf_files = result["export-page-pdf"].as<bool>();

--- a/cmake/extlib_blend2d.cmake
+++ b/cmake/extlib_blend2d.cmake
@@ -48,8 +48,10 @@ else()
     FetchContent_Declare(
         blend2d
         GIT_REPOSITORY https://github.com/blend2d/blend2d.git
-        GIT_TAG        master
-        GIT_SHALLOW    TRUE
+        # Pinned so the (renamed, snake_case) C++ API cannot drift under us;
+        # bump deliberately. This is the commit the font-rendering code was
+        # validated against.
+        GIT_TAG        6dbc2cefbc996379e07104e34519a440b49b15d7
     )
     FetchContent_MakeAvailable(blend2d)
     # FetchContent creates the target "blend2d" (and alias blend2d::blend2d).

--- a/cmake/extlib_freetype.cmake
+++ b/cmake/extlib_freetype.cmake
@@ -42,6 +42,12 @@ else()
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \\
         -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES} \\
         -DCMAKE_C_FLAGS=${ENV_ARCHFLAGS} \\
+        # Pin the sub-build type and disable FreeType's forced "d" debug
+        # postfix: with the outer CMAKE_BUILD_TYPE=Debug (e.g. the CI checks
+        # workflow) FreeType would otherwise install libfreetyped.a and the
+        # IMPORTED_LOCATION below would dangle, breaking the final link.
+        -DCMAKE_BUILD_TYPE=Release \\
+        -DDISABLE_FORCE_DEBUG_POSTFIX=ON \\
         -DBUILD_SHARED_LIBS=OFF \\
         -DFT_DISABLE_ZLIB=ON \\
         -DFT_DISABLE_BZIP2=ON \\

--- a/cmake/extlib_freetype.cmake
+++ b/cmake/extlib_freetype.cmake
@@ -1,0 +1,67 @@
+
+message(STATUS "entering in extlib_freetype.cmake")
+
+set(ext_name "freetype")
+
+if(USE_SYSTEM_DEPS)
+    # Standard CMake module; provides Freetype::Freetype.
+    find_package(Freetype REQUIRED)
+    if(NOT TARGET freetype)
+        add_library(${ext_name} ALIAS Freetype::Freetype)
+    endif()
+
+else()
+    include(ExternalProject)
+    include(CMakeParseArguments)
+
+    file(MAKE_DIRECTORY ${EXTERNALS_PREFIX_PATH}/include)
+    file(MAKE_DIRECTORY ${EXTERNALS_PREFIX_PATH}/include/freetype2)
+    file(MAKE_DIRECTORY ${EXTERNALS_PREFIX_PATH}/lib)
+
+    set(FREETYPE_URL https://github.com/freetype/freetype.git)
+    set(FREETYPE_TAG VER-2-13-3)
+    set(FREETYPE_IMPORTED_LIB ${EXTERNALS_PREFIX_PATH}/lib/libfreetype.a)
+
+    # All optional codec/shaping dependencies are disabled: the renderer only
+    # needs outline loading for Type 1 / CFF / TrueType font programs, and a
+    # dependency-free static build keeps every wheel platform (incl.
+    # windows-arm64) simple.
+    ExternalProject_Add(extlib_freetype
+
+        PREFIX extlib_freetype
+
+        UPDATE_COMMAND ""
+        GIT_REPOSITORY ${FREETYPE_URL}
+        GIT_TAG ${FREETYPE_TAG}
+
+        BUILD_ALWAYS OFF
+
+        INSTALL_DIR ${EXTERNALS_PREFIX_PATH}
+
+        CMAKE_ARGS \\
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \\
+        -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES} \\
+        -DCMAKE_C_FLAGS=${ENV_ARCHFLAGS} \\
+        -DBUILD_SHARED_LIBS=OFF \\
+        -DFT_DISABLE_ZLIB=ON \\
+        -DFT_DISABLE_BZIP2=ON \\
+        -DFT_DISABLE_PNG=ON \\
+        -DFT_DISABLE_HARFBUZZ=ON \\
+        -DFT_DISABLE_BROTLI=ON \\
+        -DCMAKE_INSTALL_LIBDIR=${EXTERNALS_PREFIX_PATH}/lib \\
+        -DCMAKE_INSTALL_PREFIX=${EXTERNALS_PREFIX_PATH}
+
+        # FreeType's CMakeLists rejects in-source builds, so (unlike the other
+        # extlibs) build in ExternalProject's separate binary directory.
+        BUILD_IN_SOURCE OFF
+        LOG_DOWNLOAD ON
+    )
+
+    add_library(${ext_name} STATIC IMPORTED)
+    add_dependencies(${ext_name} extlib_freetype)
+    set_target_properties(${ext_name} PROPERTIES
+        IMPORTED_LOCATION ${FREETYPE_IMPORTED_LIB}
+        INTERFACE_INCLUDE_DIRECTORIES "${EXTERNALS_PREFIX_PATH}/include/freetype2;${EXTERNALS_PREFIX_PATH}/include"
+    )
+
+endif()

--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -1360,6 +1360,7 @@ def _copy_render_config(src: RenderConfig) -> RenderConfig:
     dst.render_text = src.render_text
     dst.draw_text_bbox = src.draw_text_bbox
     dst.resolve_fonts = src.resolve_fonts
+    dst.use_embedded_fonts = src.use_embedded_fonts
     dst.font_similarity_cutoff = src.font_similarity_cutoff
     dst.scale = src.scale
     dst.canvas_width = src.canvas_width

--- a/docling_parse/pdf_resources/glyphs/custom/TeX/glyphs_03.dat
+++ b/docling_parse/pdf_resources/glyphs/custom/TeX/glyphs_03.dat
@@ -49,7 +49,7 @@ Iroman;0406
 # Unicode approximations for text extraction)
 # OT1 slot 040: the crossbar overlaid on l/L to build lslash; zero-width
 # space keeps extracted text clean ("suppress"+"l" -> "l")
-suppress;200B
+# suppress;200B
 # vertical extension module of big double arrows (cmex-style fonts)
 arrowvertexdbl;2016
 # MSBM short vertical bar (negation piece)

--- a/docling_parse/pdf_resources/glyphs/custom/TeX/glyphs_03.dat
+++ b/docling_parse/pdf_resources/glyphs/custom/TeX/glyphs_03.dat
@@ -44,3 +44,19 @@ hard;044A
 Hard;042A
 iroman;0456
 Iroman;0406
+# --- TeX glyph names with no assignment in lcdf-typetools texglyphlist.txt ---
+# (texglyphlist marks most of these "XXX"; mappings below are the closest
+# Unicode approximations for text extraction)
+# OT1 slot 040: the crossbar overlaid on l/L to build lslash; zero-width
+# space keeps extracted text clean ("suppress"+"l" -> "l")
+suppress;200B
+# vertical extension module of big double arrows (cmex-style fonts)
+arrowvertexdbl;2016
+# MSBM short vertical bar (negation piece)
+barshort;2223
+# MSBM dashed-arrow pieces: axis-height dash segment and arrowhead pieces
+axisshort;2212
+arrowaxisleft;21E0
+arrowaxisright;21E2
+# MSAM/MSBM small filled square
+squaresmallsolid;25AA

--- a/scripts/export_dclx.py
+++ b/scripts/export_dclx.py
@@ -12,7 +12,7 @@ docling-parse plus the rendered page image and assembles a
 The document is then serialized with ``save_as_doclang_archive`` to a ``.dclx``.
 
 Usage:
-    python scripts/export_dclx.py -i input.pdf [-m word] [-o out.dclx]
+    python scripts/export_dclx.py -i input.pdf [-m word] [-p 1] [-o out.dclx]
 
 Modes:
     char  -> one TextItem per character cell
@@ -61,6 +61,8 @@ def parse_args(argv=None):
                     help="Cell granularity exported as TextItems (default: word).")
     ap.add_argument("-o", "--output", type=Path, default=None,
                     help="Output .dclx path (default: <input>.<mode>.dclx).")
+    ap.add_argument("-p", "--page", type=int, default=None,
+                    help="1-indexed page number to export (default: all pages).")
     ap.add_argument("--scale", type=float, default=2.0,
                     help="Page-image raster scale in pixels-per-point (default: 2.0).")
     ap.add_argument("--threads", type=int, default=4,
@@ -120,8 +122,10 @@ def _add_page_to_doc(doc, page_no, page, image, dpi, unit):
     return n_cells, n_pictures
 
 
-def export(input_path: Path, mode: str, scale: float, threads: int) -> DoclingDocument:
+def export(input_path: Path, mode: str, scale: float, threads: int,
+           page: int | None = None) -> DoclingDocument:
     content_config = _content_config_for(mode)
+    page_numbers = [page] if page is not None else None
 
     render_config = RenderConfig()
     render_config.render_text = True
@@ -139,7 +143,7 @@ def export(input_path: Path, mode: str, scale: float, threads: int) -> DoclingDo
     # the DoclingDocument is assembled in natural reading order.
     pages = {}
     try:
-        parser.load(str(input_path))
+        parser.load(str(input_path), page_numbers=page_numbers)
         for result in parser.iterate_results():
             if not result.success:
                 print(f"  warning: page {result.page_number} failed: "
@@ -177,10 +181,20 @@ def main(argv=None):
         print(f"error: input not found: {args.input}", file=sys.stderr)
         return 1
 
-    print(f"Exporting '{args.input}' (mode={args.mode}, scale={args.scale}) ...")
-    doc = export(args.input, args.mode, args.scale, args.threads)
+    if args.page is not None and args.page < 1:
+        print(f"error: --page must be >= 1 (got {args.page})", file=sys.stderr)
+        return 1
 
-    output = args.output or args.input.with_suffix(f".{args.mode}.dclx")
+    page_label = f", page={args.page}" if args.page is not None else ""
+    print(f"Exporting '{args.input}' (mode={args.mode}, scale={args.scale}{page_label}) ...")
+    doc = export(args.input, args.mode, args.scale, args.threads, args.page)
+
+    default_suffix = (
+        f".{args.mode}.p{args.page}.dclx"
+        if args.page is not None
+        else f".{args.mode}.dclx"
+    )
+    output = args.output or args.input.with_suffix(default_suffix)
     doc.save_as_doclang_archive(output)
     print(f"Wrote {output}")
     return 0

--- a/src/parse/config.h
+++ b/src/parse/config.h
@@ -38,6 +38,12 @@ namespace pdflib
 
     bool populate_json_objects = false;
 
+    // Extract embedded font programs (/FontFile, /FontFile2, /FontFile3) and
+    // attach them to text render instructions. Off by default so that
+    // parse-only workloads (text extraction) never pay for font stream
+    // decoding; the render pipeline turns it on.
+    bool extract_font_programs = false;
+
     // threading
     bool do_thread_safe = true; // slight compute/memory overhead in single threaded case
     int release_native_memory_every_n_pages = 0; // 0 disables allocator trimming
@@ -83,6 +89,7 @@ namespace pdflib
     j["line_space_width_factor_for_merge_with_space"] = line_space_width_factor_for_merge_with_space;
 
     j["populate_json_objects"] = populate_json_objects;
+    j["extract_font_programs"] = extract_font_programs;
     j["release_native_memory_every_n_pages"] = release_native_memory_every_n_pages;
 
     j["keep_glyphs"] = keep_glyphs;
@@ -117,6 +124,7 @@ namespace pdflib
     if(j.count("line_space_width_factor_for_merge_with_space")) { line_space_width_factor_for_merge_with_space = j["line_space_width_factor_for_merge_with_space"]; }
 
     if(j.count("populate_json_objects")) { populate_json_objects = j["populate_json_objects"]; }
+    if(j.count("extract_font_programs")) { extract_font_programs = j["extract_font_programs"]; }
     if(j.count("release_native_memory_every_n_pages")) { release_native_memory_every_n_pages = j["release_native_memory_every_n_pages"]; }
 
     if(j.count("keep_glyphs")) { keep_glyphs = j["keep_glyphs"]; }
@@ -173,6 +181,7 @@ namespace pdflib
        << std::setw(48) << "line_space_width_factor_for_merge" << line_space_width_factor_for_merge << "\n"
        << std::setw(48) << "line_space_width_factor_for_merge_with_space" << line_space_width_factor_for_merge_with_space << "\n"
        << std::setw(48) << "populate_json_objects" << (populate_json_objects ? "true" : "false") << "\n"
+       << std::setw(48) << "extract_font_programs" << (extract_font_programs ? "true" : "false") << "\n"
        << std::setw(48) << "release_native_memory_every_n_pages" << release_native_memory_every_n_pages << "\n"
        << std::setw(48) << "keep_glyphs" << (keep_glyphs ? "true" : "false") << "\n"
        << std::setw(48) << "keep_qpdf_warnings" << (keep_qpdf_warnings ? "true" : "false") << "\n";

--- a/src/parse/enums.h
+++ b/src/parse/enums.h
@@ -135,6 +135,35 @@ namespace pdflib
 
     return "FONT_FILE_UNKNOWN";
   }
+
+  // Distinguishes the /FontFile3 subtypes that embedded_font_file_kind folds
+  // into FONT_FILE_CFF. The renderer needs this: Blend2D loads only SFNT
+  // containers (TRUETYPE/OPENTYPE), while TYPE1/TYPE1C/CID_TYPE0C need a
+  // different backend.
+  enum class embedded_font_format
+  {
+    UNKNOWN,
+    TYPE1,      // /FontFile  (PFA/PFB)
+    TRUETYPE,   // /FontFile2
+    TYPE1C,     // /FontFile3 /Subtype /Type1C (bare CFF)
+    CID_TYPE0C, // /FontFile3 /Subtype /CIDFontType0C (CID-keyed bare CFF)
+    OPENTYPE    // /FontFile3 /Subtype /OpenType
+  };
+
+  inline std::string to_string(embedded_font_format format)
+  {
+    switch(format)
+      {
+      case embedded_font_format::UNKNOWN:    return "UNKNOWN";
+      case embedded_font_format::TYPE1:      return "TYPE1";
+      case embedded_font_format::TRUETYPE:   return "TRUETYPE";
+      case embedded_font_format::TYPE1C:     return "TYPE1C";
+      case embedded_font_format::CID_TYPE0C: return "CID_TYPE0C";
+      case embedded_font_format::OPENTYPE:   return "OPENTYPE";
+      }
+
+    return "UNKNOWN";
+  }
   
   enum xobject_subtype_name {
     XOBJECT_UNKNOWN,

--- a/src/parse/page_item_sanitators/cells.h
+++ b/src/parse/page_item_sanitators/cells.h
@@ -492,7 +492,8 @@ namespace pdflib
 		// after a ligature and returns to normal once the inflated bbox is absorbed.
 		cells[i].last_merged_cell_was_ligature = utils::string::is_ligature(cells[j].text);
 		cells[j].active = false;
-		// LOG_S(INFO) << " -> merging cell-" << i << " with " << j << " '" << cells[j].text << "'"<< ": " << cells[i].text;
+
+		LOG_S(INFO) << " -> merging cell-" << i << " with " << j << " '" << cells[j].text << "'"<< ": " << cells[i].text;
 	      }
 	    else if(allow_reverse and cells[j].is_adjacent_to(cells[i], delta_0, adj_eps_d1))
 	      {

--- a/src/parse/page_items/embedded_font_blob.h
+++ b/src/parse/page_items/embedded_font_blob.h
@@ -1,0 +1,139 @@
+//-*-C++-*-
+
+#ifndef PAGE_ITEM_EMBEDDED_FONT_BLOB_H
+#define PAGE_ITEM_EMBEDDED_FONT_BLOB_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <parse/enums.h>
+
+namespace pdflib
+{
+  // Render-facing view of an embedded font program (/FontFile, /FontFile2,
+  // /FontFile3). Deliberately free of qpdf and nlohmann types so that render
+  // instructions and the renderer can carry it without pulling in the parse
+  // dependencies. One blob is built per PDF font resource and shared (via
+  // shared_ptr) by every text instruction that uses that font; the byte
+  // buffer is immutable after construction.
+  class embedded_font_blob
+  {
+  public:
+
+    embedded_font_blob();
+    embedded_font_blob(std::string cache_key,
+                       std::string font_name,
+                       std::string base_font,
+                       std::string source_key,
+                       embedded_font_format format,
+                       bool is_cid_font,
+                       bool cid_to_gid_identity,
+                       std::shared_ptr<const std::vector<uint8_t> > bytes);
+
+    // Content-derived identity (FNV-1a over the decoded bytes + size).
+    // PDF object ids are NOT used: they are only unique within one document,
+    // and the renderer-side face cache may outlive/serve many documents.
+    const std::string& get_cache_key() const { return cache_key; }
+
+    const std::string& get_font_name() const { return font_name; }
+    const std::string& get_base_font() const { return base_font; }
+
+    // "/FontFile", "/FontFile2" or "/FontFile3"
+    const std::string& get_source_key() const { return source_key; }
+
+    embedded_font_format get_format() const { return format; }
+
+    // font belongs to a /Type0 composite font
+    bool get_is_cid_font() const { return is_cid_font; }
+
+    // /CIDToGIDMap is /Identity or absent
+    bool get_cid_to_gid_identity() const { return cid_to_gid_identity; }
+
+    const std::shared_ptr<const std::vector<uint8_t> >& get_bytes() const { return bytes; }
+
+    bool has_bytes() const;
+    size_t byte_size() const;
+
+    static std::string compute_cache_key(const std::vector<uint8_t>& data);
+
+  private:
+
+    std::string cache_key;
+
+    std::string font_name;
+    std::string base_font;
+    std::string source_key;
+
+    embedded_font_format format;
+
+    bool is_cid_font;
+    bool cid_to_gid_identity;
+
+    std::shared_ptr<const std::vector<uint8_t> > bytes;
+  };
+
+  inline embedded_font_blob::embedded_font_blob():
+    cache_key(),
+    font_name(),
+    base_font(),
+    source_key(),
+    format(embedded_font_format::UNKNOWN),
+    is_cid_font(false),
+    cid_to_gid_identity(false),
+    bytes(nullptr)
+  {}
+
+  inline embedded_font_blob::embedded_font_blob(std::string cache_key_,
+                                                std::string font_name_,
+                                                std::string base_font_,
+                                                std::string source_key_,
+                                                embedded_font_format format_,
+                                                bool is_cid_font_,
+                                                bool cid_to_gid_identity_,
+                                                std::shared_ptr<const std::vector<uint8_t> > bytes_):
+    cache_key(std::move(cache_key_)),
+    font_name(std::move(font_name_)),
+    base_font(std::move(base_font_)),
+    source_key(std::move(source_key_)),
+    format(format_),
+    is_cid_font(is_cid_font_),
+    cid_to_gid_identity(cid_to_gid_identity_),
+    bytes(std::move(bytes_))
+  {}
+
+  inline bool embedded_font_blob::has_bytes() const
+  {
+    return bytes != nullptr and not bytes->empty();
+  }
+
+  inline size_t embedded_font_blob::byte_size() const
+  {
+    return bytes ? bytes->size() : 0;
+  }
+
+  inline std::string embedded_font_blob::compute_cache_key(const std::vector<uint8_t>& data)
+  {
+    uint64_t hash = 0xcbf29ce484222325ULL; // FNV-1a 64 offset basis
+    for(uint8_t byte : data)
+      {
+        hash ^= byte;
+        hash *= 0x100000001b3ULL;
+      }
+
+    static const char* digits = "0123456789abcdef";
+
+    std::string key(16, '0');
+    for(int i = 0; i < 16; i++)
+      {
+        key[15 - i] = digits[(hash >> (4 * i)) & 0xF];
+      }
+
+    return key + "-" + std::to_string(data.size());
+  }
+
+}
+
+#endif

--- a/src/parse/page_items/render_instructions.h
+++ b/src/parse/page_items/render_instructions.h
@@ -221,6 +221,12 @@ namespace pdflib
     void set_char_code(int64_t char_code);
     int64_t get_char_code() const;
 
+    // Optional glyph name assigned to the character code by the PDF's
+    // /Encoding /Differences; empty when none. This is the authoritative
+    // glyph identity inside the embedded font program.
+    void set_glyph_name(std::string glyph_name);
+    const std::string& get_glyph_name() const;
+
   private:
 
     const std::string text;
@@ -255,6 +261,7 @@ namespace pdflib
 
     std::shared_ptr<const embedded_font_blob> embedded_font_;
     int64_t char_code_ = -1;
+    std::string glyph_name_;
   };
 
   inline void text_instruction::set_embedded_font(std::shared_ptr<const embedded_font_blob> blob)
@@ -280,6 +287,16 @@ namespace pdflib
   inline int64_t text_instruction::get_char_code() const
   {
     return char_code_;
+  }
+
+  inline void text_instruction::set_glyph_name(std::string glyph_name)
+  {
+    glyph_name_ = std::move(glyph_name);
+  }
+
+  inline const std::string& text_instruction::get_glyph_name() const
+  {
+    return glyph_name_;
   }
 
   class text_widget_instruction

--- a/src/parse/page_items/render_instructions.h
+++ b/src/parse/page_items/render_instructions.h
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include <parse/enums.h>
+#include <parse/page_items/embedded_font_blob.h>
 
 namespace pdflib
 {
@@ -207,6 +208,19 @@ namespace pdflib
     double get_g_x1() const { return g_x1_; }
     double get_g_y1() const { return g_y1_; }
 
+    // Optional embedded font program shared by all text instructions of one
+    // PDF font resource. Set after construction to keep the (already long)
+    // constructor signature stable; may be null.
+    void set_embedded_font(std::shared_ptr<const embedded_font_blob> blob);
+    const std::shared_ptr<const embedded_font_blob>& get_embedded_font() const;
+    bool has_embedded_font() const;
+
+    // Optional decoded PDF character code (or CID for composite fonts) of a
+    // single-character text cell; -1 when unknown or multi-character. Needed
+    // later for glyph-identity rendering of symbolic/subset fonts.
+    void set_char_code(int64_t char_code);
+    int64_t get_char_code() const;
+
   private:
 
     const std::string text;
@@ -238,7 +252,35 @@ namespace pdflib
     const double g_y0_;
     const double g_x1_;
     const double g_y1_;
+
+    std::shared_ptr<const embedded_font_blob> embedded_font_;
+    int64_t char_code_ = -1;
   };
+
+  inline void text_instruction::set_embedded_font(std::shared_ptr<const embedded_font_blob> blob)
+  {
+    embedded_font_ = std::move(blob);
+  }
+
+  inline const std::shared_ptr<const embedded_font_blob>& text_instruction::get_embedded_font() const
+  {
+    return embedded_font_;
+  }
+
+  inline bool text_instruction::has_embedded_font() const
+  {
+    return embedded_font_ != nullptr and embedded_font_->has_bytes();
+  }
+
+  inline void text_instruction::set_char_code(int64_t char_code)
+  {
+    char_code_ = char_code;
+  }
+
+  inline int64_t text_instruction::get_char_code() const
+  {
+    return char_code_;
+  }
 
   class text_widget_instruction
   {

--- a/src/parse/pdf_resources/page_font.h
+++ b/src/parse/pdf_resources/page_font.h
@@ -50,6 +50,11 @@ namespace pdflib
 
     std::array<double, 4> get_font_bbox() { return font_bbox; }
     const embedded_font_program& get_font_program() const { return font_program; }
+
+    // Lazily extracts the embedded font program (first call only) and returns
+    // the shared render-facing blob; null when the font has no usable embedded
+    // program. All text instructions of this font share the same blob.
+    std::shared_ptr<const embedded_font_blob> get_embedded_font_blob();
     
     std::string get_utf8_string(std::string line, bool is_hex_str);
 
@@ -85,6 +90,10 @@ namespace pdflib
                                std::string const& source_path,
                                embedded_font_file_kind kind,
                                bool from_descendant_font);
+
+    embedded_font_format resolve_embedded_font_format() const;
+    bool resolve_cid_to_gid_identity() const;
+    void build_embedded_font_blob();
     
     void init_ascent_and_descent();
 
@@ -168,6 +177,9 @@ namespace pdflib
 
     uint32_t space_index;
     embedded_font_program font_program;
+
+    bool font_blob_initialized = false;
+    std::shared_ptr<const embedded_font_blob> font_blob;
   };
 
   font_glyphs    pdf_resource<PAGE_FONT>::glyphs = font_glyphs();
@@ -698,7 +710,7 @@ namespace pdflib
       init_font_name();
       init_font_bbox();
       init_font_matrix();
-      // init_font_program(); // not really needed for now I believe
+      // init_font_program(); // extraction is lazy: see get_embedded_font_blob()
       
       init_ascent_and_descent();
       
@@ -1273,9 +1285,10 @@ namespace pdflib
     font_program.from_descendant_font = from_descendant_font;
     font_program.descriptor_json = descriptor_json;
     font_program.stream_dict_json = to_json(stream_obj, {}, 0, 2);
-    LOG_S(INFO) << __FUNCTION__
-                << ": stream-dict-json=\n"
-                << font_program.stream_dict_json.dump(2);
+    // Disabled: dumping the full stream dictionary per font floods the logs.
+    // LOG_S(INFO) << __FUNCTION__
+    //             << ": stream-dict-json=\n"
+    //             << font_program.stream_dict_json.dump(2);
 
     auto subtype_info = to_string(stream_obj, "/Subtype");
     if(subtype_info.first)
@@ -1301,34 +1314,38 @@ namespace pdflib
     update_length("/Length2", font_program.length2);
     update_length("/Length3", font_program.length3);
 
-    try
-      {
-        LOG_S(INFO) << __FUNCTION__ << ": decoding font stream with qpdf_stream_decoder";
-        qpdf_stream_decoder decoder(font_program.decoded_stream);
-        decoder.decode(stream_obj);
-        LOG_S(INFO) << __FUNCTION__
-                    << ": decoded stream instruction count="
-                    << font_program.decoded_stream.size();
-        decoder.print();
-      }
-    catch(const std::exception& e)
-      {
-        LOG_S(INFO) << __FUNCTION__ << ": failed to decode stream instructions: " << e.what();
-      }
+    // Disabled: a font program is binary data, not a content stream —
+    // running the instruction decoder over it is meaningless work.
+    // try
+    //   {
+    //     LOG_S(INFO) << __FUNCTION__ << ": decoding font stream with qpdf_stream_decoder";
+    //     qpdf_stream_decoder decoder(font_program.decoded_stream);
+    //     decoder.decode(stream_obj);
+    //     LOG_S(INFO) << __FUNCTION__
+    //                 << ": decoded stream instruction count="
+    //                 << font_program.decoded_stream.size();
+    //     decoder.print();
+    //   }
+    // catch(const std::exception& e)
+    //   {
+    //     LOG_S(INFO) << __FUNCTION__ << ": failed to decode stream instructions: " << e.what();
+    //   }
 
-    try
-      {
-        font_program.raw_data = to_shared_ptr(stream_obj.getRawStreamData());
-        if(font_program.raw_data)
-          {
-            font_program.raw_size = font_program.raw_data->getSize();
-          }
-        LOG_S(INFO) << __FUNCTION__ << ": raw_size=" << font_program.raw_size;
-      }
-    catch(const std::exception& e)
-      {
-        LOG_S(INFO) << __FUNCTION__ << ": failed to read raw stream data: " << e.what();
-      }
+    // Disabled: keeping raw (compressed) bytes next to the decoded bytes
+    // doubles the memory per font; the renderer only needs decoded bytes.
+    // try
+    //   {
+    //     font_program.raw_data = to_shared_ptr(stream_obj.getRawStreamData());
+    //     if(font_program.raw_data)
+    //       {
+    //         font_program.raw_size = font_program.raw_data->getSize();
+    //       }
+    //     LOG_S(INFO) << __FUNCTION__ << ": raw_size=" << font_program.raw_size;
+    //   }
+    // catch(const std::exception& e)
+    //   {
+    //     LOG_S(INFO) << __FUNCTION__ << ": failed to read raw stream data: " << e.what();
+    //   }
 
     try
       {
@@ -1350,7 +1367,115 @@ namespace pdflib
                 << " source=" << font_program.source_path
                 << " declared_subtype=" << font_program.declared_subtype;
   }
-  
+
+  std::shared_ptr<const embedded_font_blob> pdf_resource<PAGE_FONT>::get_embedded_font_blob()
+  {
+    if(not font_blob_initialized)
+      {
+        font_blob_initialized = true;
+
+        init_font_program();
+        build_embedded_font_blob();
+      }
+
+    return font_blob;
+  }
+
+  embedded_font_format pdf_resource<PAGE_FONT>::resolve_embedded_font_format() const
+  {
+    switch(font_program.kind)
+      {
+      case FONT_FILE_TYPE1:
+        {
+          return embedded_font_format::TYPE1;
+        }
+      case FONT_FILE_TRUETYPE:
+        {
+          return embedded_font_format::TRUETYPE;
+        }
+      case FONT_FILE_CFF:
+        {
+          if(font_program.declared_subtype == "/Type1C")
+            {
+              return embedded_font_format::TYPE1C;
+            }
+          if(font_program.declared_subtype == "/CIDFontType0C")
+            {
+              return embedded_font_format::CID_TYPE0C;
+            }
+          if(font_program.declared_subtype == "/OpenType")
+            {
+              return embedded_font_format::OPENTYPE;
+            }
+          return embedded_font_format::UNKNOWN;
+        }
+      default:
+        {
+          return embedded_font_format::UNKNOWN;
+        }
+      }
+  }
+
+  bool pdf_resource<PAGE_FONT>::resolve_cid_to_gid_identity() const
+  {
+    if(subtype != TYPE_0)
+      {
+        return false;
+      }
+
+    // PDF spec: /CIDToGIDMap defaults to /Identity when absent. Any stream
+    // value means an explicit map that we do not resolve here.
+    std::vector<std::string> keys = {"/CIDToGIDMap"};
+    if(not utils::json::has(keys, desc_font))
+      {
+        return true;
+      }
+
+    nlohmann::json value = utils::json::get(keys, desc_font);
+    return value.is_string() and value.get<std::string>() == "/Identity";
+  }
+
+  void pdf_resource<PAGE_FONT>::build_embedded_font_blob()
+  {
+    if(not font_program.found or
+       not font_program.decoded_data or
+       font_program.decoded_data->getSize() == 0)
+      {
+        LOG_S(INFO) << __FUNCTION__ << ": no embedded font bytes for font-key=" << font_key;
+        return;
+      }
+
+    auto bytes = std::make_shared<std::vector<uint8_t> >(
+      font_program.decoded_data->getBuffer(),
+      font_program.decoded_data->getBuffer() + font_program.decoded_data->getSize());
+
+    // The blob owns the only long-lived copy; drop the qpdf buffer so the
+    // bytes are not held twice.
+    font_program.decoded_data.reset();
+
+    embedded_font_format format = resolve_embedded_font_format();
+
+    font_blob = std::make_shared<const embedded_font_blob>(
+      embedded_font_blob::compute_cache_key(*bytes),
+      font_name,
+      base_font,
+      font_program.source_path,
+      format,
+      subtype == TYPE_0,
+      resolve_cid_to_gid_identity(),
+      std::move(bytes));
+
+    LOG_S(INFO) << __FUNCTION__
+                << ": font-key=" << font_key
+                << " font-name=" << font_name
+                << " source=" << font_blob->get_source_key()
+                << " format=" << to_string(font_blob->get_format())
+                << " bytes=" << font_blob->byte_size()
+                << " cache-key=" << font_blob->get_cache_key()
+                << " cid=" << font_blob->get_is_cid_font()
+                << " cid-to-gid-identity=" << font_blob->get_cid_to_gid_identity();
+  }
+
   void pdf_resource<PAGE_FONT>::init_ascent_and_descent()
   {
     LOG_S(INFO) << __FUNCTION__;

--- a/src/parse/pdf_resources/page_font.h
+++ b/src/parse/pdf_resources/page_font.h
@@ -55,6 +55,11 @@ namespace pdflib
     // the shared render-facing blob; null when the font has no usable embedded
     // program. All text instructions of this font share the same blob.
     std::shared_ptr<const embedded_font_blob> get_embedded_font_blob();
+
+    // Raw glyph name (no leading '/') that /Encoding /Differences assigns to
+    // this character code; empty when the code has no override. Used by the
+    // renderer for glyph-identity lookups in embedded font programs.
+    std::string get_glyph_name(uint32_t code);
     
     std::string get_utf8_string(std::string line, bool is_hex_str);
 
@@ -172,6 +177,7 @@ namespace pdflib
     //std::unordered_map<uint32_t, std::string> cmap_numb_to_char;
     cmap_value cmap_numb_to_char;
     std::unordered_map<uint32_t, std::string> diff_numb_to_char;
+    std::unordered_map<uint32_t, std::string> diff_numb_to_name;
 
     std::unordered_map<uint32_t, int> unknown_numbs;
 
@@ -1381,6 +1387,17 @@ namespace pdflib
     return font_blob;
   }
 
+  std::string pdf_resource<PAGE_FONT>::get_glyph_name(uint32_t code)
+  {
+    auto itr = diff_numb_to_name.find(code);
+    if(itr != diff_numb_to_name.end())
+      {
+        return itr->second;
+      }
+
+    return "";
+  }
+
   embedded_font_format pdf_resource<PAGE_FONT>::resolve_embedded_font_format() const
   {
     switch(font_program.kind)
@@ -2206,6 +2223,14 @@ namespace pdflib
                       }
 		    else
 		      {}
+
+		    // Keep the raw glyph name (with any ".suffix", without the
+		    // leading '/'): it is the identity of the glyph inside the
+		    // embedded font program.
+		    if(numb >= 0 and name.size() > 1 and name[0] == '/')
+		      {
+			diff_numb_to_name[numb] = name.substr(1);
+		      }
 
 		    LOG_S(INFO) << name << ", in cmap: " << cmap_numb_to_char.count(numb) << ", #-names: " << name_to_descr.size() << ", type: " << subtype;
 		    

--- a/src/parse/pdf_states/text.h
+++ b/src/parse/pdf_states/text.h
@@ -693,15 +693,26 @@ namespace pdflib
                                 cell.enc_name,
                                 font.get_base_font(),
                                 cell.font_size,
-                                glyph_rect.at(0), glyph_rect.at(1), 
+                                glyph_rect.at(0), glyph_rect.at(1),
                                 glyph_rect.at(2), glyph_rect.at(3),
 				glyph_rect.at(4), glyph_rect.at(5),
-				glyph_rect.at(6), glyph_rect.at(7), 
+				glyph_rect.at(6), glyph_rect.at(7),
                                 font_ascent*ratio, font_descent*ratio,
 				d_base_x, d_base_y,
                                 has_glyph_bbox,
                                 glyph_bbox[0], glyph_bbox[1],
                                 glyph_bbox[2], glyph_bbox[3]);
+
+        tinstr.set_char_code(glyph_code);
+
+        if(config.extract_font_programs)
+          {
+            auto font_blob = font.get_embedded_font_blob();
+            if(font_blob != nullptr and font_blob->has_bytes())
+              {
+                tinstr.set_embedded_font(font_blob);
+              }
+          }
 
         instructions.add_text_instruction(std::move(tinstr));
       }

--- a/src/parse/pdf_states/text.h
+++ b/src/parse/pdf_states/text.h
@@ -704,6 +704,10 @@ namespace pdflib
                                 glyph_bbox[2], glyph_bbox[3]);
 
         tinstr.set_char_code(glyph_code);
+        if(glyph_code >= 0)
+          {
+            tinstr.set_glyph_name(font.get_glyph_name(static_cast<uint32_t>(glyph_code)));
+          }
 
         if(config.extract_font_programs)
           {

--- a/src/pybind/docling_threaded_renderer.h
+++ b/src/pybind/docling_threaded_renderer.h
@@ -36,6 +36,10 @@ namespace docling
     // process instead of once per page. Safe across documents: entries are
     // keyed by a content hash of the font bytes, not by PDF object ids.
     std::shared_ptr<pdflib::blend2d_embedded_font_cache> embedded_font_cache_;
+
+    // Same sharing/keying for the Type 1 / bare CFF programs that Blend2D
+    // cannot load; FreeType serializes internally on its own mutex.
+    std::shared_ptr<pdflib::freetype_embedded_font_cache> freetype_font_cache_;
   };
 
   inline docling_threaded_renderer::docling_threaded_renderer(std::string loglevel,
@@ -49,7 +53,8 @@ namespace docling
                                                                          decode_config),
     render_cfg(render_config),
     font_resolver_(std::make_shared<pdflib::blend2d_font_resolver>()),
-    embedded_font_cache_(std::make_shared<pdflib::blend2d_embedded_font_cache>())
+    embedded_font_cache_(std::make_shared<pdflib::blend2d_embedded_font_cache>()),
+    freetype_font_cache_(std::make_shared<pdflib::freetype_embedded_font_cache>())
   {
     font_resolver_->warm();
 
@@ -129,7 +134,8 @@ namespace docling
                 stage_start = clock_type::now();
                 pdflib::renderer<pdflib::BLEND2D> rnd(render_cfg,
                                                       font_resolver_,
-                                                      embedded_font_cache_);
+                                                      embedded_font_cache_,
+                                                      freetype_font_cache_);
                 page_decoder->get_instructions().iterate_over_instructions(rnd);
                 result.timings.render_page_s
                   = std::chrono::duration<double>(clock_type::now() - stage_start).count();

--- a/src/pybind/docling_threaded_renderer.h
+++ b/src/pybind/docling_threaded_renderer.h
@@ -31,6 +31,11 @@ namespace docling
 
     // Shared across workers; pages keep only their tiny local alias cache.
     std::shared_ptr<pdflib::blend2d_font_resolver> font_resolver_;
+
+    // Shared across workers so embedded font programs are loaded once per
+    // process instead of once per page. Safe across documents: entries are
+    // keyed by a content hash of the font bytes, not by PDF object ids.
+    std::shared_ptr<pdflib::blend2d_embedded_font_cache> embedded_font_cache_;
   };
 
   inline docling_threaded_renderer::docling_threaded_renderer(std::string loglevel,
@@ -43,9 +48,14 @@ namespace docling
                                                                          max_concurrent_results,
                                                                          decode_config),
     render_cfg(render_config),
-    font_resolver_(std::make_shared<pdflib::blend2d_font_resolver>())
+    font_resolver_(std::make_shared<pdflib::blend2d_font_resolver>()),
+    embedded_font_cache_(std::make_shared<pdflib::blend2d_embedded_font_cache>())
   {
     font_resolver_->warm();
+
+    // This pipeline always renders, so embedded font programs must be
+    // extracted during page decoding; parse-only pipelines leave this off.
+    config.extract_font_programs = true;
   }
 
   inline void docling_threaded_renderer::worker_loop()
@@ -117,7 +127,9 @@ namespace docling
                   }
 
                 stage_start = clock_type::now();
-                pdflib::renderer<pdflib::BLEND2D> rnd(render_cfg, font_resolver_);
+                pdflib::renderer<pdflib::BLEND2D> rnd(render_cfg,
+                                                      font_resolver_,
+                                                      embedded_font_cache_);
                 page_decoder->get_instructions().iterate_over_instructions(rnd);
                 result.timings.render_page_s
                   = std::chrono::duration<double>(clock_type::now() - stage_start).count();

--- a/src/render/blend2d_embedded_font_cache.h
+++ b/src/render/blend2d_embedded_font_cache.h
@@ -1,0 +1,142 @@
+//-*-C++-*-
+
+#ifndef PDF_BLEND2D_EMBEDDED_FONT_CACHE_H
+#define PDF_BLEND2D_EMBEDDED_FONT_CACHE_H
+
+#include <blend2d/blend2d.h>
+
+#ifndef LOGURU_WITH_STREAMS
+#define LOGURU_WITH_STREAMS 1
+#endif
+#include <loguru.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <parse/page_items/embedded_font_blob.h>
+
+namespace pdflib
+{
+  // Loads BLFontFace objects from embedded PDF font programs and caches the
+  // result (success or failure) by the blob's content-hash cache key. The
+  // cache key is content-derived, so one cache instance can safely serve
+  // multiple documents and threads.
+  //
+  // Blend2D only accepts SFNT containers (TrueType `0x00010000`/`true`,
+  // OpenType `OTTO`, collections `ttcf`); bare CFF (/FontFile3 /Type1C,
+  // /CIDFontType0C) and Type 1 (/FontFile) fail with
+  // BL_ERROR_INVALID_SIGNATURE and are cached as failures so the renderer
+  // falls back to system fonts without retrying per text cell.
+  class blend2d_embedded_font_cache
+  {
+  public:
+
+    blend2d_embedded_font_cache();
+
+    // Returns the loaded face for the blob, or an empty/invalid face when the
+    // blob is null, has no bytes, or Blend2D cannot load the format.
+    BLFontFace resolve(const std::shared_ptr<const embedded_font_blob>& blob);
+
+  private:
+
+    struct cache_entry
+    {
+      // Keeps the byte buffer alive: BLFontData wraps the memory without
+      // copying, so the bytes must outlive data/face.
+      std::shared_ptr<const std::vector<uint8_t> > bytes;
+
+      BLFontData data;
+      BLFontFace face;
+
+      bool failed = false;
+    };
+
+    BLFontFace load_face(const std::shared_ptr<const embedded_font_blob>& blob);
+
+    mutable std::shared_mutex cache_mutex_;
+    std::unordered_map<std::string, cache_entry> cache_;
+  };
+
+  inline blend2d_embedded_font_cache::blend2d_embedded_font_cache() = default;
+
+  inline BLFontFace blend2d_embedded_font_cache::resolve(
+      const std::shared_ptr<const embedded_font_blob>& blob)
+  {
+    if(blob == nullptr or not blob->has_bytes())
+      {
+        return {};
+      }
+
+    {
+      std::shared_lock lock(cache_mutex_);
+      auto itr = cache_.find(blob->get_cache_key());
+      if(itr != cache_.end())
+        {
+          return itr->second.face;
+        }
+    }
+
+    return load_face(blob);
+  }
+
+  inline BLFontFace blend2d_embedded_font_cache::load_face(
+      const std::shared_ptr<const embedded_font_blob>& blob)
+  {
+    cache_entry entry;
+    entry.bytes = blob->get_bytes();
+
+    const BLResult data_res = entry.data.create_from_data(
+        entry.bytes->data(), entry.bytes->size());
+
+    BLResult face_res = BL_ERROR_INVALID_DATA;
+    if(data_res == BL_SUCCESS)
+      {
+        face_res = entry.face.create_from_data(entry.data, 0);
+      }
+
+    entry.failed = not (data_res == BL_SUCCESS and
+                        face_res == BL_SUCCESS and
+                        entry.face.is_valid());
+
+    if(entry.failed)
+      {
+        // A failed load keeps no byte buffer alive.
+        entry.bytes.reset();
+        entry.data.reset();
+        entry.face.reset();
+
+        LOG_S(INFO) << "embedded font cache: load failed"
+                    << " font_name=`" << blob->get_font_name() << "`"
+                    << " source=" << blob->get_source_key()
+                    << " format=" << to_string(blob->get_format())
+                    << " bytes=" << blob->byte_size()
+                    << " data_res=" << data_res
+                    << " face_res=" << face_res
+                    << " cache_key=" << blob->get_cache_key();
+      }
+    else
+      {
+        LOG_S(INFO) << "embedded font cache: loaded face"
+                    << " font_name=`" << blob->get_font_name() << "`"
+                    << " family=`" << entry.face.family_name().data() << "`"
+                    << " source=" << blob->get_source_key()
+                    << " format=" << to_string(blob->get_format())
+                    << " bytes=" << blob->byte_size()
+                    << " cache_key=" << blob->get_cache_key();
+      }
+
+    {
+      std::unique_lock lock(cache_mutex_);
+      auto [itr, inserted] = cache_.emplace(blob->get_cache_key(), std::move(entry));
+      return itr->second.face;
+    }
+  }
+
+}
+
+#endif

--- a/src/render/blend2d_renderer.h
+++ b/src/render/blend2d_renderer.h
@@ -6,6 +6,7 @@
 #include <render/template_renderer.h>
 #include <render/config.h>
 #include <render/blend2d_font_resolver.h>
+#include <render/blend2d_embedded_font_cache.h>
 
 #include <blend2d/blend2d.h>
 
@@ -45,6 +46,13 @@ namespace pdflib
     // can be shared across page renderers.
     explicit renderer(render_config config,
                       std::shared_ptr<blend2d_font_resolver> font_resolver);
+
+    // Same as above, additionally sharing an embedded font cache so that
+    // embedded font programs are loaded once per document instead of once per
+    // page renderer. Passing nullptr creates a private cache.
+    explicit renderer(render_config config,
+                      std::shared_ptr<blend2d_font_resolver> font_resolver,
+                      std::shared_ptr<blend2d_embedded_font_cache> embedded_font_cache);
 
     // Initializes the page canvas from the PDF crop box and render_config. This
     // computes the PDF-to-canvas scale/origin, creates a PRGB32 Blend2D image,
@@ -132,6 +140,7 @@ namespace pdflib
     double origin_y_ = 0.0;    // crop_bbox y origin (pdf units, y-up)
 
     std::shared_ptr<blend2d_font_resolver> font_resolver_;
+    std::shared_ptr<blend2d_embedded_font_cache> embedded_font_cache_;
     std::unordered_map<std::string, BLFontFace> local_font_cache_;
 
     // Returns the active Blend2D context for the page, starting it lazily if
@@ -193,6 +202,27 @@ namespace pdflib
     // system font if none can be resolved.  Results are cached.
     BLFontFace resolve_font_face(const std::string& font_name,
                                  const std::string& base_font);
+
+    // Returns true when every glyph in the shaped buffer is glyph id 0
+    // (.notdef). Shaping against an embedded subset font succeeds even when
+    // the font has no glyph for the codepoint, so this — not a shaping error —
+    // signals that the embedded face cannot draw the cell.
+    static bool glyph_run_all_notdef(const BLGlyphBuffer& gb)
+    {
+      const size_t count = gb.size();
+      const uint32_t* glyph_ids = gb.glyph_run().glyph_data_as<uint32_t>();
+      if (count == 0 or glyph_ids == nullptr) { return true; }
+
+      for (size_t i = 0; i < count; ++i)
+        {
+          if (glyph_ids[i] != 0)
+            {
+              return false;
+            }
+        }
+
+      return true;
+    }
 
     // Computes the canvas-space baseline, bounding quad, text cell height
     // vector, and Blend2D font size for one text instruction.
@@ -503,13 +533,15 @@ namespace pdflib
 
   inline renderer<BLEND2D>::renderer()
     : shape_({0, 0, 4}),
-      font_resolver_(blend2d_font_resolver::default_resolver())
+      font_resolver_(blend2d_font_resolver::default_resolver()),
+      embedded_font_cache_(std::make_shared<blend2d_embedded_font_cache>())
   {}
 
   inline renderer<BLEND2D>::renderer(render_config config)
     : config_(config),
       shape_({0, 0, 4}),
-      font_resolver_(blend2d_font_resolver::default_resolver())
+      font_resolver_(blend2d_font_resolver::default_resolver()),
+      embedded_font_cache_(std::make_shared<blend2d_embedded_font_cache>())
   {}
 
   inline renderer<BLEND2D>::renderer(render_config config,
@@ -517,7 +549,20 @@ namespace pdflib
     : config_(config),
       shape_({0, 0, 4}),
       font_resolver_(font_resolver ? std::move(font_resolver)
-                                   : blend2d_font_resolver::default_resolver())
+                                   : blend2d_font_resolver::default_resolver()),
+      embedded_font_cache_(std::make_shared<blend2d_embedded_font_cache>())
+  {}
+
+  inline renderer<BLEND2D>::renderer(render_config config,
+                                     std::shared_ptr<blend2d_font_resolver> font_resolver,
+                                     std::shared_ptr<blend2d_embedded_font_cache> embedded_font_cache)
+    : config_(config),
+      shape_({0, 0, 4}),
+      font_resolver_(font_resolver ? std::move(font_resolver)
+                                   : blend2d_font_resolver::default_resolver()),
+      embedded_font_cache_(embedded_font_cache
+                             ? std::move(embedded_font_cache)
+                             : std::make_shared<blend2d_embedded_font_cache>())
   {}
 
   inline BLContext& renderer<BLEND2D>::page_context()
@@ -1003,11 +1048,32 @@ namespace pdflib
     //             << " cell_span=" << cell_span
     //             << " em_size=" << em_size << " size=" << size;
 
-    BLFontFace face = resolve_font_face(instr.get_font_name(),
-                                        instr.get_base_font());
+    // Resolution order: embedded font program (if carried by the instruction
+    // and loadable by Blend2D) → system font resolver → hardcoded fallback.
+    bool using_embedded_font = false;
+    BLFontFace face;
+    if (config_.use_embedded_fonts and instr.has_embedded_font())
+      {
+        face = embedded_font_cache_->resolve(instr.get_embedded_font());
+        using_embedded_font = face.is_valid();
+        if (not using_embedded_font)
+          {
+            LOG_S(INFO) << "render_text: embedded font not loadable"
+                        << " font_name=`" << instr.get_font_name() << "`"
+                        << " format=" << to_string(instr.get_embedded_font()->get_format())
+                        << " — using system resolver";
+          }
+      }
+
+    if (not using_embedded_font)
+      {
+        face = resolve_font_face(instr.get_font_name(),
+                                 instr.get_base_font());
+      }
     // LOG_S(INFO) << "face valid=" << face.is_valid()
     //             << " font_name=`" << instr.get_font_name() << "`"
-    //             << " base_font=`" << instr.get_base_font() << "`";
+    //             << " base_font=`" << instr.get_base_font() << "`"
+    //             << " embedded=" << using_embedded_font;
 
     BLContext& ctx = page_context();
 
@@ -1069,6 +1135,34 @@ namespace pdflib
                 draw_bbox_fallback();
                 return;
               }
+
+            if (using_embedded_font and glyph_run_all_notdef(gb))
+              {
+                // Shaping against an embedded subset font "succeeds" with
+                // glyph id 0 when the font simply lacks the glyph; drawing
+                // would produce blank/tofu output. Fall back to the system
+                // face for this cell only.
+                LOG_S(INFO) << "render_text: embedded face has no glyph"
+                            << " text=`" << instr.get_text() << "`"
+                            << " font_name=`" << instr.get_font_name() << "`"
+                            << " — falling back to system font";
+
+                BLFontFace system_face = resolve_font_face(instr.get_font_name(),
+                                                           instr.get_base_font());
+                BLFont system_font;
+                if (system_face.is_valid() and
+                    system_font.create_from_face(system_face,
+                                                 static_cast<float>(geom.size)) == BL_SUCCESS)
+                  {
+                    gb.set_utf8_text(instr.get_text().c_str());
+                    if (system_font.shape(gb) == BL_SUCCESS and not gb.is_empty())
+                      {
+                        font = system_font;
+                        using_embedded_font = false;
+                      }
+                  }
+              }
+
             const auto* placement_data = gb.placement_data();
             if (placement_data == nullptr)
               {

--- a/src/render/blend2d_renderer.h
+++ b/src/render/blend2d_renderer.h
@@ -7,6 +7,7 @@
 #include <render/config.h>
 #include <render/blend2d_font_resolver.h>
 #include <render/blend2d_embedded_font_cache.h>
+#include <render/freetype_embedded_font_cache.h>
 
 #include <blend2d/blend2d.h>
 
@@ -47,12 +48,15 @@ namespace pdflib
     explicit renderer(render_config config,
                       std::shared_ptr<blend2d_font_resolver> font_resolver);
 
-    // Same as above, additionally sharing an embedded font cache so that
-    // embedded font programs are loaded once per document instead of once per
-    // page renderer. Passing nullptr creates a private cache.
+    // Same as above, additionally sharing an embedded font cache (SFNT
+    // programs loaded natively by Blend2D) and a FreeType cache (Type 1 /
+    // bare CFF programs rendered as outline paths), so embedded font programs
+    // are loaded once per document instead of once per page renderer.
+    // Passing nullptr for either creates a private cache.
     explicit renderer(render_config config,
                       std::shared_ptr<blend2d_font_resolver> font_resolver,
-                      std::shared_ptr<blend2d_embedded_font_cache> embedded_font_cache);
+                      std::shared_ptr<blend2d_embedded_font_cache> embedded_font_cache,
+                      std::shared_ptr<freetype_embedded_font_cache> freetype_font_cache = nullptr);
 
     // Initializes the page canvas from the PDF crop box and render_config. This
     // computes the PDF-to-canvas scale/origin, creates a PRGB32 Blend2D image,
@@ -141,6 +145,7 @@ namespace pdflib
 
     std::shared_ptr<blend2d_font_resolver> font_resolver_;
     std::shared_ptr<blend2d_embedded_font_cache> embedded_font_cache_;
+    std::shared_ptr<freetype_embedded_font_cache> freetype_font_cache_;
     std::unordered_map<std::string, BLFontFace> local_font_cache_;
 
     // Returns the active Blend2D context for the page, starting it lazily if
@@ -223,6 +228,15 @@ namespace pdflib
 
       return true;
     }
+
+    // Draws a text cell whose embedded font program Blend2D cannot load
+    // (Type 1, bare CFF) by filling FreeType-decomposed outline paths.
+    // Returns true when the cell was fully handled (including the optional
+    // basepoint/bbox debug drawing); false means the caller should continue
+    // with the system font path.
+    bool render_text_freetype(text_instruction& instr,
+                              const text_geometry& geom,
+                              const BLPath& bbox_path);
 
     // Computes the canvas-space baseline, bounding quad, text cell height
     // vector, and Blend2D font size for one text instruction.
@@ -534,14 +548,16 @@ namespace pdflib
   inline renderer<BLEND2D>::renderer()
     : shape_({0, 0, 4}),
       font_resolver_(blend2d_font_resolver::default_resolver()),
-      embedded_font_cache_(std::make_shared<blend2d_embedded_font_cache>())
+      embedded_font_cache_(std::make_shared<blend2d_embedded_font_cache>()),
+      freetype_font_cache_(std::make_shared<freetype_embedded_font_cache>())
   {}
 
   inline renderer<BLEND2D>::renderer(render_config config)
     : config_(config),
       shape_({0, 0, 4}),
       font_resolver_(blend2d_font_resolver::default_resolver()),
-      embedded_font_cache_(std::make_shared<blend2d_embedded_font_cache>())
+      embedded_font_cache_(std::make_shared<blend2d_embedded_font_cache>()),
+      freetype_font_cache_(std::make_shared<freetype_embedded_font_cache>())
   {}
 
   inline renderer<BLEND2D>::renderer(render_config config,
@@ -550,19 +566,24 @@ namespace pdflib
       shape_({0, 0, 4}),
       font_resolver_(font_resolver ? std::move(font_resolver)
                                    : blend2d_font_resolver::default_resolver()),
-      embedded_font_cache_(std::make_shared<blend2d_embedded_font_cache>())
+      embedded_font_cache_(std::make_shared<blend2d_embedded_font_cache>()),
+      freetype_font_cache_(std::make_shared<freetype_embedded_font_cache>())
   {}
 
   inline renderer<BLEND2D>::renderer(render_config config,
                                      std::shared_ptr<blend2d_font_resolver> font_resolver,
-                                     std::shared_ptr<blend2d_embedded_font_cache> embedded_font_cache)
+                                     std::shared_ptr<blend2d_embedded_font_cache> embedded_font_cache,
+                                     std::shared_ptr<freetype_embedded_font_cache> freetype_font_cache)
     : config_(config),
       shape_({0, 0, 4}),
       font_resolver_(font_resolver ? std::move(font_resolver)
                                    : blend2d_font_resolver::default_resolver()),
       embedded_font_cache_(embedded_font_cache
                              ? std::move(embedded_font_cache)
-                             : std::make_shared<blend2d_embedded_font_cache>())
+                             : std::make_shared<blend2d_embedded_font_cache>()),
+      freetype_font_cache_(freetype_font_cache
+                             ? std::move(freetype_font_cache)
+                             : std::make_shared<freetype_embedded_font_cache>())
   {}
 
   inline BLContext& renderer<BLEND2D>::page_context()
@@ -1014,6 +1035,68 @@ namespace pdflib
   }
 
   // ---------------------------------------------------------------------------
+  // render_text_freetype
+  //
+  // Fallback path for embedded font programs Blend2D cannot load (Type 1,
+  // bare CFF): FreeType maps the cell's character code through the font's
+  // builtin encoding and decomposes the glyph outlines into a BLPath, which
+  // is filled under the same text transform as the regular path.
+  // ---------------------------------------------------------------------------
+
+  inline bool renderer<BLEND2D>::render_text_freetype(text_instruction& instr,
+                                                      const text_geometry& geom,
+                                                      const BLPath& bbox_path)
+  {
+    if (freetype_font_cache_ == nullptr or not freetype_font_cache_->available())
+      {
+        return false;
+      }
+
+    // With text rendering disabled the regular path handles the debug-only
+    // drawing (basepoint/bbox) through the system-resolved face.
+    if (not config_.render_text) { return false; }
+
+    if (geom.size <= 0.5) { return false; }
+
+    BLPath text_path;
+    if (not freetype_font_cache_->build_text_path(instr.get_embedded_font(),
+                                                  instr.get_text(),
+                                                  instr.get_char_code(),
+                                                  geom.size,
+                                                  text_path))
+      {
+        return false;
+      }
+
+    BLContext& ctx = page_context();
+
+    ctx.save();
+    const BLResult transform_res = ctx.apply_transform(make_text_transform(geom));
+    if (transform_res != BL_SUCCESS)
+      {
+        ctx.restore();
+        LOG_S(WARNING) << "render_text_freetype: apply_transform failed"
+                       << " (BLResult=" << transform_res << ")";
+        return false;
+      }
+
+    ctx.set_fill_style(BLRgba32(0xFF000000u)); // opaque black
+    if (not text_path.is_empty())
+      {
+        ctx.fill_path(text_path);
+      }
+    ctx.restore();
+
+    draw_text_basepoint(ctx, geom);
+    if (config_.draw_text_bbox)
+      {
+        stroke_text_bbox(ctx, bbox_path);
+      }
+
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
   // render_text
   //
   // Applies a full affine context transform
@@ -1048,8 +1131,9 @@ namespace pdflib
     //             << " cell_span=" << cell_span
     //             << " em_size=" << em_size << " size=" << size;
 
-    // Resolution order: embedded font program (if carried by the instruction
-    // and loadable by Blend2D) → system font resolver → hardcoded fallback.
+    // Resolution order: embedded font program — natively in Blend2D (SFNT)
+    // or as FreeType outline paths (Type 1, bare CFF) — then the system font
+    // resolver, then the hardcoded fallback.
     bool using_embedded_font = false;
     BLFontFace face;
     if (config_.use_embedded_fonts and instr.has_embedded_font())
@@ -1058,6 +1142,11 @@ namespace pdflib
         using_embedded_font = face.is_valid();
         if (not using_embedded_font)
           {
+            if (render_text_freetype(instr, geom, bbox_path))
+              {
+                return;
+              }
+
             LOG_S(INFO) << "render_text: embedded font not loadable"
                         << " font_name=`" << instr.get_font_name() << "`"
                         << " format=" << to_string(instr.get_embedded_font()->get_format())

--- a/src/render/blend2d_renderer.h
+++ b/src/render/blend2d_renderer.h
@@ -238,6 +238,55 @@ namespace pdflib
                               const text_geometry& geom,
                               const BLPath& bbox_path);
 
+    // Last-chance glyph-identity mapping when Unicode shaping against an
+    // embedded (Blend2D-loaded) face produced only .notdef: CID fonts with an
+    // identity CIDToGIDMap use the character code as glyph index directly;
+    // symbolic fonts are retried through the 0xF000 private-use convention.
+    // On success gb holds a positioned glyph run ready for fill_glyph_run.
+    static bool recover_embedded_glyphs(const BLFont& font,
+                                        text_instruction& instr,
+                                        BLGlyphBuffer& gb)
+    {
+      const int64_t char_code = instr.get_char_code();
+      if (char_code < 0 or not instr.has_embedded_font()) { return false; }
+
+      const auto& blob = instr.get_embedded_font();
+
+      if (blob->get_is_cid_font() and blob->get_cid_to_gid_identity())
+        {
+          const uint32_t glyph_id = static_cast<uint32_t>(char_code);
+          gb.set_glyphs(&glyph_id, 1);
+          // shape() rejects glyph content, so position directly.
+          if (font.position_glyphs(gb) == BL_SUCCESS and
+              not gb.is_empty() and
+              gb.placement_data() != nullptr)
+            {
+              LOG_S(INFO) << "render_text: recovered glyph via CID identity"
+                          << " cid=" << char_code
+                          << " font_name=`" << instr.get_font_name() << "`";
+              return true;
+            }
+        }
+
+      if (char_code <= 0xFF)
+        {
+          const uint32_t codepoint = 0xF000u + static_cast<uint32_t>(char_code);
+          gb.set_utf32_text(&codepoint, 1);
+          if (font.shape(gb) == BL_SUCCESS and
+              not gb.is_empty() and
+              gb.placement_data() != nullptr and
+              not glyph_run_all_notdef(gb))
+            {
+              LOG_S(INFO) << "render_text: recovered glyph via symbol cmap"
+                          << " char_code=" << char_code
+                          << " font_name=`" << instr.get_font_name() << "`";
+              return true;
+            }
+        }
+
+      return false;
+    }
+
     // Computes the canvas-space baseline, bounding quad, text cell height
     // vector, and Blend2D font size for one text instruction.
     text_geometry make_text_geometry(text_instruction& instr) const;
@@ -1062,6 +1111,7 @@ namespace pdflib
     if (not freetype_font_cache_->build_text_path(instr.get_embedded_font(),
                                                   instr.get_text(),
                                                   instr.get_char_code(),
+                                                  instr.get_glyph_name(),
                                                   geom.size,
                                                   text_path))
       {
@@ -1228,26 +1278,30 @@ namespace pdflib
             if (using_embedded_font and glyph_run_all_notdef(gb))
               {
                 // Shaping against an embedded subset font "succeeds" with
-                // glyph id 0 when the font simply lacks the glyph; drawing
-                // would produce blank/tofu output. Fall back to the system
-                // face for this cell only.
-                LOG_S(INFO) << "render_text: embedded face has no glyph"
-                            << " text=`" << instr.get_text() << "`"
-                            << " font_name=`" << instr.get_font_name() << "`"
-                            << " — falling back to system font";
-
-                BLFontFace system_face = resolve_font_face(instr.get_font_name(),
-                                                           instr.get_base_font());
-                BLFont system_font;
-                if (system_face.is_valid() and
-                    system_font.create_from_face(system_face,
-                                                 static_cast<float>(geom.size)) == BL_SUCCESS)
+                // glyph id 0 when the Unicode cmap simply lacks the
+                // codepoint. Try glyph-identity mapping (CID identity,
+                // symbol cmap) before giving the cell to the system face —
+                // drawing the .notdef run would produce blank/tofu output.
+                if (not recover_embedded_glyphs(font, instr, gb))
                   {
-                    gb.set_utf8_text(instr.get_text().c_str());
-                    if (system_font.shape(gb) == BL_SUCCESS and not gb.is_empty())
+                    LOG_S(INFO) << "render_text: embedded face has no glyph"
+                                << " text=`" << instr.get_text() << "`"
+                                << " font_name=`" << instr.get_font_name() << "`"
+                                << " — falling back to system font";
+
+                    BLFontFace system_face = resolve_font_face(instr.get_font_name(),
+                                                               instr.get_base_font());
+                    BLFont system_font;
+                    if (system_face.is_valid() and
+                        system_font.create_from_face(system_face,
+                                                     static_cast<float>(geom.size)) == BL_SUCCESS)
                       {
-                        font = system_font;
-                        using_embedded_font = false;
+                        gb.set_utf8_text(instr.get_text().c_str());
+                        if (system_font.shape(gb) == BL_SUCCESS and not gb.is_empty())
+                          {
+                            font = system_font;
+                            using_embedded_font = false;
+                          }
                       }
                   }
               }
@@ -1304,17 +1358,20 @@ namespace pdflib
                   }
                 adjustment.draw_origin.reset(0.0, 0.0);
               }
+            // Draw the glyph run that was already shaped (or recovered by
+            // glyph identity) above; fill_utf8_text would re-shape the text
+            // and lose any glyph-identity recovery.
             const BLResult text_res =
-              ctx.fill_utf8_text(adjustment.draw_origin,
+              ctx.fill_glyph_run(adjustment.draw_origin,
                                  font,
-                                 instr.get_text().c_str());
-            // LOG_S(INFO) << "render_text: after fill_utf8_text res=" << text_res;
+                                 gb.glyph_run());
+            // LOG_S(INFO) << "render_text: after fill_glyph_run res=" << text_res;
             // LOG_S(INFO) << "render_text: before ctx.restore";
             ctx.restore();
 
             if (text_res != BL_SUCCESS)
               {
-                LOG_S(WARNING) << "render_text: fill_utf8_text failed"
+                LOG_S(WARNING) << "render_text: fill_glyph_run failed"
                                << " (BLResult=" << text_res << ")"
                                << " text=`" << instr.get_text() << "`";
                 draw_bbox_fallback();

--- a/src/render/config.h
+++ b/src/render/config.h
@@ -40,13 +40,15 @@ namespace pdflib
     // (Helvetica / Arial) without any name lookup.
     bool resolve_fonts = true;
 
-    // Prefer the embedded font program (/FontFile2, /FontFile3 /OpenType)
-    // over system font resolution when the text instruction carries one and
-    // Blend2D can load it. Cells whose glyphs are missing from the embedded
-    // (usually subset) font fall back to the system-resolved font, so turning
-    // this off only forces the pre-embedded behaviour for A/B comparisons.
-    // Independent of resolve_fonts: with resolve_fonts=false the fallback is
-    // the hardcoded font instead of a name lookup.
+    // Prefer the embedded font program over system font resolution when the
+    // text instruction carries one. SFNT programs (/FontFile2, /FontFile3
+    // /OpenType) load natively in Blend2D; Type 1 and bare CFF programs
+    // (/FontFile, /FontFile3 /Type1C, /CIDFontType0C) render as
+    // FreeType-decomposed outline paths. Cells whose glyphs are missing from
+    // the embedded (usually subset) font fall back to the system-resolved
+    // font, so turning this off only forces the pre-embedded behaviour for
+    // A/B comparisons. Independent of resolve_fonts: with resolve_fonts=false
+    // the fallback is the hardcoded font instead of a name lookup.
     bool use_embedded_fonts = true;
 
     // Minimum Jaccard similarity required when fuzzy-matching a PDF font name

--- a/src/render/config.h
+++ b/src/render/config.h
@@ -40,6 +40,15 @@ namespace pdflib
     // (Helvetica / Arial) without any name lookup.
     bool resolve_fonts = true;
 
+    // Prefer the embedded font program (/FontFile2, /FontFile3 /OpenType)
+    // over system font resolution when the text instruction carries one and
+    // Blend2D can load it. Cells whose glyphs are missing from the embedded
+    // (usually subset) font fall back to the system-resolved font, so turning
+    // this off only forces the pre-embedded behaviour for A/B comparisons.
+    // Independent of resolve_fonts: with resolve_fonts=false the fallback is
+    // the hardcoded font instead of a name lookup.
+    bool use_embedded_fonts = true;
+
     // Minimum Jaccard similarity required when fuzzy-matching a PDF font name
     // to a system font file.  Candidates below this threshold are rejected and
     // the hardcoded fallback font is used instead.  Range [0, 1]; lower values

--- a/src/render/freetype_embedded_font_cache.h
+++ b/src/render/freetype_embedded_font_cache.h
@@ -30,13 +30,16 @@ namespace pdflib
   // FreeType, and converts glyph outlines into BLPath objects so that Blend2D
   // still performs all rasterization.
   //
-  // Character mapping: for a single-character cell the decoded PDF character
-  // code is resolved through the font's builtin encoding (Adobe custom /
-  // standard / Latin-1 charmaps — this is the faithful path for TeX fonts,
-  // whose PDF character codes are the font's own encoding), with the Unicode
-  // charmap as fallback; CID fonts with an identity CIDToGIDMap use the CID
-  // directly as glyph index. When nothing maps, the caller falls back to the
-  // system-resolved font for that cell.
+  // Glyph identity is resolved in decreasing order of authority:
+  //   1. CID with identity CIDToGIDMap — the CID is the glyph index;
+  //   2. the glyph name assigned by /Encoding /Differences (FT_Get_Name_Index);
+  //   3. the decoded PDF character code through the font's builtin encoding
+  //      (Adobe custom / standard / Latin-1, and MS symbol with the 0xF000
+  //      offset convention) — the faithful path for TeX fonts, whose PDF
+  //      character codes are the font's own encoding;
+  //   4. the Unicode codepoints of the cell text.
+  // When nothing maps, the caller falls back to the system-resolved font for
+  // that cell.
   //
   // FreeType is not thread-safe, so every entry point serializes on one
   // mutex; decomposed glyph paths are cached per face (in font units) to keep
@@ -64,6 +67,7 @@ namespace pdflib
     bool build_text_path(const std::shared_ptr<const embedded_font_blob>& blob,
                          const std::string& utf8_text,
                          int64_t char_code,
+                         const std::string& glyph_name,
                          double size,
                          BLPath& path);
 
@@ -96,6 +100,7 @@ namespace pdflib
                                const std::shared_ptr<const embedded_font_blob>& blob,
                                const std::string& utf8_text,
                                int64_t char_code,
+                               const std::string& glyph_name,
                                std::vector<FT_UInt>& glyph_indices);
 
     FT_UInt char_code_to_glyph_index(FT_Face face, FT_ULong code);
@@ -149,6 +154,7 @@ namespace pdflib
       const std::shared_ptr<const embedded_font_blob>& blob,
       const std::string& utf8_text,
       int64_t char_code,
+      const std::string& glyph_name,
       double size,
       BLPath& path)
   {
@@ -166,7 +172,7 @@ namespace pdflib
       }
 
     std::vector<FT_UInt> glyph_indices;
-    if(not resolve_glyph_indices(entry, blob, utf8_text, char_code, glyph_indices))
+    if(not resolve_glyph_indices(entry, blob, utf8_text, char_code, glyph_name, glyph_indices))
       {
         return false;
       }
@@ -251,6 +257,7 @@ namespace pdflib
       const std::shared_ptr<const embedded_font_blob>& blob,
       const std::string& utf8_text,
       int64_t char_code,
+      const std::string& glyph_name,
       std::vector<FT_UInt>& glyph_indices)
   {
     glyph_indices.clear();
@@ -265,6 +272,19 @@ namespace pdflib
             return true;
           }
         return false;
+      }
+
+    // /Encoding /Differences overrides the builtin encoding, so its glyph
+    // name is the most authoritative identity when present.
+    if(not glyph_name.empty() and FT_HAS_GLYPH_NAMES(entry.face))
+      {
+        const FT_UInt glyph_index =
+          FT_Get_Name_Index(entry.face, glyph_name.c_str());
+        if(glyph_index != 0)
+          {
+            glyph_indices.push_back(glyph_index);
+            return true;
+          }
       }
 
     // Single-character cell: the decoded PDF character code through the
@@ -329,6 +349,20 @@ namespace pdflib
           {
             return glyph_index;
           }
+      }
+
+    // Symbolic TrueType fonts (rejected by Blend2D when they lack a Unicode
+    // cmap) expose a (3,0) symbol cmap; by convention the byte codes live in
+    // the private-use range at 0xF000.
+    if(code <= 0xFF and FT_Select_Charmap(face, FT_ENCODING_MS_SYMBOL) == 0)
+      {
+        const FT_UInt glyph_index = FT_Get_Char_Index(face, 0xF000u + code);
+        if(glyph_index != 0)
+          {
+            return glyph_index;
+          }
+
+        return FT_Get_Char_Index(face, code);
       }
 
     return 0;

--- a/src/render/freetype_embedded_font_cache.h
+++ b/src/render/freetype_embedded_font_cache.h
@@ -1,0 +1,485 @@
+//-*-C++-*-
+
+#ifndef PDF_FREETYPE_EMBEDDED_FONT_CACHE_H
+#define PDF_FREETYPE_EMBEDDED_FONT_CACHE_H
+
+#include <blend2d/blend2d.h>
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_OUTLINE_H
+
+#ifndef LOGURU_WITH_STREAMS
+#define LOGURU_WITH_STREAMS 1
+#endif
+#include <loguru.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <parse/page_items/embedded_font_blob.h>
+
+namespace pdflib
+{
+  // Loads the embedded font program formats that Blend2D rejects — Type 1
+  // (/FontFile) and bare CFF (/FontFile3 /Type1C, /CIDFontType0C) — through
+  // FreeType, and converts glyph outlines into BLPath objects so that Blend2D
+  // still performs all rasterization.
+  //
+  // Character mapping: for a single-character cell the decoded PDF character
+  // code is resolved through the font's builtin encoding (Adobe custom /
+  // standard / Latin-1 charmaps — this is the faithful path for TeX fonts,
+  // whose PDF character codes are the font's own encoding), with the Unicode
+  // charmap as fallback; CID fonts with an identity CIDToGIDMap use the CID
+  // directly as glyph index. When nothing maps, the caller falls back to the
+  // system-resolved font for that cell.
+  //
+  // FreeType is not thread-safe, so every entry point serializes on one
+  // mutex; decomposed glyph paths are cached per face (in font units) to keep
+  // the critical section short after warm-up.
+  class freetype_embedded_font_cache
+  {
+  public:
+
+    freetype_embedded_font_cache();
+    ~freetype_embedded_font_cache();
+
+    freetype_embedded_font_cache(const freetype_embedded_font_cache&) = delete;
+    freetype_embedded_font_cache& operator=(const freetype_embedded_font_cache&) = delete;
+
+    // False when FT_Init_FreeType failed; every build_text_path call then
+    // returns false.
+    bool available() const;
+
+    // Builds the filled outline path of one text cell in Blend2D text space:
+    // baseline at the origin, y pointing down, units equal to pixels at em
+    // size `size`. Returns true when every character of the cell was mapped
+    // to a glyph (an empty path is a valid result, e.g. spaces); returns
+    // false when the font cannot be loaded or a character has no glyph, so
+    // the caller can fall back.
+    bool build_text_path(const std::shared_ptr<const embedded_font_blob>& blob,
+                         const std::string& utf8_text,
+                         int64_t char_code,
+                         double size,
+                         BLPath& path);
+
+  private:
+
+    struct glyph_entry
+    {
+      // Decomposed outline in font units (FreeType y-up convention).
+      BLPath path;
+      double advance = 0.0; // horizontal advance in font units
+      bool failed = false;
+    };
+
+    struct face_entry
+    {
+      // FT_New_Memory_Face does not copy the bytes; keep them alive.
+      std::shared_ptr<const std::vector<uint8_t> > bytes;
+
+      FT_Face face = nullptr;
+      bool failed = false;
+
+      std::unordered_map<FT_UInt, glyph_entry> glyphs;
+    };
+
+    face_entry& get_face_entry(const std::shared_ptr<const embedded_font_blob>& blob);
+
+    // Resolves the glyph indices of the cell; returns false when any
+    // character cannot be mapped.
+    bool resolve_glyph_indices(face_entry& entry,
+                               const std::shared_ptr<const embedded_font_blob>& blob,
+                               const std::string& utf8_text,
+                               int64_t char_code,
+                               std::vector<FT_UInt>& glyph_indices);
+
+    FT_UInt char_code_to_glyph_index(FT_Face face, FT_ULong code);
+
+    // Returns the cached (or freshly decomposed) outline and advance of one
+    // glyph in font units. Returns nullptr on failure (failures are cached).
+    const glyph_entry* get_glyph_entry(face_entry& entry, FT_UInt glyph_index);
+
+    static bool decompose_outline(FT_Outline& outline, BLPath& path);
+
+    static std::vector<uint32_t> decode_utf8(const std::string& text);
+
+    FT_Library library_ = nullptr;
+    std::mutex mutex_;
+    std::unordered_map<std::string, face_entry> faces_;
+  };
+
+  inline freetype_embedded_font_cache::freetype_embedded_font_cache()
+  {
+    const FT_Error error = FT_Init_FreeType(&library_);
+    if(error != 0)
+      {
+        library_ = nullptr;
+        LOG_S(WARNING) << "freetype font cache: FT_Init_FreeType failed with error=" << error;
+      }
+  }
+
+  inline freetype_embedded_font_cache::~freetype_embedded_font_cache()
+  {
+    for(auto& itr : faces_)
+      {
+        if(itr.second.face != nullptr)
+          {
+            FT_Done_Face(itr.second.face);
+          }
+      }
+    faces_.clear();
+
+    if(library_ != nullptr)
+      {
+        FT_Done_FreeType(library_);
+      }
+  }
+
+  inline bool freetype_embedded_font_cache::available() const
+  {
+    return library_ != nullptr;
+  }
+
+  inline bool freetype_embedded_font_cache::build_text_path(
+      const std::shared_ptr<const embedded_font_blob>& blob,
+      const std::string& utf8_text,
+      int64_t char_code,
+      double size,
+      BLPath& path)
+  {
+    if(library_ == nullptr or blob == nullptr or not blob->has_bytes() or size <= 0.0)
+      {
+        return false;
+      }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    face_entry& entry = get_face_entry(blob);
+    if(entry.failed or entry.face == nullptr)
+      {
+        return false;
+      }
+
+    std::vector<FT_UInt> glyph_indices;
+    if(not resolve_glyph_indices(entry, blob, utf8_text, char_code, glyph_indices))
+      {
+        return false;
+      }
+
+    const double units_per_em =
+      (entry.face->units_per_EM > 0) ? entry.face->units_per_EM : 1000.0;
+    const double scale = size / units_per_em;
+
+    path.clear();
+
+    double pen_x = 0.0;
+    for(FT_UInt glyph_index : glyph_indices)
+      {
+        const glyph_entry* glyph = get_glyph_entry(entry, glyph_index);
+        if(glyph == nullptr)
+          {
+            return false;
+          }
+
+        // Font units (y-up) -> Blend2D text space (y-down, pixels).
+        const BLMatrix2D m(scale, 0.0,
+                           0.0, -scale,
+                           pen_x * scale, 0.0);
+        path.add_path(glyph->path, m);
+
+        pen_x += glyph->advance;
+      }
+
+    return true;
+  }
+
+  inline freetype_embedded_font_cache::face_entry&
+  freetype_embedded_font_cache::get_face_entry(
+      const std::shared_ptr<const embedded_font_blob>& blob)
+  {
+    auto itr = faces_.find(blob->get_cache_key());
+    if(itr != faces_.end())
+      {
+        return itr->second;
+      }
+
+    face_entry entry;
+    entry.bytes = blob->get_bytes();
+
+    const FT_Error error = FT_New_Memory_Face(library_,
+                                              entry.bytes->data(),
+                                              static_cast<FT_Long>(entry.bytes->size()),
+                                              0,
+                                              &entry.face);
+    entry.failed = (error != 0 or entry.face == nullptr);
+
+    if(entry.failed)
+      {
+        entry.face = nullptr;
+        entry.bytes.reset();
+
+        LOG_S(INFO) << "freetype font cache: load failed"
+                    << " font_name=`" << blob->get_font_name() << "`"
+                    << " source=" << blob->get_source_key()
+                    << " format=" << to_string(blob->get_format())
+                    << " bytes=" << blob->byte_size()
+                    << " ft_error=" << error
+                    << " cache_key=" << blob->get_cache_key();
+      }
+    else
+      {
+        LOG_S(INFO) << "freetype font cache: loaded face"
+                    << " font_name=`" << blob->get_font_name() << "`"
+                    << " family=`" << (entry.face->family_name ? entry.face->family_name : "?") << "`"
+                    << " glyphs=" << entry.face->num_glyphs
+                    << " units_per_em=" << entry.face->units_per_EM
+                    << " format=" << to_string(blob->get_format())
+                    << " cache_key=" << blob->get_cache_key();
+      }
+
+    auto [inserted_itr, inserted] = faces_.emplace(blob->get_cache_key(), std::move(entry));
+    return inserted_itr->second;
+  }
+
+  inline bool freetype_embedded_font_cache::resolve_glyph_indices(
+      face_entry& entry,
+      const std::shared_ptr<const embedded_font_blob>& blob,
+      const std::string& utf8_text,
+      int64_t char_code,
+      std::vector<FT_UInt>& glyph_indices)
+  {
+    glyph_indices.clear();
+
+    // CID-keyed font with identity CIDToGIDMap: the character code is the
+    // CID is the glyph index.
+    if(blob->get_is_cid_font() and blob->get_cid_to_gid_identity() and char_code >= 0)
+      {
+        if(char_code < entry.face->num_glyphs)
+          {
+            glyph_indices.push_back(static_cast<FT_UInt>(char_code));
+            return true;
+          }
+        return false;
+      }
+
+    // Single-character cell: the decoded PDF character code through the
+    // font's builtin encoding.
+    if(char_code >= 0)
+      {
+        const FT_UInt glyph_index =
+          char_code_to_glyph_index(entry.face, static_cast<FT_ULong>(char_code));
+        if(glyph_index != 0)
+          {
+            glyph_indices.push_back(glyph_index);
+            return true;
+          }
+      }
+
+    // Fallback (and multi-character cells): Unicode codepoints of the text.
+    if(FT_Select_Charmap(entry.face, FT_ENCODING_UNICODE) != 0)
+      {
+        return false;
+      }
+
+    const std::vector<uint32_t> codepoints = decode_utf8(utf8_text);
+    if(codepoints.empty())
+      {
+        return false;
+      }
+
+    for(uint32_t codepoint : codepoints)
+      {
+        const FT_UInt glyph_index = FT_Get_Char_Index(entry.face, codepoint);
+        if(glyph_index == 0)
+          {
+            return false;
+          }
+        glyph_indices.push_back(glyph_index);
+      }
+
+    return true;
+  }
+
+  inline FT_UInt freetype_embedded_font_cache::char_code_to_glyph_index(
+      FT_Face face,
+      FT_ULong code)
+  {
+    // The builtin encodings of Type 1 / CFF fonts; Adobe custom comes first
+    // because subset TeX fonts expose their own encoding through it.
+    const FT_Encoding encodings[] = {
+      FT_ENCODING_ADOBE_CUSTOM,
+      FT_ENCODING_ADOBE_STANDARD,
+      FT_ENCODING_ADOBE_LATIN_1,
+    };
+
+    for(FT_Encoding encoding : encodings)
+      {
+        if(FT_Select_Charmap(face, encoding) != 0)
+          {
+            continue;
+          }
+
+        const FT_UInt glyph_index = FT_Get_Char_Index(face, code);
+        if(glyph_index != 0)
+          {
+            return glyph_index;
+          }
+      }
+
+    return 0;
+  }
+
+  inline const freetype_embedded_font_cache::glyph_entry*
+  freetype_embedded_font_cache::get_glyph_entry(face_entry& entry,
+                                                FT_UInt glyph_index)
+  {
+    auto itr = entry.glyphs.find(glyph_index);
+    if(itr != entry.glyphs.end())
+      {
+        return itr->second.failed ? nullptr : &itr->second;
+      }
+
+    glyph_entry glyph;
+
+    const FT_Error error = FT_Load_Glyph(entry.face,
+                                         glyph_index,
+                                         FT_LOAD_NO_SCALE | FT_LOAD_NO_BITMAP);
+    if(error != 0 or entry.face->glyph == nullptr)
+      {
+        LOG_S(INFO) << "freetype font cache: FT_Load_Glyph failed"
+                    << " glyph_index=" << glyph_index
+                    << " ft_error=" << error;
+        glyph.failed = true;
+      }
+    else
+      {
+        // With FT_LOAD_NO_SCALE all metrics are in font units.
+        glyph.advance = static_cast<double>(entry.face->glyph->advance.x);
+
+        if(entry.face->glyph->format == FT_GLYPH_FORMAT_OUTLINE)
+          {
+            glyph.failed = not decompose_outline(entry.face->glyph->outline, glyph.path);
+          }
+      }
+
+    auto [inserted_itr, inserted] = entry.glyphs.emplace(glyph_index, std::move(glyph));
+    return inserted_itr->second.failed ? nullptr : &inserted_itr->second;
+  }
+
+  inline bool freetype_embedded_font_cache::decompose_outline(FT_Outline& outline,
+                                                              BLPath& path)
+  {
+    struct decompose_state
+    {
+      BLPath* path;
+      bool has_contour;
+    };
+
+    FT_Outline_Funcs funcs;
+    funcs.shift = 0;
+    funcs.delta = 0;
+
+    funcs.move_to = [](const FT_Vector* to, void* user) -> int
+    {
+      auto* state = static_cast<decompose_state*>(user);
+      if(state->has_contour)
+        {
+          state->path->close();
+        }
+      state->has_contour = true;
+      state->path->move_to(static_cast<double>(to->x), static_cast<double>(to->y));
+      return 0;
+    };
+
+    funcs.line_to = [](const FT_Vector* to, void* user) -> int
+    {
+      auto* state = static_cast<decompose_state*>(user);
+      state->path->line_to(static_cast<double>(to->x), static_cast<double>(to->y));
+      return 0;
+    };
+
+    funcs.conic_to = [](const FT_Vector* control, const FT_Vector* to, void* user) -> int
+    {
+      auto* state = static_cast<decompose_state*>(user);
+      state->path->quad_to(static_cast<double>(control->x), static_cast<double>(control->y),
+                           static_cast<double>(to->x), static_cast<double>(to->y));
+      return 0;
+    };
+
+    funcs.cubic_to = [](const FT_Vector* control1, const FT_Vector* control2,
+                        const FT_Vector* to, void* user) -> int
+    {
+      auto* state = static_cast<decompose_state*>(user);
+      state->path->cubic_to(static_cast<double>(control1->x), static_cast<double>(control1->y),
+                            static_cast<double>(control2->x), static_cast<double>(control2->y),
+                            static_cast<double>(to->x), static_cast<double>(to->y));
+      return 0;
+    };
+
+    decompose_state state{&path, false};
+
+    const FT_Error error = FT_Outline_Decompose(&outline, &funcs, &state);
+    if(error != 0)
+      {
+        LOG_S(INFO) << "freetype font cache: FT_Outline_Decompose failed with error=" << error;
+        return false;
+      }
+
+    if(state.has_contour)
+      {
+        path.close();
+      }
+
+    return true;
+  }
+
+  inline std::vector<uint32_t> freetype_embedded_font_cache::decode_utf8(
+      const std::string& text)
+  {
+    std::vector<uint32_t> codepoints;
+
+    size_t i = 0;
+    while(i < text.size())
+      {
+        const uint8_t byte = static_cast<uint8_t>(text[i]);
+
+        uint32_t codepoint = 0;
+        size_t extra = 0;
+
+        if(byte < 0x80)       { codepoint = byte;        extra = 0; }
+        else if(byte < 0xC0)  { return {}; } // stray continuation byte
+        else if(byte < 0xE0)  { codepoint = byte & 0x1F; extra = 1; }
+        else if(byte < 0xF0)  { codepoint = byte & 0x0F; extra = 2; }
+        else if(byte < 0xF8)  { codepoint = byte & 0x07; extra = 3; }
+        else                  { return {}; }
+
+        if(i + extra >= text.size())
+          {
+            return {};
+          }
+
+        for(size_t k = 1; k <= extra; k++)
+          {
+            const uint8_t continuation = static_cast<uint8_t>(text[i + k]);
+            if((continuation & 0xC0) != 0x80)
+              {
+                return {};
+              }
+            codepoint = (codepoint << 6) | (continuation & 0x3F);
+          }
+
+        codepoints.push_back(codepoint);
+        i += extra + 1;
+      }
+
+    return codepoints;
+  }
+
+}
+
+#endif

--- a/tests/test_embedded_fonts.py
+++ b/tests/test_embedded_fonts.py
@@ -14,6 +14,9 @@ font programs:
 
 from io import BytesIO
 
+from docling_parse.pdf_parsers import (  # type: ignore[import]
+    DecodePageConfig as _DecodePageConfig,
+)
 from PIL import Image as PILImage
 
 from docling_parse.pdf_parser import (
@@ -21,9 +24,6 @@ from docling_parse.pdf_parser import (
     DoclingThreadedPdfParser,
     RenderConfig,
     ThreadedPdfParserConfig,
-)
-from docling_parse.pdf_parsers import (  # type: ignore[import]
-    DecodePageConfig as _DecodePageConfig,
 )
 
 ARXIV_PDF = "tests/data/regression/2508.13113v2.pdf"

--- a/tests/test_embedded_fonts.py
+++ b/tests/test_embedded_fonts.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python
+"""Tests for embedded font extraction and rendering.
+
+The fixture ``tests/data/regression/2508.13113v2.pdf`` embeds two kinds of
+font programs:
+
+- raw Type 1 (``/FontFile``: NimbusRomNo9L, CMR/CMSY/CMTT/CMMI TeX fonts) on
+  the text pages (e.g. page 1) — Blend2D cannot load these, so the renderer
+  must fall back to the system resolver and produce output identical to the
+  pre-embedded behaviour;
+- TrueType (``/FontFile2``: DejaVu Serif/Sans subsets) inside the figure Form
+  XObjects on pages 8, 17, 20, 21 and 22 — Blend2D loads these, so the
+  embedded face is actually used for drawing.
+"""
+
+from io import BytesIO
+
+from PIL import Image as PILImage
+
+from docling_parse.pdf_parser import (
+    DecodeConfig,
+    DoclingThreadedPdfParser,
+    RenderConfig,
+    ThreadedPdfParserConfig,
+)
+from docling_parse.pdf_parsers import (  # type: ignore[import]
+    DecodePageConfig as _DecodePageConfig,
+)
+
+ARXIV_PDF = "tests/data/regression/2508.13113v2.pdf"
+
+TYPE1_ONLY_PAGE = 1  # only /FontFile (Type 1) fonts
+TRUETYPE_PAGE = 21  # /FontFile2 DejaVu subsets inside figure XObjects
+
+
+def _make_parser(render_config: RenderConfig) -> DoclingThreadedPdfParser:
+    return DoclingThreadedPdfParser(
+        parser_config=ThreadedPdfParserConfig(
+            loglevel="fatal",
+            threads=1,
+            max_concurrent_results=32,
+            render_config=render_config,
+        ),
+        decode_config=DecodeConfig(),
+    )
+
+
+def _render_page(page_number: int, render_config: RenderConfig) -> PILImage.Image:
+    parser = _make_parser(render_config)
+    parser.load(ARXIV_PDF, page_numbers=[page_number])
+
+    result = next(parser.iterate_results())
+    assert result.success, result.error_message
+    assert result.page_number == page_number
+
+    return result.get_image()
+
+
+def _is_blank(image: PILImage.Image) -> bool:
+    lo, hi = image.convert("L").getextrema()
+    return lo == hi
+
+
+def test_render_config_exposes_use_embedded_fonts():
+    """RenderConfig exposes the embedded-font opt-out, defaulting to on."""
+    render_config = RenderConfig()
+    assert render_config.use_embedded_fonts is True
+
+    render_config.use_embedded_fonts = False
+    assert render_config.use_embedded_fonts is False
+
+
+def test_decode_page_config_exposes_extract_font_programs():
+    """The C++ decode config exposes extraction, defaulting to off.
+
+    Parse-only pipelines must not pay for font stream decoding; the threaded
+    render pipeline switches it on internally.
+    """
+    cpp_config = _DecodePageConfig()
+    assert cpp_config.extract_font_programs is False
+
+    cpp_config.extract_font_programs = True
+    assert cpp_config.extract_font_programs is True
+
+
+def test_embedded_truetype_changes_rendering():
+    """An embedded TrueType face must actually be used for drawing.
+
+    With resolve_fonts=False the only alternatives are the hardcoded fallback
+    font or the bbox outline, so using the embedded DejaVu subsets on the
+    figure page must change the output on every platform. (With
+    resolve_fonts=True the system resolver may find the same DejaVu family
+    and produce near-identical pixels, which would make this test flaky.)
+    """
+    embedded_on = RenderConfig()
+    embedded_on.resolve_fonts = False
+    embedded_on.use_embedded_fonts = True
+
+    embedded_off = RenderConfig()
+    embedded_off.resolve_fonts = False
+    embedded_off.use_embedded_fonts = False
+
+    image_on = _render_page(TRUETYPE_PAGE, embedded_on)
+    image_off = _render_page(TRUETYPE_PAGE, embedded_off)
+
+    assert not _is_blank(image_on)
+    assert not _is_blank(image_off)
+    assert image_on.size == image_off.size
+    assert image_on.tobytes() != image_off.tobytes()
+
+
+def test_unloadable_type1_falls_back_to_identical_output():
+    """Type 1 embedded fonts cannot load in Blend2D; output must not change.
+
+    The embedded-font path caches the load failure and falls back to the
+    system resolver, so a page with only /FontFile fonts renders byte-for-byte
+    the same whether the embedded path is enabled or not — and must not crash.
+    """
+    embedded_on = RenderConfig()
+    embedded_on.use_embedded_fonts = True
+
+    embedded_off = RenderConfig()
+    embedded_off.use_embedded_fonts = False
+
+    image_on = _render_page(TYPE1_ONLY_PAGE, embedded_on)
+    image_off = _render_page(TYPE1_ONLY_PAGE, embedded_off)
+
+    assert not _is_blank(image_on)
+    assert image_on.size == image_off.size
+    assert image_on.tobytes() == image_off.tobytes()
+
+
+def test_embedded_fonts_render_all_font_pages():
+    """Smoke test: every embedded-font-bearing page renders successfully.
+
+    Covers the .notdef fallback (subset fonts missing glyphs must not produce
+    blank cells or crashes) across Type 1, TrueType and mixed pages.
+    """
+    render_config = RenderConfig()
+
+    parser = _make_parser(render_config)
+    pages = [1, 2, 8, 9, 17, 21]
+    parser.load(ARXIV_PDF, page_numbers=pages)
+
+    rendered: dict[int, PILImage.Image] = {}
+    for result in parser.iterate_results():
+        assert result.success, (
+            f"Render failed page {result.page_number}: {result.error_message}"
+        )
+        rendered[result.page_number] = result.get_image()
+
+    assert sorted(rendered) == pages
+    for page_number, image in rendered.items():
+        assert not _is_blank(image), f"page {page_number} rendered blank"
+
+
+def _export_text_instructions(page_number: int) -> list:
+    parser = _make_parser(RenderConfig())
+    parser.load(ARXIV_PDF, page_numbers=[page_number])
+
+    result = next(parser.iterate_results())
+    assert result.success, result.error_message
+
+    exported = result._export_render_instructions_json()
+    return [
+        row
+        for row in exported["instructions"]
+        if row["type"] == "TEXT_RENDER_INSTRUCTION"
+    ]
+
+
+def test_extraction_attaches_embedded_font_metadata():
+    """Text instructions carry embedded font metadata (never the bytes)."""
+    rows = _export_text_instructions(TYPE1_ONLY_PAGE)
+    assert len(rows) > 0
+
+    embedded_rows = [row for row in rows if row["has_embedded_font"]]
+    assert len(embedded_rows) > 0, "no instruction carries an embedded font"
+
+    for row in embedded_rows:
+        embedded = row["embedded_font"]
+        assert embedded["source_key"] in (
+            "/FontDescriptor/FontFile",
+            "/FontDescriptor/FontFile2",
+            "/FontDescriptor/FontFile3",
+            "/FontFile",
+            "/FontFile2",
+            "/FontFile3",
+        )
+        assert embedded["byte_size"] > 0
+        assert embedded["cache_key"] != ""
+        assert "bytes" not in embedded
+
+    # page 1 embeds only raw Type 1 programs
+    formats = {row["embedded_font"]["format"] for row in embedded_rows}
+    assert formats == {"TYPE1"}
+
+
+def test_embedded_font_blob_is_shared_per_font():
+    """All instructions of one PDF font reference the same blob.
+
+    The content-hash cache key is the observable identity of the shared
+    blob: one font resource must yield exactly one cache key.
+    """
+    rows = _export_text_instructions(TYPE1_ONLY_PAGE)
+
+    keys_per_font: dict[str, set[str]] = {}
+    for row in rows:
+        if not row["has_embedded_font"]:
+            continue
+        keys_per_font.setdefault(row["font_key"], set()).add(
+            row["embedded_font"]["cache_key"]
+        )
+
+    assert len(keys_per_font) > 0
+    for font_key, cache_keys in keys_per_font.items():
+        assert len(cache_keys) == 1, (
+            f"font {font_key} produced multiple blobs: {cache_keys}"
+        )
+
+
+def test_char_code_is_exported_for_single_char_cells():
+    """Single-character cells expose their decoded PDF character code."""
+    rows = _export_text_instructions(TYPE1_ONLY_PAGE)
+
+    coded = [row for row in rows if row["char_code"] >= 0]
+    assert len(coded) > 0, "no instruction carries a character code"
+
+
+def test_embedded_face_cache_is_shared_across_documents():
+    """Two documents with identical fonts share one embedded-face cache.
+
+    The cache inside one parser is shared by all workers and documents and is
+    keyed by a content hash of the font bytes, so loading the same PDF twice
+    makes the second document hit cached faces (and cached Type 1 failures)
+    instead of re-loading — and both must render identically.
+    """
+    render_config = RenderConfig()
+
+    parser = _make_parser(render_config)
+    path_key = parser.load(ARXIV_PDF, page_numbers=[TRUETYPE_PAGE])
+    with open(ARXIV_PDF, "rb") as f:
+        bytes_key = parser.load(BytesIO(f.read()), page_numbers=[TRUETYPE_PAGE])
+
+    images: dict[str, PILImage.Image] = {}
+    for result in parser.iterate_results():
+        assert result.success, result.error_message
+        images[result.doc_key] = result.get_image()
+
+    assert set(images) == {path_key, bytes_key}
+    assert images[path_key].tobytes() == images[bytes_key].tobytes()

--- a/tests/test_embedded_fonts.py
+++ b/tests/test_embedded_fonts.py
@@ -227,6 +227,23 @@ def test_char_code_is_exported_for_single_char_cells():
     assert len(coded) > 0, "no instruction carries a character code"
 
 
+def test_glyph_names_are_exported_for_differences_encodings():
+    """Cells of fonts with /Encoding /Differences expose their glyph name.
+
+    The page-1 NimbusRomNo9L fonts carry a /Differences array, so at least
+    some single-character cells must expose the glyph name that identifies
+    the glyph inside the embedded font program.
+    """
+    rows = _export_text_instructions(TYPE1_ONLY_PAGE)
+
+    named = [row for row in rows if row["glyph_name"] != ""]
+    assert len(named) > 0, "no instruction carries a glyph name"
+
+    for row in named:
+        assert row["char_code"] >= 0
+        assert not row["glyph_name"].startswith("/")
+
+
 def test_embedded_face_cache_is_shared_across_documents():
     """Two documents with identical fonts share one embedded-face cache.
 

--- a/tests/test_embedded_fonts.py
+++ b/tests/test_embedded_fonts.py
@@ -6,11 +6,10 @@ font programs:
 
 - raw Type 1 (``/FontFile``: NimbusRomNo9L, CMR/CMSY/CMTT/CMMI TeX fonts) on
   the text pages (e.g. page 1) — Blend2D cannot load these, so the renderer
-  must fall back to the system resolver and produce output identical to the
-  pre-embedded behaviour;
+  draws them as FreeType-decomposed outline paths;
 - TrueType (``/FontFile2``: DejaVu Serif/Sans subsets) inside the figure Form
-  XObjects on pages 8, 17, 20, 21 and 22 — Blend2D loads these, so the
-  embedded face is actually used for drawing.
+  XObjects on pages 8, 17, 20, 21 and 22 — Blend2D loads these natively, so
+  the embedded face is used for drawing directly.
 """
 
 from io import BytesIO
@@ -109,25 +108,30 @@ def test_embedded_truetype_changes_rendering():
     assert image_on.tobytes() != image_off.tobytes()
 
 
-def test_unloadable_type1_falls_back_to_identical_output():
-    """Type 1 embedded fonts cannot load in Blend2D; output must not change.
+def test_embedded_type1_changes_rendering():
+    """Type 1 embedded fonts render through the FreeType outline path.
 
-    The embedded-font path caches the load failure and falls back to the
-    system resolver, so a page with only /FontFile fonts renders byte-for-byte
-    the same whether the embedded path is enabled or not — and must not crash.
+    Blend2D rejects raw /FontFile programs, so the renderer decomposes their
+    glyph outlines with FreeType instead of substituting a system font. With
+    resolve_fonts=False the alternative is the hardcoded fallback font, so
+    using the embedded CM/Nimbus outlines must change the output on every
+    platform — and must not crash on the TeX subset fonts.
     """
     embedded_on = RenderConfig()
+    embedded_on.resolve_fonts = False
     embedded_on.use_embedded_fonts = True
 
     embedded_off = RenderConfig()
+    embedded_off.resolve_fonts = False
     embedded_off.use_embedded_fonts = False
 
     image_on = _render_page(TYPE1_ONLY_PAGE, embedded_on)
     image_off = _render_page(TYPE1_ONLY_PAGE, embedded_off)
 
     assert not _is_blank(image_on)
+    assert not _is_blank(image_off)
     assert image_on.size == image_off.size
-    assert image_on.tobytes() == image_off.tobytes()
+    assert image_on.tobytes() != image_off.tobytes()
 
 
 def test_embedded_fonts_render_all_font_pages():

--- a/tests/test_embedded_fonts.py
+++ b/tests/test_embedded_fonts.py
@@ -166,11 +166,7 @@ def _export_text_instructions(page_number: int) -> list:
     assert result.success, result.error_message
 
     exported = result._export_render_instructions_json()
-    return [
-        row
-        for row in exported["instructions"]
-        if row["type"] == "TEXT_RENDER_INSTRUCTION"
-    ]
+    return [row for row in exported["instructions"] if row["type"] == "text"]
 
 
 def test_extraction_attaches_embedded_font_metadata():


### PR DESCRIPTION
  ## Embedded Font Support for PDF Parser

  ### Summary

  Add full embedded font rendering support using FreeType and Blend2D, enabling the parser to extract and render fonts
  directly from PDF files rather than falling back to substitutes.

  ### Changes

  - **Font extraction**: New `embedded_font_blob.h` handles embedded font data blobs from PDFs
  - **Font caching & rendering**:
    - `freetype_embedded_font_cache.h`: FreeType library integration for glyph metrics/shapes
    - `blend2d_embedded_font_cache.h`: Blend2D integration for rasterization
  - **Glyph name resolution**: Extract glyph names from PDF `/Differences` arrays and propagate through render
  instructions
  - **CMake integration**: Added `extlib_freetype.cmake` for FreeType build configuration, with DEBUG_POSTFIX fix for
  CI compatibility
  - **Tests**: Comprehensive test suite covering embedded font extraction and rendering

  ### Testing

  - New `test_embedded_fonts.py` with 268 lines of test coverage
  - All wheel builds (manylinux/macOS, Python 3.10-3.13) passing
  - Code checks fixed with proper CMAKE_DEBUG_POSTFIX handling
  
  ## Scaling
  
  ```
uv run python ./perf/run_scaling.py --threads "8" --other ""

backend             threads    wall_time (s)  vs threaded(1)      pages/sec    ms/page
----------------  ---------  ---------------  ----------------  -----------  ---------
docling threaded          1         1642.82   1.00x                    33.2      30.1
docling threaded          2          842.129  1.95x                    64.8      15.43
docling threaded          4          434.296  3.78x                   125.7       7.96
docling threaded          8          242.115  6.78x                   225.4       4.44
docling threaded         12          191.881  8.56x                   284.5       3.52
```
  