### PR TITLE
fix(build): resolve MSVC /bigobj, add zlib dependency, and stabilize local builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if (WIN32)
         # (e.g. the curly quotes and en/em dashes in src/parse/utils/string.h) as
         # multi-character constants -> error C2015. GCC/Clang assume UTF-8, so this
         # only bites the MSVC/arm64 build.
-        add_compile_options(/utf-8)
+        add_compile_options(/utf-8 /bigobj)
         # MSVC's <cmath> only exposes M_PI (used in src/parse/utils/values.h) when
         # _USE_MATH_DEFINES is defined before the include -> without it, C2065.
         # NOMINMAX stops <windows.h> from defining min()/max() function-like
@@ -129,6 +129,7 @@ if(NOT USE_SYSTEM_DEPS)
 endif()
 
 # include dependencies
+include(cmake/extlib_zlib.cmake)
 include(cmake/extlib_cxxopts.cmake)
 include(cmake/extlib_loguru.cmake)
 include(cmake/extlib_json.cmake)
@@ -143,7 +144,7 @@ include(cmake/extlib_freetype.cmake)
 include(cmake/extlib_pdfium_jbig2.cmake)
 
 # aggregate the targets created by the dependencies
-set(DEPENDENCIES qpdf jpeg openjpeg lcms2 utf8 json loguru cxxopts blend2d freetype pdfium_jbig2)
+set(DEPENDENCIES zlib qpdf jpeg openjpeg lcms2 utf8 json loguru cxxopts blend2d freetype pdfium_jbig2)
 
 # ************************
 # *** libraries        ***

--- a/cmake/extlib_qpdf_v12.cmake
+++ b/cmake/extlib_qpdf_v12.cmake
@@ -49,7 +49,7 @@ else()
 
       PREFIX extlib_qpdf
 
-      DEPENDS extlib_jpeg
+      DEPENDS extlib_jpeg extlib_zlib
 
       UPDATE_COMMAND ""
 
@@ -68,6 +68,10 @@ else()
       -DREQUIRE_CRYPTO_NATIVE=ON \\ 
       -DCMAKE_CXX_FLAGS=${QPDF_EXTRA_CXX_FLAGS} \\ 
       -DCMAKE_C_FLAGS=${QPDF_EXTRA_C_FLAGS} \\ 
+      -DZLIB_H_PATH=${EXTERNALS_PREFIX_PATH}/include \\ 
+      -DZLIB_LIB_PATH=${ZLIB_LIB} \\ 
+      -DZLIB_LIBRARY=${ZLIB_LIB} \\ 
+      -DZLIB_INCLUDE_DIR=${EXTERNALS_PREFIX_PATH}/include \\ 
       -DLIBJPEG_LIBRARY=${JPEG_LIB} \\ 
       -DLIBJPEG_LIBRARIES=${JPEG_LIB} \\ 
       -DLIBJPEG_LIB_PATH=${JPEG_LIB} \\ 

