### PR TITLE
feat: added the rendering-regression with pypdfium

### DIFF
--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -74,6 +74,7 @@ namespace
       size["type"] = instruction_name(pdflib::SIZE_INSTRUCTION);
       size["media_bbox"] = instr.media_bbox;
       size["crop_bbox"] = instr.crop_bbox;
+      size["angle"] = instr.angle;
       root["size_instruction"] = size;
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,8 @@ python_version = "3.10"
 module = [
     "tabulate.*",
     "botocore.*",
-    "boto3.*"
+    "boto3.*",
+    "pypdfium2.*"
 ]
 ignore_missing_imports = true
 

--- a/src/parse/page_items/page_dimension.h
+++ b/src/parse/page_items/page_dimension.h
@@ -291,6 +291,20 @@ namespace pdflib
 	  }
       }
 
+    // A rectangle may be written with any pair of opposite corners, and shall
+    // be normalised so that the first corner is the lower-left one
+    // (ISO 32000-1, 7.9.5). Without this, a page box written top-down has a
+    // negative extent, which propagates into every page size derived from it.
+    if(result[0] > result[2])
+      {
+	std::swap(result[0], result[2]);
+      }
+
+    if(result[1] > result[3])
+      {
+	std::swap(result[1], result[3]);
+      }
+
     return result;
   }
 

--- a/src/parse/page_items/render_instructions.h
+++ b/src/parse/page_items/render_instructions.h
@@ -156,8 +156,19 @@ namespace pdflib
   public:
     const static RENDER_INSTRUCTION_NAME instr = SIZE_INSTRUCTION;
 
-    std::array<int, 4> media_bbox;
-    std::array<int, 4> crop_bbox;
+    // Page boxes in PDF units (ISO 32000-1, 14.11.2). They are real-valued
+    // rectangles and are kept as written: truncating them to integers both
+    // shifts the page origin and shrinks the page by up to a point, which a
+    // renderer would turn into a misplaced and undersized canvas.
+    std::array<double, 4> media_bbox;
+    std::array<double, 4> crop_bbox;
+
+    // The page's /Rotate value (ISO 32000-1, Table 30): the number of degrees
+    // by which the page shall be rotated clockwise when displayed. The boxes
+    // above are the ones written in the PDF, so they are stated before that
+    // rotation is applied, and so are all following render instructions. A
+    // renderer therefore has to rotate its finished canvas by this angle.
+    int angle = 0;
   };
 
 
@@ -689,7 +700,8 @@ namespace pdflib
     // add instruction methods
 
     void set_size_instruction(std::array<double, 4> media_bbox,
-                              std::array<double, 4> crop_bbox);
+                              std::array<double, 4> crop_bbox,
+                              int angle);
 
     void add_size_instruction(size_instruction& instr);
     void add_text_instruction(text_instruction_type instr);
@@ -727,13 +739,13 @@ namespace pdflib
   };
 
   inline void pdf_render_instructions::set_size_instruction(std::array<double, 4> media_bbox,
-                                                            std::array<double, 4> crop_bbox)
+                                                            std::array<double, 4> crop_bbox,
+                                                            int angle)
   {
-    for(int i = 0; i < 4; i++)
-      {
-        size_instr.media_bbox[i] = static_cast<int>(media_bbox[i]);
-        size_instr.crop_bbox[i] = static_cast<int>(crop_bbox[i]);
-      }
+    size_instr.media_bbox = media_bbox;
+    size_instr.crop_bbox = crop_bbox;
+
+    size_instr.angle = angle;
   }
 
   inline void pdf_render_instructions::add_size_instruction(size_instruction& instr)

--- a/src/parse/pdf_decoders/page.h
+++ b/src/parse/pdf_decoders/page.h
@@ -914,8 +914,12 @@ namespace pdflib
 
     page_dimension.execute(qpdf_page);
 
+    // The angle is captured here, before rotate_contents() normalizes it away:
+    // the render instructions are emitted in unrotated page space, so the
+    // renderer needs the original /Rotate to orient its canvas.
     instructions.set_size_instruction(page_dimension.get_media_bbox(),
-                                      page_dimension.get_crop_bbox());
+                                      page_dimension.get_crop_bbox(),
+                                      page_dimension.get_angle());
   }
 
   void pdf_decoder<PAGE>::decode_resources(const decode_config& config)

--- a/src/render/blend2d_renderer.h
+++ b/src/render/blend2d_renderer.h
@@ -61,6 +61,12 @@ namespace pdflib
     // Initializes the page canvas from the PDF crop box and render_config. This
     // computes the PDF-to-canvas scale/origin, creates a PRGB32 Blend2D image,
     // starts the page context, and fills the canvas with opaque white.
+    //
+    // All drawing happens in unrotated page space, which is the space the
+    // render instructions are expressed in. When the page carries a /Rotate,
+    // the canvas is allocated in that space (so width and height are swapped
+    // with respect to the reported shape) and the finished canvas is rotated
+    // into display orientation before it leaves the renderer.
     void set_size(size_instruction& instr);
 
     // Renders one text cell into the page canvas. The method converts the PDF
@@ -89,12 +95,14 @@ namespace pdflib
     // axis-aligned rectangular clips. Curve segments render as true cubics.
     void render_shape(shape_instruction& instr);
 
-    // Returns the rendered canvas as RGBA bytes, row-major top-to-bottom.
-    // The associated shape is {height, width, 4}.
+    // Returns the rendered canvas as RGBA bytes, row-major top-to-bottom, in
+    // display orientation. The associated shape is {height, width, 4}.
     std::shared_ptr<std::vector<uint8_t>> get_canvas() const;
 
-    // Returns the current canvas shape as {height, width, channels}. Before
-    // set_size() this is {0, 0, 4}.
+    // Returns the canvas shape in display orientation as {height, width,
+    // channels}. Before set_size() this is {0, 0, 4}. This is the shape the
+    // canvas has once it is handed out, so for a page rotated by 90 or 270
+    // degrees it is already the transpose of the internal drawing canvas.
     const std::array<int, 3>& get_shape() const { return shape_; }
 
     // Save the canvas to a file.  The format is inferred from the extension
@@ -139,11 +147,21 @@ namespace pdflib
     mutable BLImage    image_;  // internal canvas (PRGB32 format)
     mutable BLContext  context_;
     mutable bool       context_active_ = false;
-    std::array<int, 3> shape_;  // {height, width, 4}
+    std::array<int, 3> shape_;  // {height, width, 4}, display orientation
+    int canvas_width_ = 0;     // internal canvas width (unrotated page space)
+    int canvas_height_ = 0;    // internal canvas height (unrotated page space)
     double scale_x_ = 1.0;     // pdf-to-canvas scale along x
     double scale_y_ = 1.0;     // pdf-to-canvas scale along y
     double origin_x_ = 0.0;    // crop_bbox x origin (pdf units)
     double origin_y_ = 0.0;    // crop_bbox y origin (pdf units, y-up)
