### PR TITLE
fix: report document load failures instead of deferring them as -1 page count

### DIFF
--- a/src/pybind/docling_parser.h
+++ b/src/pybind/docling_parser.h
@@ -170,9 +170,17 @@ namespace docling
         remove_page_decoders(key);
 
         doc_decoders[key] = std::make_shared<doc_decoder_type>();
-        doc_decoders.at(key)->process_document_from_file(filename,
-                                                         password,
-                                                         keep_qpdf_warnings);
+        bool success = doc_decoders.at(key)->process_document_from_file(filename,
+                                                                        password,
+                                                                        keep_qpdf_warnings);
+        if(not success)
+          {
+            // do not keep a decoder that never parsed the document: it would
+            // report is_loaded()=true and a number_of_pages of -1
+            doc_decoders.erase(key);
+            LOG_S(ERROR) << "could not process document for key=" << key;
+            return false;
+          }
 
         return true;
       }
@@ -210,16 +218,25 @@ namespace docling
 
         doc_decoders[key] = std::make_shared<doc_decoder_type>();
         std::string description = "parsing of " + key + " from bytesio";
-        doc_decoders.at(key)->process_document_from_bytesio(data_buffer,
-                                                            password,
-                                                            description,
-                                                            keep_qpdf_warnings);
+        bool success = doc_decoders.at(key)->process_document_from_bytesio(data_buffer,
+                                                                           password,
+                                                                           description,
+                                                                           keep_qpdf_warnings);
+        if(not success)
+          {
+            // do not keep a decoder that never parsed the document: it would
+            // report is_loaded()=true and a number_of_pages of -1
+            doc_decoders.erase(key);
+            LOG_S(ERROR) << "could not decode bytesio object for key="<<key;
+            return false;
+          }
 
         return true;
       }
     catch(const std::exception& exc)
       {
-        LOG_S(ERROR) << "could not docode bytesio object for key="<<key;
+        doc_decoders.erase(key);
+        LOG_S(ERROR) << "could not decode bytesio object for key="<<key;
         return false;
       }
 