--- a/cmake/extlib_zlib.cmake
+++ b/cmake/extlib_zlib.cmake
@@ -1,0 +1,63 @@
+#
+# Copyright IBM Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+
+message(STATUS "entering in extlib_zlib.cmake")
+
+set(ext_name "zlib")
+
+if(USE_SYSTEM_DEPS)
+    find_package(ZLIB REQUIRED)
+
+    add_library(${ext_name} INTERFACE IMPORTED)
+    target_link_libraries(${ext_name} INTERFACE ZLIB::ZLIB)
+else()
+    include(ExternalProject)
+
+    set(ZLIB_URL https://github.com/madler/zlib.git)
+    set(ZLIB_TAG v1.3.1)
+
+    if(MSVC)
+        set(ZLIB_LIB ${EXTERNALS_PREFIX_PATH}/lib/zlibstatic.lib)
+    else()
+        set(ZLIB_LIB ${EXTERNALS_PREFIX_PATH}/lib/libz.a)
+    endif()
+
+    ExternalProject_Add(extlib_zlib
+
+        PREFIX extlib_zlib
+
+        UPDATE_COMMAND ""
+        GIT_REPOSITORY ${ZLIB_URL}
+        GIT_TAG ${ZLIB_TAG}
+
+        BUILD_ALWAYS OFF
+
+        INSTALL_DIR ${EXTERNALS_PREFIX_PATH}
+
+        CMAKE_ARGS \\
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \\
+        -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES} \\
+        -DCMAKE_BUILD_TYPE=Release \\
+        -DCMAKE_INSTALL_LIBDIR=${EXTERNALS_PREFIX_PATH}/lib \\
+        -DCMAKE_INSTALL_PREFIX=${EXTERNALS_PREFIX_PATH}
+
+        LOG_DOWNLOAD ON
+    )
+
+    add_library(${ext_name} STATIC IMPORTED)
+    add_dependencies(${ext_name} extlib_zlib)
+    set(EXT_INCLUDE_DIRS ${EXTERNALS_PREFIX_PATH}/include)
+    file(MAKE_DIRECTORY ${EXT_INCLUDE_DIRS})
+    set_target_properties(${ext_name} PROPERTIES
+      IMPORTED_LOCATION ${ZLIB_LIB}
+      INTERFACE_LINK_DIRECTORIES ${EXTERNALS_PREFIX_PATH}/lib
+      INTERFACE_INCLUDE_DIRECTORIES ${EXT_INCLUDE_DIRS}
+    )
+
+    if(NOT TARGET ZLIB::ZLIB)
+        add_library(ZLIB::ZLIB ALIAS ${ext_name})
+    endif()
+endif()

--- a/cmake/os_opts.cmake
+++ b/cmake/os_opts.cmake
@@ -8,7 +8,11 @@ if(WIN32)
    find_package(ZLIB)
 
    set(LIB_LINK)
-   set(OS_DEPENDENCIES ZLIB::ZLIB)
+   if(ZLIB_FOUND)
+       set(OS_DEPENDENCIES ZLIB::ZLIB)
+   else()
+       set(OS_DEPENDENCIES)
+   endif()
 
 elseif(APPLE)
    message(STATUS "compiling on mac-osx")

--- a/local_build.py
+++ b/local_build.py
@@ -98,6 +98,7 @@ def build_local(num_threads: int):
     config_cmd = [
         "cmake",
         "-B", f"{BUILD_DIR}",
+        "-DCMAKE_BUILD_TYPE=Release",
         f"-DUSE_SYSTEM_DEPS={USE_SYSTEM_DEPS}",
         f"-DPYTHON_EXECUTABLE={sys.executable}",
     ]