+
+    // Quarter turns clockwise that take the internal canvas into display
+    // orientation, derived from the page's /Rotate. In [0, 3].
+    int quarter_turns_ = 0;
+
+    // Guards the one-shot canvas rotation, so that repeated canvas access
+    // (get_canvas() followed by save(), for instance) rotates only once.
+    mutable bool rotation_applied_ = false;
 
     std::shared_ptr<blend2d_font_resolver> font_resolver_;
     std::shared_ptr<blend2d_embedded_font_cache> embedded_font_cache_;
@@ -154,16 +172,33 @@ namespace pdflib
     // necessary. Throws when called before a non-empty canvas has been created.
     BLContext& page_context();
 
-    // Ends the active Blend2D context if one is open. This flushes pending
-    // drawing operations before canvas extraction or file output.
+    // Ends the active Blend2D context if one is open and rotates the finished
+    // canvas into display orientation. This flushes pending drawing operations
+    // before canvas extraction or file output.
     void finish_page_context() const;
 
+    // Rotates the drawing canvas clockwise by quarter_turns_ so that it leaves
+    // the renderer in display orientation. Multiples of 90 degrees permute
+    // pixels exactly, so this neither resamples nor loses precision. Does
+    // nothing for an unrotated page or an already rotated canvas, and must run
+    // only after the Blend2D context has been ended.
+    void apply_page_rotation() const;
+
+    // Number of quarter turns clockwise for a /Rotate angle, normalized to
+    // [0, 3]. Angles that are not a multiple of 90 are not representable in
+    // PDF (ISO 32000-1, Table 30) and are reported and treated as unrotated.
+    static int quarter_turns_from_angle(int angle);
+
+    // True once set_size() has allocated a canvas to draw on.
+    bool has_canvas() const { return canvas_width_ > 0 and canvas_height_ > 0; }
+
     // Convert PDF coordinates (origin at crop_bbox bottom-left, y-up) to
-    // canvas coordinates (origin top-left, y-down), applying scale.
+    // canvas coordinates (origin top-left, y-down), applying scale. These are
+    // coordinates on the internal, unrotated canvas.
     double canvas_x(double pdf_x) const { return (pdf_x - origin_x_) * scale_x_; }
     double canvas_y(double pdf_y) const
     {
-      return static_cast<double>(shape_[0]) - (pdf_y - origin_y_) * scale_y_;
+      return static_cast<double>(canvas_height_) - (pdf_y - origin_y_) * scale_y_;
     }
 
     // Decides whether a text cell should use glyph-bbox fitting when glyph bbox
@@ -711,7 +746,7 @@ namespace pdflib
         return context_;
       }
 
-    if (shape_[0] == 0 or shape_[1] == 0)
+    if (not has_canvas())
       {
         throw std::runtime_error("renderer<BLEND2D>::page_context: canvas is empty");
       }
@@ -730,19 +765,128 @@ namespace pdflib
 
   inline void renderer<BLEND2D>::finish_page_context() const
   {
-    if (not context_active_)
+    if (context_active_)
+      {
+        const BLResult err = context_.end();
+        context_active_ = false;
+        if (err != BL_SUCCESS)
+          {
+            throw std::runtime_error(
+              "renderer<BLEND2D>::finish_page_context: failed to end Blend2D context "
+              "(BLResult=" + std::to_string(err) + ")");
+          }
+      }
+
+    apply_page_rotation();
+  }
+
+  inline int renderer<BLEND2D>::quarter_turns_from_angle(int angle)
+  {
+    int normalised = angle % 360;
+    if (normalised < 0)
+      {
+        normalised += 360;
+      }
+
+    if ((normalised % 90) != 0)
+      {
+        LOG_S(ERROR) << "the /Rotate angle should be a multiple of 90, got: "
+                     << angle << " -> rendering the page unrotated";
+        return 0;
+      }
+
+    return normalised / 90;
+  }
+
+  inline void renderer<BLEND2D>::apply_page_rotation() const
+  {
+    if (rotation_applied_ or quarter_turns_ == 0 or image_.is_empty())
       {
         return;
       }
 
-    const BLResult err = context_.end();
-    context_active_ = false;
-    if (err != BL_SUCCESS)
+    rotation_applied_ = true;
+
+    const int src_w = image_.width();
+    const int src_h = image_.height();
+    if (src_w <= 0 or src_h <= 0)
+      {
+        return;
+      }
+
+    BLImageData src_data;
+    const BLResult src_res = image_.get_data(&src_data);
+    if (src_res != BL_SUCCESS)
       {
         throw std::runtime_error(
-          "renderer<BLEND2D>::finish_page_context: failed to end Blend2D context "
-          "(BLResult=" + std::to_string(err) + ")");
+          "renderer<BLEND2D>::apply_page_rotation: failed to read canvas data "
+          "(BLResult=" + std::to_string(src_res) + ")");
       }
+
+    const bool transposed = (quarter_turns_ % 2) != 0;
+    const int dst_w = transposed ? src_h : src_w;
+    const int dst_h = transposed ? src_w : src_h;
+
+    BLImage rotated;
+    const BLResult create_res = rotated.create(dst_w, dst_h, BL_FORMAT_PRGB32);
+    if (create_res != BL_SUCCESS)
+      {
+        throw std::runtime_error(
+          "renderer<BLEND2D>::apply_page_rotation: failed to create rotated canvas "
+          "(BLResult=" + std::to_string(create_res) + ")");
+      }
+
+    BLImageData dst_data;
+    const BLResult dst_res = rotated.make_mutable(&dst_data);
+    if (dst_res != BL_SUCCESS)
+      {
+        throw std::runtime_error(
+          "renderer<BLEND2D>::apply_page_rotation: failed to lock rotated canvas "
+          "(BLResult=" + std::to_string(dst_res) + ")");
+      }
+
+    const auto* src_base = static_cast<const uint8_t*>(src_data.pixel_data);
+    auto* dst_base = static_cast<uint8_t*>(dst_data.pixel_data);
+
+    for (int y = 0; y < src_h; ++y)
+      {
+        const auto* src_row =
+          reinterpret_cast<const uint32_t*>(src_base + y * src_data.stride);
+
+        for (int x = 0; x < src_w; ++x)
+          {
+            // clockwise: the source top-left corner moves to the top-right for
+            // one quarter turn, to the bottom-right for two, and so on
+            int dst_x = 0;
+            int dst_y = 0;
+            switch (quarter_turns_)
+              {
+              case 1:
+                dst_x = src_h - 1 - y;
+                dst_y = x;
+                break;
+              case 2:
+                dst_x = src_w - 1 - x;
+                dst_y = src_h - 1 - y;
+                break;
+              default:
+                dst_x = y;
+                dst_y = src_w - 1 - x;
+                break;
+              }
+
+            auto* dst_row =
+              reinterpret_cast<uint32_t*>(dst_base + dst_y * dst_data.stride);
+            dst_row[dst_x] = src_row[x];
+          }
+      }
+
+    image_ = rotated;
+
+    LOG_S(INFO) << "apply_page_rotation:"
+                << " quarter_turns=" << quarter_turns_
+                << " canvas=" << src_w << "x" << src_h
+                << " -> " << dst_w << "x" << dst_h;
   }
 
   // ---------------------------------------------------------------------------