--- a/src/pybind/docling_threaded_base.h
+++ b/src/pybind/docling_threaded_base.h
@@ -217,9 +217,17 @@ namespace docling
         try
           {
             key2doc[key] = std::make_shared<doc_decoder_type>();
-            key2doc.at(key)->process_document_from_file(filename,
-                                                        password,
-                                                        config.keep_qpdf_warnings);
+            bool success = key2doc.at(key)->process_document_from_file(filename,
+                                                                       password,
+                                                                       config.keep_qpdf_warnings);
+            if(not success)
+              {
+                // do not keep a decoder that never parsed the document: it
+                // would schedule zero pages and report a page count of -1
+                key2doc.erase(key);
+                LOG_S(ERROR) << "could not decode file object for key=" << key;
+                return false;
+              }
           }
         catch(const std::exception& exc)
           {
@@ -277,10 +285,19 @@ namespace docling
       {
         key2doc[key] = std::make_shared<doc_decoder_type>();
         std::string description = "parsing of " + key + " from bytesio";
-        key2doc.at(key)->process_document_from_bytesio(data_buffer,
-                                                       password,
-                                                       description,
-                                                       config.keep_qpdf_warnings);
+        bool success = key2doc.at(key)->process_document_from_bytesio(data_buffer,
+                                                                      password,
+                                                                      description,
+                                                                      config.keep_qpdf_warnings);
+        if(not success)
+          {
+            // do not keep a decoder that never parsed the document: it would
+            // schedule zero pages and report a page count of -1
+            key2doc.erase(key);
+            key2scheduled_pages.erase(key);
+            LOG_S(ERROR) << "could not decode bytesio object for key=" << key;
+            return false;
+          }
       }
     catch(const std::exception& exc)
       {
@@ -361,6 +378,14 @@ namespace docling
       std::optional<std::vector<int>> page_numbers) const
   {
     std::vector<int> scheduled_pages;
+
+    if(num_pages < 0)
+      {
+        // a negative count means the document was never parsed; scheduling
+        // from it would silently produce an empty task list
+        throw std::runtime_error("Invalid page count " + std::to_string(num_pages)
+                                 + " for document key " + key);
+      }
 
     if(not page_numbers.has_value())
       {

--- a/tests/test_load_failure.py
+++ b/tests/test_load_failure.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""Load failures must be reported, not deferred as a -1 page count.
+
+When qpdf cannot parse a document, the C++ decoder returns false with its
+number_of_pages still at the -1 sentinel. The pybind loaders used to ignore
+that return value and report success, so the failure only surfaced later as
+number_of_pages() == -1 — which downstream docling propagated as
+"Inconsistent number of pages: N!=-1" and a silently rejected document
+(docling-parse#239, docling#3031).
+
+load() must raise at load time, and the failed key must not linger in the
+parser (is_loaded() reporting true for a document that never parsed).
+"""
+
+from io import BytesIO
+
+import pytest
+
+from docling_parse.pdf_parser import DoclingPdfParser, DoclingThreadedPdfParser
+
+GARBAGE = b"%PDF-1.4\nthis is not a valid pdf at all"
+
+
+def _minimal_pdf() -> bytes:
+    content = "BT /F1 24 Tf 72 700 Td (ok) Tj ET"
+    objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        "/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        f"<< /Length {len(content)} >>\nstream\n{content}\nendstream",
+    ]
+
+    out = b"%PDF-1.4\n"
+    offsets = []
+    for index, obj in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{index} 0 obj\n{obj}\nendobj\n".encode("latin-1")
+
+    startxref = len(out)
+    out += f"xref\n0 {len(objects) + 1}\n".encode("latin-1")
+    out += b"0000000000 65535 f \n"
+    for offset in offsets:
+        out += f"{offset:010d} 00000 n \n".encode("latin-1")
+    out += (
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{startxref}\n%%EOF"
+    ).encode("latin-1")
+    return out
+
+
+def test_bytesio_garbage_raises_at_load():
+    parser = DoclingPdfParser(loglevel="fatal")
+    with pytest.raises(RuntimeError, match="Failed to load document"):
+        parser.load(path_or_stream=BytesIO(GARBAGE))
+
+
+def test_file_garbage_raises_at_load(tmp_path):
+    bad = tmp_path / "garbage.pdf"
+    bad.write_bytes(GARBAGE)
+
+    parser = DoclingPdfParser(loglevel="fatal")
+    with pytest.raises(RuntimeError, match="Failed to load document"):
+        parser.load(path_or_stream=str(bad))
+
+
+def test_failed_load_leaves_no_stale_key():
+    parser = DoclingPdfParser(loglevel="fatal")
+    with pytest.raises(RuntimeError):
+        parser.load(path_or_stream=BytesIO(GARBAGE))
+
+    # a decoder that never parsed must not stay registered: it would report
+    # is_loaded()=true and number_of_pages()=-1
+    assert parser.list_loaded_keys() == []
+
+
+def test_valid_document_still_loads():
+    parser = DoclingPdfParser(loglevel="fatal")
+    doc = parser.load(path_or_stream=BytesIO(_minimal_pdf()))
+    assert doc.number_of_pages() == 1
+
+
+def test_threaded_bytesio_garbage_raises_at_load():
+    parser = DoclingThreadedPdfParser()
+    with pytest.raises(RuntimeError, match="Failed to load document"):
+        parser.load(path_or_stream=BytesIO(GARBAGE))
+
+
+def test_threaded_valid_document_still_loads():
+    parser = DoclingThreadedPdfParser()
+    key = parser.load(path_or_stream=BytesIO(_minimal_pdf()))
+    assert parser.page_count(key) == 1


### PR DESCRIPTION
Fixes #239. Related: docling-project/docling#3031.

## Problem

When qpdf cannot parse a document, `pdf_decoder<DOCUMENT>::process_document_from_bytesio` correctly catches the exception, logs it, and returns `false` — with `number_of_pages` still at its `-1` sentinel. But every pybind loader **discards that return value**:

- `docling_parser::load_document` returns `true` whenever the file merely exists;
- `docling_parser::load_document_from_bytesio` returns `true` unless an exception escapes — which it never does, because the decoder catches internally;
- both `docling_threaded_base` loaders have the same ignored return (their try/catch is equally unreachable for this failure).

So the Python `load()` — which does check the loader result and would raise — never gets the signal. The failure only surfaces later and indirectly:

```python
parser = DoclingPdfParser()
doc = parser.load(path_or_stream=BytesIO(b"%PDF-1.4\ngarbage"))  # "succeeds"
doc.is_loaded()          # True
doc.number_of_pages()    # -1
```

Downstream, docling propagates the `-1` as `Inconsistent number of pages: N!=-1` and rejects the document via `is_valid()` (docling#3031). In the threaded parser it is quieter still: `normalise_page_numbers(key, -1, None)` silently produces an **empty schedule** — the corrupt document "loads" and processes zero pages with no error at all, and with an explicit page list the user gets the baffling `Invalid page number 1 ... with -1 pages`.

#232 (page count from `getAllPages()`) and #240 robustify counting for documents qpdf *can* open; this PR closes the remaining path, where qpdf cannot open the document at all.

## Fix

All four loaders now check the decoder's result; on failure they erase the just-created decoder from the registry and return `false`:

- a decoder that never parsed no longer stays registered (`is_loaded()` reporting `true` with `number_of_pages() == -1`);
- the existing Python-side `raise RuntimeError("Failed to load document with key ...")` now fires at load time — a loud, immediate failure exactly where the caller can act on it (e.g. docling falling back to its lenient pypdfium2 backend, as discussed in docling#3031);
- `normalise_page_numbers` additionally rejects a negative page count outright, so a `-1` can never silently schedule an empty task list.

This is signalling-only: documents that qpdf can parse (including with warnings) load exactly as before. No groundtruth impact.

## Tests

`tests/test_load_failure.py`: garbage bytes via BytesIO and via file path raise `RuntimeError` at `load()` for both `DoclingPdfParser` and `DoclingThreadedPdfParser`; a failed load leaves no stale key registered; minimal valid PDFs still load with the correct page count.