--- a/src/parse/utils/jpeg/jpeg_utils.h
+++ b/src/parse/utils/jpeg/jpeg_utils.h
@@ -130,17 +130,23 @@ inline std::vector<unsigned char> inflate_pdf_stream(
   if(not data || size == 0) { return {}; }
   if(size > static_cast<std::size_t>(std::numeric_limits<uInt>::max())) { return {}; }
 
-  uLongf dest_size = std::max<uLongf>(size * 4, 4096);
+  uLongf buf_capacity = std::max<uLongf>(static_cast<uLongf>(size) * 4, 4096);
 
   for(int attempt = 0; attempt < 8; ++attempt)
     {
-      std::vector<unsigned char> inflated(dest_size);
-      int rc = ::uncompress(inflated.data(), &dest_size,
+      std::vector<unsigned char> inflated;
+      try {
+        inflated.resize(buf_capacity);
+      } catch (const std::bad_alloc&) {
+        return {};
+      }
+      uLongf actual_size = buf_capacity;
+      int rc = ::uncompress(inflated.data(), &actual_size,
                             reinterpret_cast<Bytef const*>(data),
                             static_cast<uInt>(size));
       if(rc == Z_OK)
         {
-          inflated.resize(dest_size);
+          inflated.resize(actual_size);
           return inflated;
         }
       if(rc != Z_BUF_ERROR)
@@ -149,11 +155,18 @@ inline std::vector<unsigned char> inflate_pdf_stream(
                       << ": zlib inflate failed with rc=" << rc;
           return {};
         }
-      if(dest_size >= static_cast<uLongf>(std::numeric_limits<uInt>::max() / 2))
+      if(actual_size > buf_capacity)
+        {
+          buf_capacity = actual_size;
+        }
+      else if(buf_capacity >= static_cast<uLongf>(std::numeric_limits<uInt>::max() / 2))
         {
           break;
         }
-      dest_size *= 2;
+      else
+        {
+          buf_capacity *= 2;
+        }
     }
 
   LOG_S(INFO) << "inflate_pdf_stream"

--- a/src/third_party/pdfium_jbig2/core/fxcrt/fx_memory_wrappers.h
+++ b/src/third_party/pdfium_jbig2/core/fxcrt/fx_memory_wrappers.h
@@ -27,6 +27,13 @@ struct IsFXDataPartitionException : std::false_type {};
   template <>                          \
   struct IsFXDataPartitionException<T> : std::true_type {}
 
+#ifdef _MSC_VER
+namespace std {
+struct _Container_proxy;
+}
+FX_DATA_PARTITION_EXCEPTION(std::_Container_proxy);
+#endif
+
 // Allocators for mapping STL containers onto Partition Alloc.
 // Otherwise, replacing e.g. the FX_AllocUninit/FX_Free pairs with STL may
 // undo some of the nice segregation that we get from PartitionAlloc.

--- a/src/third_party/pdfium_jbig2/core/fxcrt/immediate_crash.h
+++ b/src/third_party/pdfium_jbig2/core/fxcrt/immediate_crash.h
@@ -85,24 +85,8 @@
 
 #elif defined(COMPILER_MSVC)
 
-#if defined(ARCH_CPU_ARM64)
-
-// Windows ARM64 uses "BRK #F000" as its breakpoint instruction, and
-// __debugbreak() generates that in both VC++ and clang.
 #define TRAP_SEQUENCE1_() __debugbreak()
-// Intentionally empty: __builtin_unreachable() is always part of the sequence
-// (see IMMEDIATE_CRASH below) and already emits a ud2 on Win64,
-// https://crbug.com/958373
-// MSVC does not support the __asm keyword on ARM64 (or x64), so leave this
-// empty; __debugbreak() in TRAP_SEQUENCE1_() is a sufficient fatal trap.
 #define TRAP_SEQUENCE2_()
-
-#else
-
-#define TRAP_SEQUENCE1_() asm volatile("int3")
-#define TRAP_SEQUENCE2_() asm volatile("ud2")
-
-#endif  // defined(ARCH_CPU_ARM64)
 
 #else
 


### PR DESCRIPTION
This PR collects build-system and zlib-related fixes required to compile and run the project on a clean environment, especially on Windows/MSVC.

## Changes

- **MSVC: add `/bigobj`** (`CMakeLists.txt`)
  Fixes `fatal error C1128` when parser object files exceed the default COFF section limit.

- **Add bundled zlib dependency** (new `cmake/extlib_zlib.cmake`, `CMakeLists.txt`)
  QPDF v12 now requires zlib. This adds an external-project build for zlib and exposes a `zlib` target.

- **Wire zlib into QPDF** (`cmake/extlib_qpdf_v12.cmake`)
  Passes `ZLIB_H_PATH`, `ZLIB_LIB_PATH`, `ZLIB_LIBRARY`, and `ZLIB_INCLUDE_DIR` to QPDF's CMake, and makes QPDF depend on `extlib_zlib`.

- **Make system zlib optional on Windows** (`cmake/os_opts.cmake`)
  Only adds `ZLIB::ZLIB` to `OS_DEPENDENCIES` when `ZLIB_FOUND` is true, preventing configure failures on Windows setups without a system zlib.

- **Default `local_build.py` to Release** (`local_build.py`)
  Passes `-DCMAKE_BUILD_TYPE=Release` so local builds are optimized by default.

- **MSVC fixes for vendored pdfium_jbig2** (`src/third_party/pdfium_jbig2/core/fxcrt/fx_memory_wrappers.h`, `src/third_party/pdfium_jbig2/core/fxcrt/immediate_crash.h`)
  Adds a `std::_Container_proxy` exception workaround and uses `__debugbreak()` uniformly for MSVC trap sequences so the vendored code compiles on Windows.

- **Fix zlib inflate buffer handling** (`src/parse/utils/jpeg/jpeg_utils.h`)
  Separates buffer capacity from actual output size, catches `std::bad_alloc`, and prevents an incorrect double-use of `dest_size` that could corrupt retries.

## Checklist

- [x] Each new source file includes the MIT/SPDX license header.
- [x] Commits are signed off per the DCO.