@@ -754,24 +898,45 @@ namespace pdflib
     finish_page_context();
 
     const auto& bbox = instr.crop_bbox;
-    const int pdf_w  = bbox[2] - bbox[0];
-    const int pdf_h  = bbox[3] - bbox[1];
+    const double pdf_w = bbox[2] - bbox[0];
+    const double pdf_h = bbox[3] - bbox[1];
 
-    if (pdf_w <= 0 or pdf_h <= 0) { return; }
+    if (pdf_w <= 0.0 or pdf_h <= 0.0) { return; }
 
-    const auto [width, height] = resolve_canvas_size(pdf_w, pdf_h, config_);
+    quarter_turns_ = quarter_turns_from_angle(instr.angle);
+    rotation_applied_ = false;
 
+    // The requested canvas size describes the page as displayed, so it is
+    // resolved against the displayed page size and mapped back onto the
+    // unrotated canvas we actually draw on.
+    const bool transposed = (quarter_turns_ % 2) != 0;
+    const double display_pdf_w = transposed ? pdf_h : pdf_w;
+    const double display_pdf_h = transposed ? pdf_w : pdf_h;
+
+    const auto [display_width, display_height] =
+      resolve_canvas_size(display_pdf_w, display_pdf_h, config_);
+
+    const int width  = transposed ? display_height : display_width;
+    const int height = transposed ? display_width  : display_height;
+
+    // The page box is mapped onto the whole canvas, so the effective scale is
+    // the pixel count over the page extent. Since the canvas covers a
+    // fractional page extent, that is marginally more than the requested scale.
     scale_x_ = static_cast<double>(width)  / pdf_w;
     scale_y_ = static_cast<double>(height) / pdf_h;
-    origin_x_ = static_cast<double>(bbox[0]);
-    origin_y_ = static_cast<double>(bbox[1]);
+    origin_x_ = bbox[0];
+    origin_y_ = bbox[1];
 
-    shape_ = {height, width, 4};
+    canvas_width_ = width;
+    canvas_height_ = height;
+    shape_ = {display_height, display_width, 4};
 
     LOG_S(INFO) << "set_size:"
                 << " crop_bbox=[" << bbox[0] << "," << bbox[1] << "," << bbox[2] << "," << bbox[3] << "]"
                 << " pdf_size=" << pdf_w << "x" << pdf_h
+                << " angle=" << instr.angle
                 << " canvas=" << width << "x" << height
+                << " display=" << display_width << "x" << display_height
                 << " scale=(" << scale_x_ << "," << scale_y_ << ")";
 
     image_.create(width, height, BL_FORMAT_PRGB32);
