### PR TITLE
fix: avoid 1M cells reserve to reduce memory footprint

### DIFF
--- a/src/parse/page_items/page_cells.h
+++ b/src/parse/page_items/page_cells.h
@@ -44,10 +44,10 @@ namespace pdflib
   };
 
   page_item<PAGE_CELLS>::page_item():
-    cells(0) // 0 elements
-  {
-    cells.reserve(1000000); // Reserve space for 1M elements
-  }
+    cells(0) // 0 elements; capacity grows on demand. No up-front reserve:
+             // several of these containers live per decoded page, so a large
+             // fixed reserve multiplies into gigabytes of committed memory.
+  {}
 
   page_item<PAGE_CELLS>::~page_item()
   {}


### PR DESCRIPTION
Pre-allocating **1M cells** per `PAGE_CELLS` container wasted ~300 MB per vector. With 5 such vectors per decoded page (`page_cells`, `char_cells`, `cells`, `word_cells`, `line_cells` in `src/parse/pdf_decoders/page.h:161-175`) this multiplied to **~1.5 GB committed per page** and OOMs on small docs when several pages decoded concurrently (threaded parser).

**Change (1 file):**
- `src/parse/page_items/page_cells.h`: remove `cells.reserve(1000000)`, let vector grow on demand (typical pages: hundreds to few thousand cells → <2 MB)

**Verified:**
- `.venv/Scripts/python.exe -m pytest tests/test_parse.py -q` → 21 passed
- `.venv/Scripts/python.exe -m pytest -q` → 111 passed, 1 pre-existing Windows path-separator failure
- `_oom_perdoc.py`: per-page delta 0-50 MB (worst 245 MB) vs previously 1.5 GB+

Independent of the Windows/MinGW build PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)