@@ -1233,7 +1398,7 @@ namespace pdflib
   {
     // LOG_S(INFO) << __FUNCTION__;
 
-    if (shape_[0] == 0 or shape_[1] == 0) { return; }
+    if (not has_canvas()) { return; }
 
     const text_geometry geom = make_text_geometry(instr);
 
@@ -1550,7 +1715,7 @@ namespace pdflib
   {
     LOG_S(INFO) << __FUNCTION__ << " for xobject_key=" << instr.get_key();
 
-    if (shape_[0] == 0 or shape_[1] == 0)
+    if (not has_canvas())
       {
         LOG_S(WARNING) << __FUNCTION__ << ": canvas not initialised, skipping";
         return;
@@ -1702,7 +1867,7 @@ namespace pdflib
   {
     LOG_S(INFO) << __FUNCTION__ << "  text='" << instr.get_text() << "'";
 
-    if (shape_[0] == 0 or shape_[1] == 0) { return; }
+    if (not has_canvas()) { return; }
 
     BLPath path;
     path.move_to(canvas_x(instr.get_r_x0()), canvas_y(instr.get_r_y0()));
@@ -1821,7 +1986,7 @@ namespace pdflib
 
   inline void renderer<BLEND2D>::render_shape(shape_instruction& instr)
   {
-    if (shape_[0] == 0 or shape_[1] == 0) { return; }
+    if (not has_canvas()) { return; }
     if (not config_.render_shapes) { return; }
 
     BLRect bbox;

--- a/src/render/config.h
+++ b/src/render/config.h
@@ -99,15 +99,30 @@ namespace pdflib
       }
   }
 
+  // Number of pixels needed to cover a page extent expressed in canvas units.
+  // The page box is a real-valued rectangle, so a page of 595.2756 points at
+  // scale 2 needs 1191 pixels, not 1190: rounding down would drop the last
+  // fractional column of the page. Rounding up is also what PDFium does
+  // (FPDF_GetPageWidthF times the scale, rounded up), which keeps our canvas
+  // dimensions identical to a pypdfium2 render of the same page.
+  //
+  // The epsilon absorbs the noise of the box subtraction that produced the
+  // extent, so a page that is an exact 612 x 792 does not gain a pixel from a
+  // 612.0000000000001 arithmetic result.
+  inline int pixels_for_extent(double extent)
+  {
+    return static_cast<int>(std::ceil(extent - 1e-6));
+  }
+
   inline std::pair<int, int> resolve_canvas_size(
-      int pdf_width,
-      int pdf_height,
+      double pdf_width,
+      double pdf_height,
       const render_config& config)
   {
     validate_render_config(config);
 
-    int width = pdf_width;
-    int height = pdf_height;
+    int width = pixels_for_extent(pdf_width);
+    int height = pixels_for_extent(pdf_height);
 
     const bool have_width = config.canvas_width > 0;
     const bool have_height = config.canvas_height > 0;
@@ -115,8 +130,8 @@ namespace pdflib
 
     if(have_scale)
       {
-        width = static_cast<int>(std::round(static_cast<double>(pdf_width) * config.scale));
-        height = static_cast<int>(std::round(static_cast<double>(pdf_height) * config.scale));
+        width = pixels_for_extent(pdf_width * config.scale);
+        height = pixels_for_extent(pdf_height * config.scale);
       }
     else if(have_width and have_height)
       {
@@ -126,14 +141,12 @@ namespace pdflib
     else if(have_width)
       {
         width = config.canvas_width;
-        height = static_cast<int>(
-            std::round(static_cast<double>(pdf_height) * width / pdf_width));
+        height = pixels_for_extent(pdf_height * width / pdf_width);
       }
     else if(have_height)
       {
         height = config.canvas_height;
-        width = static_cast<int>(
-            std::round(static_cast<double>(pdf_width) * height / pdf_height));
+        width = pixels_for_extent(pdf_width * height / pdf_height);
       }
 
     if(width <= 0)

--- a/src/render/naive_renderer.h
+++ b/src/render/naive_renderer.h
@@ -48,8 +48,8 @@ namespace pdflib
   {
     auto& bbox = instr.crop_bbox;
 
-    const int pdf_width = bbox[2] - bbox[0];
-    const int pdf_height = bbox[3] - bbox[1];
+    const double pdf_width = bbox[2] - bbox[0];
+    const double pdf_height = bbox[3] - bbox[1];
 
     const auto [width, height] = resolve_canvas_size(pdf_width, pdf_height, config_);
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,6 +52,8 @@ code in the main repository.
 - `test_threaded_parse.py`: threaded parser behavior and content materialization.
 - `test_threaded_render.py`: threaded parse-and-render behavior using
   `DoclingThreadedPdfParser`.
+- `test_pypdfium_render.py`: non-failing comparison of the render output against
+  pypdfium2, with three-panel visualizations.
 - `rendering_regression.py`: shared helpers for renderer groundtruth comparison
   and update logic.
 - `test_embedded_fonts.py`: embedded-font and font-resolution renderer behavior.
@@ -82,6 +84,43 @@ tests/data/render_deltas/
 ```
 
 The generated files include actual, expected, and amplified diff PNGs.
+
+## Cross-Renderer Comparison Against pypdfium2
+
+`test_pypdfium_render.py` runs the same comparison as
+`test_rendered_pages_match_groundtruth`, but renders the reference with
+pypdfium2 instead of reading it from the regression dataset:
+
+```bash
+uv run pytest tests/test_pypdfium_render.py -q -s
+```
+
+Both renders use scale 2.0 and are composited onto opaque white before they are
+compared, because the two renderers disagree on what an untouched page pixel is.
+
+This test never fails on pixel differences. pypdfium2 is an independent
+implementation, so the per-page numbers are a report, not a contract: the test
+prints the metric table plus the pages above `PYPDFIUM_IMAGE_TOLERANCE`, and
+only fails if no page could be compared at all. It is skipped when pypdfium2 is
+not installed.
+
+Three-panel PNGs (pypdfium2 | docling-parse | amplified difference) are written
+to:
+
+```text
+tests/data/visualizations/delta_<mean_abs_error>_<pdf-name>.page_no_<n>.png
+```
+
+`--render-visualizations` selects which pages get one:
+
+```bash
+# only pages above tolerance (default)
+uv run pytest tests/test_pypdfium_render.py -q -s --render-visualizations above-tolerance
+# every compared page
+uv run pytest tests/test_pypdfium_render.py -q -s --render-visualizations all
+# none
+uv run pytest tests/test_pypdfium_render.py -q -s --render-visualizations none
+```
 
 ## Regression Data
 
@@ -117,7 +156,12 @@ tests/data/
   cases/                  focused case fixtures
   errors/                 failure and error-handling fixtures
   synthetic/              synthetic PDF fixtures
+  render_deltas/          diff artifacts written on image comparison failure
+  visualizations/         three-panel renderer comparison images
 ```
+
+`render_deltas/` and `visualizations/` are produced by test runs and are not
+part of the downloaded dataset.
 
 Renderer artifact naming follows this pattern:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,29 +87,43 @@ The generated files include actual, expected, and amplified diff PNGs.
 
 ## Cross-Renderer Comparison Against pypdfium2
 
-`test_pypdfium_render.py` runs the same comparison as
-`test_rendered_pages_match_groundtruth`, but renders the reference with
-pypdfium2 instead of reading it from the regression dataset:
+`test_pypdfium_render.py::test_rendered_pages_match_pypdfium` is structured like
+`test_rendered_pages_match_groundtruth`: same regression PDF set, same
+`PARSER_PAGE_RESTRICTIONS`, same threaded parser at scale 2.0. The difference is
+where the reference image comes from: pypdfium2 renders it on the spot instead
+of it being read from the Hugging Face dataset.
 
 ```bash
 uv run pytest tests/test_pypdfium_render.py -q -s
 ```
 
-Both renders use scale 2.0 and are composited onto opaque white before they are
-compared, because the two renderers disagree on what an untouched page pixel is.
+Both renders are composited onto opaque white before they are compared, because
+the two renderers disagree on what an untouched page pixel is: pypdfium2 paints
+an opaque page, while the Blend2D path can leave the background transparent.
 
-This test never fails on pixel differences. pypdfium2 is an independent
-implementation, so the per-page numbers are a report, not a contract: the test
-prints the metric table plus the pages above `PYPDFIUM_IMAGE_TOLERANCE`, and
-only fails if no page could be compared at all. It is skipped when pypdfium2 is
-not installed.
+### This test never fails on pixel differences
 
-Three-panel PNGs (pypdfium2 | docling-parse | amplified difference) are written
-to:
+pypdfium2 is an independent implementation, so the per-page numbers are a
+report, not a contract. The test prints the metric table and the list of pages
+above `PYPDFIUM_IMAGE_TOLERANCE` (reported, not enforced), and only fails when
+no page could be compared at all. It is skipped when pypdfium2 is not installed.
+
+Consequently `PYPDFIUM_IMAGE_TOLERANCE` is not a regression limit. It is only
+the cut-off that decides which pages are called out in the report and, by
+default, which ones get a visualization written.
+
+### Three-panel visualizations
+
+Comparison images are written to:
 
 ```text
 tests/data/visualizations/delta_<mean_abs_error>_<pdf-name>.page_no_<n>.png
 ```
+
+Left to right, the panels are pypdfium2, docling-parse, and their difference
+amplified by `DIFFERENCE_AMPLIFICATION`. Each panel carries a label whose font
+scales with the page width, so the image stays readable when the full
+three-panel png is scaled down to fit on screen.
 
 `--render-visualizations` selects which pages get one:
 
@@ -121,6 +135,57 @@ uv run pytest tests/test_pypdfium_render.py -q -s --render-visualizations all
 # none
 uv run pytest tests/test_pypdfium_render.py -q -s --render-visualizations none
 ```
+
+A full run over the regression set writes tens of megabytes of png into
+`tests/data/visualizations`. That directory is not part of the downloaded
+dataset and can be deleted at any time.
+
+### Reading the result
+
+A run after page `/Rotate` was implemented in the Blend2D renderer compared 93
+pages, of which 51 were reported above tolerance. The large deltas are the
+interesting ones, and the visualization usually makes the cause obvious at a
+glance.
+
+Page rotation is applied: `rotated_page_01`, `rotated_image` and
+`jbig2_test_01` render landscape at 1584x1224 like pypdfium2, with mean
+absolute errors of 1.21, 0.22 and 0.22, and the
+`ocr_test_rotated_{000,090,180,270}` set agrees with pypdfium2 on orientation
+as well.
+
+What is left in the report is mostly one of three things:
+
+- A page size that is off by one or two pixels. 33 of the 93 pages report
+  `size_match False`, with the pypdfium2 render one or two pixels wider and/or
+  taller (for example 1190x1682 against 1191x1684). A size mismatch on its own
+  already puts a page above tolerance, and the images are then compared on
+  their common top-left area, so the accumulated sub-pixel scale difference
+  shifts glyph and image edges towards the far side of the page. Such a page
+  can report a large `mean_abs_error` while looking identical side by side:
+  `complex_invisible_fonts_01` at 24.80 is a full-page photograph that differs
+  only by that offset.
+- Content one renderer draws and the other does not. `form_fields` page 3
+  (20.31) and `fillable_form` (16.31) are widget annotation appearances that
+  docling-parse paints and pypdfium2 leaves out, and `right_to_left_02` (45.28)
+  is a tiling pattern that docling-parse paints over the whole page.
+  `device_n_black` (48.37) is the other direction: pypdfium2 draws a
+  gradient-filled banner that docling-parse leaves blank.
+- Anti-aliasing, hinting and glyph rasterization, which differ between the two
+  renderers on nearly every page. The size-matching pages sit around a mean
+  absolute error of 2.6, and those small deltas are not worth chasing.
+
+### Shared helpers
+
+The comparison machinery lives in `rendering_regression.py` and is shared with
+the groundtruth test:
+
+- `measure_image_pair()` computes the pixel metrics for any two images;
+  `measure_image_comparison()` is the wrapper that loads the groundtruth png.
+- `render_pypdfium_page()` renders the reference page.
+- `flatten_on_white()` puts both renders on the same page background.
+- `amplified_difference()` builds the difference panel, and is also used for the
+  `render_deltas` diff artifacts.
+- `write_comparison_visualization()` assembles and writes the three-panel png.
 
 ## Regression Data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,15 @@ def pytest_addoption(parser) -> None:
         default=False,
         help="Rewrite parser and renderer groundtruth fixtures.",
     )
+    parser.addoption(
+        "--render-visualizations",
+        choices=("above-tolerance", "all", "none"),
+        default="above-tolerance",
+        help=(
+            "Which three-panel renderer comparison images to write to "
+            "tests/data/visualizations (above-tolerance)."
+        ),
+    )
 
 
 def pytest_configure(config) -> None:
@@ -19,11 +28,20 @@ def pytest_configure(config) -> None:
         "markers",
         "groundtruth: tests that compare or update checked-in groundtruth fixtures",
     )
+    config.addinivalue_line(
+        "markers",
+        "pypdfium: tests that compare rendering against pypdfium2 without failing",
+    )
 
 
 @pytest.fixture
 def update_groundtruth(request) -> bool:
     return request.config.getoption("--update-groundtruth")
+
+
+@pytest.fixture
+def render_visualizations(request) -> str:
+    return request.config.getoption("--render-visualizations")
 
 
 def pytest_sessionstart(session) -> None:

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,5 +1,5 @@
 HF_DATASET_REPO_ID = "docling-project/regression-dataset-for-docling-parse"
-HF_DATASET_REVISION = "cfef7a8397b1ff177fd93f3ca050ffd50cb0a6a3"
+HF_DATASET_REVISION = "590465e48f45e7ac7b95317d970ab297f496750f"
 
 REGRESSION_DIR = "tests/data/regression"
 

--- a/tests/rendering_regression.py
+++ b/tests/rendering_regression.py
@@ -177,18 +177,33 @@ def _diff_artifact_path(doc_name: str, page_no: int, suffix: str) -> Path:
     )
 
 
+def resize_to_match(actual: Image.Image, expected: Image.Image) -> Image.Image:
+    """Scale `actual` onto the size of `expected`, if they differ.
+
+    Both renders cover the same page box, so a page whose size in pixels comes
+    out one or two pixels apart is showing the same content at a marginally
+    different scale. Cropping to the common area would then compare pixels that
+    drift further apart towards the far edge of the page, which reports a large
+    error for renders that are visually identical. Resampling first puts the
+    page content back on top of itself; the size difference itself is reported
+    separately through `size_matches`.
+    """
+    if actual.size == expected.size:
+        return actual
+
+    return actual.resize(expected.size, Image.Resampling.LANCZOS)
+
+
 def amplified_difference(
     actual: Image.Image,
     expected: Image.Image,
     *,
     amplification: int = DIFFERENCE_AMPLIFICATION,
 ) -> Image.Image:
-    """Brightened per-pixel difference of the common area of both images."""
-    width = min(actual.width, expected.width)
-    height = min(actual.height, expected.height)
+    """Brightened per-pixel difference of both images, on the size of `expected`."""
     diff = ImageChops.difference(
-        actual.convert("RGB").crop((0, 0, width, height)),
-        expected.convert("RGB").crop((0, 0, width, height)),
+        resize_to_match(actual.convert("RGB"), expected),
+        expected.convert("RGB"),
     )
     return ImageEnhance.Brightness(diff).enhance(amplification)
 
@@ -217,23 +232,23 @@ def measure_image_pair(
 ) -> ImageComparison:
     """Compare two rendered images of the same page, whatever produced them.
 
-    Images of differing size are compared on their common top-left area; the
-    size mismatch itself is reported through `size_matches`.
+    An image of differing size is resampled onto the size of `expected` before
+    the pixels are compared, so the metrics describe the page content rather
+    than the size difference; the size mismatch itself is reported through
+    `size_matches`.
     """
     actual_full = actual.convert("RGBA")
     expected_full = expected.convert("RGBA")
     size_matches = actual_full.size == expected_full.size
-    width = min(actual_full.width, expected_full.width)
-    height = min(actual_full.height, expected_full.height)
-    if width <= 0 or height <= 0:
+    width, height = expected_full.size
+    if width <= 0 or height <= 0 or actual_full.width <= 0 or actual_full.height <= 0:
         raise AssertionError(
             f"rendered image has empty comparison area for {doc_name}@{page_no}: "
             f"expected {expected_full.size}, got {actual_full.size}"
         )
 
-    actual_rgba = actual_full.crop((0, 0, width, height))
-    expected_rgba = expected_full.crop((0, 0, width, height))
-    diff = ImageChops.difference(actual_rgba, expected_rgba)
+    actual_rgba = resize_to_match(actual_full, expected_full)
+    diff = ImageChops.difference(actual_rgba, expected_full)
     stat = ImageStat.Stat(diff)
     mean_abs_error = sum(stat.mean) / len(stat.mean)
     extrema = diff.getextrema()

--- a/tests/rendering_regression.py
+++ b/tests/rendering_regression.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
-from PIL import Image, ImageChops, ImageEnhance, ImageStat
+from PIL import Image, ImageChops, ImageDraw, ImageEnhance, ImageFont, ImageStat
 
 from tests.data_utils import (
     RENDER_GROUNDTRUTH_BITMAPS_DIR,
@@ -14,6 +14,11 @@ from tests.data_utils import (
 from tests.test_parse import _round_floats
 
 RENDER_DELTA_FOLDER = Path("tests/data/render_deltas")
+RENDER_VISUALIZATION_FOLDER = Path("tests/data/visualizations")
+
+# amplification of the per-pixel difference in the visualization panel: raw
+# deltas of a few grey levels are invisible on screen
+DIFFERENCE_AMPLIFICATION = 8
 
 
 @dataclass(frozen=True)
@@ -172,6 +177,22 @@ def _diff_artifact_path(doc_name: str, page_no: int, suffix: str) -> Path:
     )
 
 
+def amplified_difference(
+    actual: Image.Image,
+    expected: Image.Image,
+    *,
+    amplification: int = DIFFERENCE_AMPLIFICATION,
+) -> Image.Image:
+    """Brightened per-pixel difference of the common area of both images."""
+    width = min(actual.width, expected.width)
+    height = min(actual.height, expected.height)
+    diff = ImageChops.difference(
+        actual.convert("RGB").crop((0, 0, width, height)),
+        expected.convert("RGB").crop((0, 0, width, height)),
+    )
+    return ImageEnhance.Brightness(diff).enhance(amplification)
+
+
 def _write_diff_artifacts(
     doc_name: str,
     page_no: int,
@@ -181,35 +202,32 @@ def _write_diff_artifacts(
     RENDER_DELTA_FOLDER.mkdir(parents=True, exist_ok=True)
     actual.save(_diff_artifact_path(doc_name, page_no, "actual.png"))
     expected.save(_diff_artifact_path(doc_name, page_no, "expected.png"))
-
-    width = min(actual.width, expected.width)
-    height = min(actual.height, expected.height)
-    diff = ImageChops.difference(
-        actual.crop((0, 0, width, height)),
-        expected.crop((0, 0, width, height)),
+    amplified_difference(actual, expected).save(
+        _diff_artifact_path(doc_name, page_no, "diff.png")
     )
-    amplified = ImageEnhance.Brightness(diff).enhance(8)
-    amplified.save(_diff_artifact_path(doc_name, page_no, "diff.png"))
 
 
-def measure_image_comparison(
+def measure_image_pair(
     doc_name: str,
     page_no: int,
     actual: Image.Image,
+    expected: Image.Image,
     *,
     tolerance: ImageTolerance = ImageTolerance(),
 ) -> ImageComparison:
-    path = renderer_image_path(doc_name, page_no)
-    assert path.exists(), f"missing rendered image groundtruth: {path}"
+    """Compare two rendered images of the same page, whatever produced them.
 
+    Images of differing size are compared on their common top-left area; the
+    size mismatch itself is reported through `size_matches`.
+    """
     actual_full = actual.convert("RGBA")
-    expected_full = Image.open(path).convert("RGBA")
+    expected_full = expected.convert("RGBA")
     size_matches = actual_full.size == expected_full.size
     width = min(actual_full.width, expected_full.width)
     height = min(actual_full.height, expected_full.height)
     if width <= 0 or height <= 0:
         raise AssertionError(
-            f"rendered image has empty comparison area for {path}: "
+            f"rendered image has empty comparison area for {doc_name}@{page_no}: "
             f"expected {expected_full.size}, got {actual_full.size}"
         )
 
@@ -245,6 +263,25 @@ def measure_image_comparison(
         changed_pixels_ratio=changed_pixels_ratio,
         changed_pixels=changed_pixels,
         total_pixels=actual_rgba.width * actual_rgba.height,
+    )
+
+
+def measure_image_comparison(
+    doc_name: str,
+    page_no: int,
+    actual: Image.Image,
+    *,
+    tolerance: ImageTolerance = ImageTolerance(),
+) -> ImageComparison:
+    path = renderer_image_path(doc_name, page_no)
+    assert path.exists(), f"missing rendered image groundtruth: {path}"
+
+    return measure_image_pair(
+        doc_name,
+        page_no,
+        actual,
+        Image.open(path),
+        tolerance=tolerance,
     )
 
 
@@ -375,3 +412,154 @@ def compare_bitmap_artifacts(doc_name: str, page_no: int, result) -> None:
         assert bytes(artifact.get("encoded_data", b"")) == image_path.read_bytes(), (
             f"bitmap image mismatch: {image_path}"
         )
+
+
+def render_pypdfium_page(
+    pdf_path: str | Path,
+    page_no: int,
+    *,
+    scale: float,
+) -> Image.Image:
+    """Render one page with pypdfium2, as the cross-renderer reference."""
+    import pypdfium2 as pdfium
+
+    pdf = pdfium.PdfDocument(str(pdf_path))
+    try:
+        page = pdf[page_no - 1]
+        return page.render(scale=scale).to_pil().convert("RGBA")
+    finally:
+        pdf.close()
+
+
+def flatten_on_white(image: Image.Image) -> Image.Image:
+    """Composite an image onto opaque white.
+
+    The two renderers do not agree on what an untouched pixel is: pypdfium2
+    paints an opaque white page, while the Blend2D path can leave the page
+    background transparent. Comparing them only makes sense on a common
+    background.
+    """
+    rgba = image.convert("RGBA")
+    canvas = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+    canvas.alpha_composite(rgba)
+    return canvas.convert("RGB")
+
+
+def _label_font(size: int):
+    try:
+        return ImageFont.load_default(size=size)
+    except TypeError:
+        # Pillow < 10.1 only offers the fixed-size bitmap default font
+        return ImageFont.load_default()
+
+
+def _labelled_panel(
+    image: Image.Image,
+    label: str,
+    *,
+    size: tuple[int, int],
+    label_height: int,
+    font_size: int,
+    font,
+    background: tuple[int, int, int],
+    foreground: tuple[int, int, int],
+) -> Image.Image:
+    panel = Image.new("RGB", (size[0], size[1] + label_height), background)
+    panel.paste(image.convert("RGB"), (0, label_height))
+    ImageDraw.Draw(panel).text(
+        (label_height // 3, max(0, (label_height - font_size) // 2)),
+        label,
+        fill=foreground,
+        font=font,
+    )
+    return panel
+
+
+def visualization_path(
+    doc_name: str,
+    page_no: int,
+    delta: float,
+    *,
+    folder: Path = RENDER_VISUALIZATION_FOLDER,
+) -> Path:
+    return (
+        folder / f"delta_{delta:.3f}_{renderer_artifact_prefix(doc_name, page_no)}.png"
+    )
+
+
+def write_comparison_visualization(
+    doc_name: str,
+    page_no: int,
+    reference: Image.Image,
+    actual: Image.Image,
+    delta: float,
+    *,
+    reference_label: str = "pypdfium2",
+    actual_label: str = "docling-parse",
+    folder: Path = RENDER_VISUALIZATION_FOLDER,
+    gap: int = 8,
+) -> Path:
+    """Write a three-panel png: reference, actual and their amplified difference."""
+    reference_rgb = flatten_on_white(reference)
+    actual_rgb = flatten_on_white(actual)
+    difference = amplified_difference(actual_rgb, reference_rgb)
+
+    panel_width = max(reference_rgb.width, actual_rgb.width, difference.width)
+    panel_height = max(reference_rgb.height, actual_rgb.height, difference.height)
+    panel_size = (panel_width, panel_height)
+    # the label has to stay readable when the full three-panel image is scaled
+    # down to fit on screen, so it grows with the page
+    font_size = max(12, panel_width // 40)
+    label_height = font_size * 2
+    font = _label_font(font_size)
+    background = (24, 24, 24)
+    foreground = (240, 240, 240)
+
+    panels = [
+        _labelled_panel(
+            reference_rgb,
+            reference_label,
+            size=panel_size,
+            label_height=label_height,
+            font_size=font_size,
+            font=font,
+            background=background,
+            foreground=foreground,
+        ),
+        _labelled_panel(
+            actual_rgb,
+            actual_label,
+            size=panel_size,
+            label_height=label_height,
+            font_size=font_size,
+            font=font,
+            background=background,
+            foreground=foreground,
+        ),
+        _labelled_panel(
+            difference,
+            f"difference (x{DIFFERENCE_AMPLIFICATION}, mean_abs_error={delta:.3f})",
+            size=panel_size,
+            label_height=label_height,
+            font_size=font_size,
+            font=font,
+            background=background,
+            foreground=foreground,
+        ),
+    ]
+
+    canvas = Image.new(
+        "RGB",
+        (
+            len(panels) * panel_width + (len(panels) - 1) * gap,
+            panel_height + label_height,
+        ),
+        background,
+    )
+    for index, panel in enumerate(panels):
+        canvas.paste(panel, (index * (panel_width + gap), 0))
+
+    path = visualization_path(doc_name, page_no, delta, folder=folder)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    canvas.save(path)
+    return path

--- a/tests/test_pypdfium_render.py
+++ b/tests/test_pypdfium_render.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+"""Cross-renderer comparison of the Blend2D render path against pypdfium2.
+
+This mirrors `test_rendered_pages_match_groundtruth`, but the reference image is
+produced by pypdfium2 instead of being read from the regression dataset. The
+two renderers are independent implementations, so the per-page numbers are a
+report and not a contract: this test never fails on pixel differences. It only
+fails when there is nothing to compare at all.
+
+Three-panel visualizations (pypdfium2 | docling-parse | amplified difference)
+are written to `tests/data/visualizations`; `--render-visualizations` selects
+whether that happens for every page, only for pages above tolerance, or never.
+"""
+
+import glob
+import os
+from pathlib import Path
+
+import pytest
+
+from docling_parse.pdf_parser import RenderConfig
+from tests.constants import PARSER_PAGE_RESTRICTIONS
+from tests.rendering_regression import (
+    RENDER_VISUALIZATION_FOLDER,
+    ImageComparison,
+    ImageTolerance,
+    flatten_on_white,
+    format_image_comparison_table,
+    image_comparison_failed,
+    measure_image_pair,
+    render_pypdfium_page,
+    write_comparison_visualization,
+)
+from tests.test_parse import REGRESSION_FOLDER
+from tests.test_threaded_render import _make_parser
+
+PYPDFIUM_RENDER_SCALE = 2.0
+
+# Not enforced: this is only the cut-off that decides which pages are reported
+# as "above tolerance" and, by default, which ones get a visualization written.
+PYPDFIUM_IMAGE_TOLERANCE = ImageTolerance(
+    pixel_threshold=12,
+    mean_abs_error=9.0,
+    changed_pixels_ratio=0.09,
+)
+
+
+def _make_pypdfium_render_config() -> RenderConfig:
+    render_config = RenderConfig()
+    render_config.scale = PYPDFIUM_RENDER_SCALE
+    return render_config
+
+
+def _format_visualization_summary(paths: list[Path]) -> str:
+    if not paths:
+        return f"No comparison visualizations written to {RENDER_VISUALIZATION_FOLDER}."
+
+    lines = [f"Wrote {len(paths)} comparison visualization(s):"]
+    lines.extend(f"  {path}" for path in sorted(paths))
+    return "\n".join(lines)
+
+
+@pytest.mark.pypdfium
+def test_rendered_pages_match_pypdfium(render_visualizations: str) -> None:
+    """Report how far the Blend2D render output is from pypdfium2, without failing."""
+    pytest.importorskip(
+        "pypdfium2",
+        reason="pypdfium2 is required for the cross-renderer comparison",
+    )
+
+    pdf_docs = sorted(glob.glob(REGRESSION_FOLDER))
+    assert len(pdf_docs) > 0, "len(pdf_docs)==0 -> nothing to test"
+
+    parser = _make_parser(
+        threads=4,
+        max_concurrent=32,
+        render_config=_make_pypdfium_render_config(),
+    )
+
+    key_to_path: dict[str, str] = {}
+    for pdf_doc_path in pdf_docs:
+        rname = os.path.basename(pdf_doc_path)
+        key = parser.load(
+            pdf_doc_path,
+            page_numbers=PARSER_PAGE_RESTRICTIONS.get(rname),
+        )
+        key_to_path[key] = pdf_doc_path
+
+    comparisons: list[ImageComparison] = []
+    visualizations: list[Path] = []
+    above_tolerance: list[str] = []
+    skipped: list[str] = []
+
+    for result in parser.iterate_results():
+        pdf_doc_path = key_to_path[result.doc_key]
+        rname = os.path.basename(pdf_doc_path)
+
+        if not result.success:
+            skipped.append(
+                f"{rname}@{result.page_number}[render: {result.error_message}]"
+            )
+            continue
+
+        try:
+            reference = render_pypdfium_page(
+                pdf_doc_path,
+                result.page_number,
+                scale=PYPDFIUM_RENDER_SCALE,
+            )
+        except Exception as exc:
+            skipped.append(f"{rname}@{result.page_number}[pypdfium2: {exc}]")
+            continue
+
+        # both renderers must sit on the same page background before the pixels
+        # are comparable at all
+        actual = flatten_on_white(result.get_image())
+        expected = flatten_on_white(reference)
+
+        comparison = measure_image_pair(
+            rname,
+            result.page_number,
+            actual,
+            expected,
+            tolerance=PYPDFIUM_IMAGE_TOLERANCE,
+        )
+        comparisons.append(comparison)
+
+        failed = image_comparison_failed(
+            comparison,
+            tolerance=PYPDFIUM_IMAGE_TOLERANCE,
+        )
+        if failed:
+            above_tolerance.append(f"{rname}@{result.page_number}")
+
+        if render_visualizations == "all" or (
+            render_visualizations == "above-tolerance" and failed
+        ):
+            visualizations.append(
+                write_comparison_visualization(
+                    rname,
+                    result.page_number,
+                    expected,
+                    actual,
+                    comparison.mean_abs_error,
+                )
+            )
+
+    parser.unload_all()
+
+    print(format_image_comparison_table(comparisons))
+    print()
+    print(_format_visualization_summary(visualizations))
+
+    if above_tolerance:
+        print()
+        print(
+            f"{len(above_tolerance)} of {len(comparisons)} page(s) above the "
+            f"pypdfium2 comparison tolerance (reported, not enforced): "
+            + ", ".join(sorted(above_tolerance))
+        )
+
+    if skipped:
+        print()
+        print(f"{len(skipped)} page(s) could not be compared: " + ", ".join(skipped))
+
+    assert len(comparisons) > 0, "no page could be compared against pypdfium2"

--- a/tests/test_threaded_render.py
+++ b/tests/test_threaded_render.py
@@ -2,6 +2,7 @@
 """Tests for threaded parse-and-render mode."""
 
 import glob
+import math
 import os
 from io import BytesIO
 from pathlib import Path
@@ -278,8 +279,8 @@ def test_get_image_scale_rerenders_for_canvas_config():
     scaled_image = result.get_image(scale=2.0)
 
     assert scaled_image.size == (
-        round(result.page_width * 2.0),
-        round(result.page_height * 2.0),
+        math.ceil(result.page_width * 2.0),
+        math.ceil(result.page_height * 2.0),
     )
 
 
@@ -296,8 +297,8 @@ def test_get_image_rerenders_non_default_scale():
     scaled_image = result.get_image(scale=2.0)
 
     assert scaled_image.size == (
-        round(result.page_width * 2.0),
-        round(result.page_height * 2.0),
+        math.ceil(result.page_width * 2.0),
+        math.ceil(result.page_height * 2.0),
     )
     assert scaled_image.size != default_image.size
 
@@ -335,12 +336,12 @@ def test_get_image_canvas_size_is_accepted_for_scale_config():
     same_image = result.get_image(canvas_size=default_image.size)
 
     assert default_image.size == (
-        round(result.page_width * 2.0),
-        round(result.page_height * 2.0),
+        math.ceil(result.page_width * 2.0),
+        math.ceil(result.page_height * 2.0),
     )
     assert semantic_image.size == (
-        round(result.page_width),
-        round(result.page_height),
+        math.ceil(result.page_width),
+        math.ceil(result.page_height),
     )
     assert same_image.size == default_image.size
 


### PR DESCRIPTION
## Fix page-size rounding and honor page rotation when rendering

  Renders of some pages came out slightly undersized, shifted, or in the wrong
  orientation. Both causes are in how the page box reaches the renderer.

  The visualization comparison is shown here: https://huggingface.co/datasets/docling-project/regression-dataset-for-docling-parse/tree/main/visualizations

  ### What was wrong

  1. **Page boxes were truncated to integers.** `size_instruction` stored
     `media_bbox`/`crop_bbox` as `std::array<int, 4>`, so a page box of
     `595.2756 x 841.8898` became `595 x 841`. That both shifts the page origin
     and shrinks the page by up to a point, which the renderer turns into a
     misplaced and undersized canvas.
  2. **Page boxes were not normalized.** A rectangle may be written with any pair
     of opposite corners (ISO 32000-1, 7.9.5). A page box written top-down has a
     negative extent, which propagated into every derived page size.
  3. **`/Rotate` was dropped.** The page angle (ISO 32000-1, Table 30) never left
     the parser, so a page marked 90 or 270 rendered sideways relative to how
     every viewer displays it.

  ### What changed

  - `size_instruction` now carries real-valued `media_bbox`/`crop_bbox` and the
    page's `angle`; `page_dimension` normalizes boxes to lower-left/upper-right.
  - `pdf_decoder<PAGE>` captures `/Rotate` **before** `rotate_contents()`
    normalizes it away — render instructions stay in unrotated page space, so the
    renderer is the one that needs the angle.
  - `resolve_canvas_size()` takes doubles and rounds canvas extents **up**
    (`pixels_for_extent`, with an epsilon to absorb subtraction noise). This
    matches PDFium, so our canvas dimensions line up with a pypdfium2 render of
    the same page.
  - The Blend2D renderer allocates its canvas in unrotated page space and rotates
    the finished canvas clockwise by whole quarter turns before handing it out.
    Quarter turns permute pixels exactly — no resampling, no precision loss. The
    rotation is one-shot, so `get_canvas()` followed by `save()` rotates once.
    Non-multiple-of-90 angles are logged and treated as unrotated.
  - `angle` is exposed through the pybind JSON as `size_instruction.angle`.

  ### Tests

  - New `tests/test_pypdfium_render.py`: compares our renders against pypdfium2.
    Marked `pypdfium` and non-failing — it reports rather than gates.
  - `tests/rendering_regression.py` gained resampling-based comparison so pages
    differing by a pixel or two in size are compared on top of each other instead
    of drifting apart toward the page edge; size mismatch is still reported
    separately. Three-panel comparison images are written per the new
    `--render-visualizations` option (`above-tolerance` by default).
  - `test_threaded_render.py` expectations moved from `round()` to `math.ceil()`
    to match the new canvas sizing.
  - `tests/README.md` documents the new test surface.