### PR TITLE
feat: expose PDF embedded-file attachments on SegmentedPage

### DIFF
--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -921,7 +921,66 @@ PYBIND11_MODULE(pdf_parsers, m) {
 
     Returns:
         dict: A None or string of the metadata in xml of the document.)")
-    
+
+    .def("get_attachments",
+	 [](docling::docling_parser &self, const std::string &key) -> nlohmann::json {
+	   return self.get_attachments(key);
+	 },
+	 pybind11::arg("key"),
+	 R"(
+    Retrieve attachments for the document identified by its unique key.
+
+    Parameters:
+        key (str): The unique key of the document.
+
+    Returns:
+        list: A JSON array of attachment metadata (name, mime_type, size, annotations).
+
+    Raises:
+        RuntimeError: If the key is not loaded.)")
+
+    .def("get_attachment_data",
+	 [](docling::docling_parser &self, const std::string &key, int index, long long max_size) -> pybind11::bytes {
+	   return self.get_attachment_data(key, index, max_size);
+	 },
+	 pybind11::arg("key"),
+	 pybind11::arg("index"),
+	 pybind11::arg("max_size"),
+	 R"(
+    Retrieve raw bytes for a single attachment.
+
+    Parameters:
+        key (str): The unique key of the document.
+        index (int): Attachment index from get_attachments().
+        max_size (int): Maximum allowed decoded size in bytes (required).
+
+    Returns:
+        bytes: Decoded attachment payload.
+
+    Raises:
+        RuntimeError: If the key is not loaded, index is out of range,
+            size exceeds max_size, or the stream cannot be decoded.)")
+
+    .def("write_attachment_data",
+	 [](docling::docling_parser &self, const std::string &key, int index, long long max_size, const std::string &path) {
+	   self.write_attachment_data(key, index, max_size, path);
+	 },
+	 pybind11::arg("key"),
+	 pybind11::arg("index"),
+	 pybind11::arg("max_size"),
+	 pybind11::arg("path"),
+	 R"(
+    Stream a single attachment directly to a file without buffering the full decoded payload.
+
+    Parameters:
+        key (str): The unique key of the document.
+        index (int): Attachment index from get_attachments().
+        max_size (int): Maximum allowed decoded size in bytes (required).
+        path (str): Destination file path.
+
+    Raises:
+        RuntimeError: If size exceeds max_size or the stream cannot be decoded.)")
+
     .def("get_page_decoder",
 	 [](docling::docling_parser &self,
 	    const std::string &key,

--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -6,7 +6,7 @@ import math
 from enum import IntEnum
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterator, List, Sequence, Tuple, Union
 
 from docling_core.types.doc.base import BoundingBox, CoordOrigin, ImageRefMode
 from docling_core.types.doc.document import ImageRef
@@ -15,6 +15,8 @@ from docling_core.types.doc.page import (
     BoundingRectangle,
     ColorRGBA,
     Coord2D,
+    FileAttachmentAnnotation,
+    PdfAttachment,
     PdfHyperlink,
     PdfMetaData,
     PdfPageBoundaryType,
@@ -75,6 +77,12 @@ from docling_parse.pdf_parsers import (  # type: ignore[import]
 
 # Configure logging
 _log = logging.getLogger(__name__)
+
+# Cap for eagerly-loaded attachment payloads (200 MB, per the PDF-attachment
+# PR spec). Attachments at or below this size carry their decoded bytes in
+# PdfAttachment.data; larger ones are reported with data=None (metadata only)
+# plus a warning.
+_MAX_ATTACHMENT_DATA_BYTES: int = 200 * 1024 * 1024
 
 
 class PdfTocEntry(BaseModel):
@@ -691,6 +699,7 @@ class PdfDocument:
         self._toc: PdfTableOfContents | None = None
         self._meta: PdfMetaData | None = None
         self._annotations: PdfAnnotations | None = None
+        self._attachments: List[PdfAttachment] | None = None
 
     def _ensure_page_decoder(
         self, page_no: int, content_config: ContentConfig
@@ -900,6 +909,97 @@ class PdfDocument:
         else:
             raise RuntimeError("This document is not loaded.")
 
+    def get_attachments(self) -> List[PdfAttachment]:
+        """Get embedded-file attachments, eagerly decoding binary payloads.
+
+        Attachments at or below ``_MAX_ATTACHMENT_DATA_BYTES`` (200 MB) carry
+        their decoded bytes in ``data``. Attachments above the cap, or whose
+        payload cannot be decoded, are still reported with their metadata but
+        with ``data=None`` plus a warning. The list is computed once and cached
+        on the document.
+
+        Returns:
+            List[PdfAttachment]: attachments with name, mime_type, size, page
+                annotations, and (within the cap) binary data.
+
+        Raises:
+            RuntimeError: if the document is not loaded (missing key).
+        """
+        if not self.is_loaded():
+            raise RuntimeError("This document is not loaded.")
+
+        if self._attachments is not None:
+            return self._attachments
+
+        raw = self._parser.get_attachments(key=self._key)
+        result: List[PdfAttachment] = []
+        for index, item in enumerate(raw):
+            name = item.get("name", "attachment")
+            mime = item.get("mime_type")
+            size = int(item.get("size", 0) or 0)
+            anns: List[FileAttachmentAnnotation] = []
+            for ja in item.get("annotations") or []:
+                try:
+                    bbox_vals = ja.get("bbox") or [0, 0, 0, 0]
+                    bbox = _to_bounding_rectangle(tuple(float(v) for v in bbox_vals))  # type: ignore[arg-type]
+                    anns.append(
+                        FileAttachmentAnnotation(
+                            page_no=int(ja.get("page_no", 0)) + 1, bbox=bbox
+                        )
+                    )
+                except Exception:
+                    _log.debug("Skipping malformed annotation %s", ja, exc_info=True)
+
+            data: bytes | None = None
+            try:
+                data = self.get_attachment_data(
+                    index, max_size=_MAX_ATTACHMENT_DATA_BYTES
+                )
+            except Exception as exc:
+                _log.warning(
+                    "Attachment %r (%s bytes) not decoded (%s); exposing metadata only",
+                    name,
+                    size,
+                    exc,
+                )
+
+            result.append(
+                PdfAttachment(
+                    name=name, mime_type=mime, size=size, annotations=anns, data=data
+                )
+            )
+
+        self._attachments = result
+        return result
+
+    def get_attachment_data(self, index: int, *, max_size: int) -> bytes:
+        """Get raw bytes for a single attachment (memory-safe, requires max_size).
+
+        Args:
+            index: Attachment index from get_attachments().
+            max_size: Maximum allowed decoded size (required, enforces caller policy).
+
+        Raises:
+            ValueError/RuntimeError: if size exceeds max_size or decode fails.
+        """
+        if not self.is_loaded():
+            raise RuntimeError("This document is not loaded.")
+        if not isinstance(max_size, int):
+            raise TypeError("max_size is required and must be an int")
+        return bytes(
+            self._parser.get_attachment_data(
+                key=self._key, index=index, max_size=max_size
+            )
+        )
+
+    def _attachments_for_page(self, page_no: int) -> List[PdfAttachment]:
+        """Attachments anchored to ``page_no`` via FileAttachment annotations."""
+        return [
+            att
+            for att in self.get_attachments()
+            if any(a.page_no == page_no for a in att.annotations)
+        ]
+
     def get_page(
         self,
         page_no: int,
@@ -918,6 +1018,7 @@ class PdfDocument:
 
         decoder = self._ensure_page_decoder(page_no, cc)
         page = segmented_page_from_decoder(decoder, self._boundary_type, cc)
+        page.attachments = self._attachments_for_page(page_no)
         self._pages[cache_key] = page
         return page
 
@@ -939,6 +1040,7 @@ class PdfDocument:
             self._decoded_content_configs.pop(page_no, None)
         decoder = self._ensure_page_decoder(page_no, cc)
         segmented_page = segmented_page_from_decoder(decoder, self._boundary_type, cc)
+        segmented_page.attachments = self._attachments_for_page(page_no)
         timings = Timings(
             data=dict(decoder.get_timings()),
             raw_data=dict(decoder.get_timings_raw()),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pillow>=10.0.0,<13.0.0",
     "pydantic>=2.0.0",
-    "docling-core>=2.85.0,<3.0.0",
+    "docling-core>=2.92.0,<3.0.0",
     "pywin32>=305; sys_platform == 'win32'",
 ]
 [project.urls]

--- a/src/parse/pdf_decoders/document.h
+++ b/src/parse/pdf_decoders/document.h
@@ -8,9 +8,11 @@
 #include <mutex>
 #include <optional>
 #include <qpdf/QPDFAcroFormDocumentHelper.hh>
+#include <qpdf/Pipeline.hh>
 #include <qpdf/QPDF.hh>
 #include <qpdf/QPDFWriter.hh>
 
+#include <parse/qpdf/attachments.h>
 #include <parse/qpdf/logger.h>
 
 namespace pdflib
@@ -35,6 +37,10 @@ namespace pdflib
 
     nlohmann::json get_meta_xml();
     nlohmann::json get_table_of_contents();
+
+    nlohmann::json get_attachments();
+    std::shared_ptr<Buffer> get_attachment_data(int index, long long max_size);
+    void write_attachment_data(int index, long long max_size, const std::string& path);
 
     bool process_document_from_file(std::string& _filename,
                                     std::optional<std::string>& _password,
@@ -74,6 +80,13 @@ namespace pdflib
 
     void ensure_annots_loaded();
 
+    void ensure_attachments_loaded();
+
+    // Shared attachment helpers (deduped from get/write paths).
+    const AttachmentRecord& require_attachment_record(int index, long long max_size);
+    QPDFObjectHandle require_attachment_stream(int index, long long max_size);
+    static void warn_if_raw_length_exceeds(const QPDFObjectHandle& stream_obj, long long max_size);
+
     void update_timings(pdf_timings& timings_, bool set_timer);
 
   private:
@@ -93,6 +106,10 @@ namespace pdflib
     nlohmann::json json_annots;
     bool annots_loaded;
 
+    // Attachments (metadata only, lazy)
+    std::vector<AttachmentRecord> attachment_records;
+    bool attachments_loaded;
+
     // New: Persistent page decoders for typed API
     std::map<int, page_decoder_ptr> page_decoders;
   };
@@ -111,6 +128,8 @@ namespace pdflib
 
     json_annots(nlohmann::json::value_t::null),
     annots_loaded(false),
+    attachment_records({}),
+    attachments_loaded(false),
     page_decoders({})
   {
     configure_qpdf_warnings(qpdf_document);
@@ -130,6 +149,8 @@ namespace pdflib
 
     json_annots(nlohmann::json::value_t::null),
     annots_loaded(false),
+    attachment_records({}),
+    attachments_loaded(false),
     page_decoders({})
   {
     configure_qpdf_warnings(qpdf_document);
@@ -179,6 +200,145 @@ namespace pdflib
   {
     ensure_annots_loaded();
     return json_annots["table_of_contents"];
+  }
+
+  void pdf_decoder<DOCUMENT>::ensure_attachments_loaded()
+  {
+    if(attachments_loaded)
+      return;
+    try
+      {
+        QPDFObjectHandle qpdf_root = qpdf_document.getRoot();
+        attachment_records = extract_attachment_records(qpdf_document, qpdf_root);
+      }
+    catch(const std::exception& exc)
+      {
+        LOG_S(WARNING) << "filename: " << filename << " failed to extract attachments: " << exc.what();
+      }
+    attachments_loaded = true;
+  }
+
+  const AttachmentRecord& pdf_decoder<DOCUMENT>::require_attachment_record(int index, long long max_size)
+  {
+    ensure_attachments_loaded();
+    if(index < 0 || index >= static_cast<int>(attachment_records.size()))
+      throw std::out_of_range("attachment index out of range");
+    const auto& rec = attachment_records[static_cast<size_t>(index)];
+    if(rec.size > max_size)
+      throw std::runtime_error("attachment size " + std::to_string(rec.size) + " exceeds max_size " + std::to_string(max_size));
+    if(!rec.obj_gen.isIndirect())
+      throw std::runtime_error(
+        "attachment at index " + std::to_string(index) +
+        " has a direct (non-indirect) EF stream and cannot be fetched — direct streams have no indirect object ID");
+    return rec;
+  }
+
+  QPDFObjectHandle pdf_decoder<DOCUMENT>::require_attachment_stream(int index, long long max_size)
+  {
+    const auto& rec = require_attachment_record(index, max_size);
+    QPDFObjectHandle stream_obj;
+    try { stream_obj = qpdf_document.getObjectByObjGen(rec.obj_gen); }
+    catch(const std::exception& exc) { LOG_S(WARNING) << "attachment stream lookup failed: " << exc.what(); }
+    if(!stream_obj.isStream())
+      throw std::runtime_error("attachment stream not found for index " + std::to_string(index));
+    return stream_obj;
+  }
+
+  void pdf_decoder<DOCUMENT>::warn_if_raw_length_exceeds(const QPDFObjectHandle& stream_obj, long long max_size)
+  {
+    // Guard against filter bombs: compare the declared raw /Length against the
+    // limit before decoding. The 10x slack only decides when a mismatch is
+    // worth a warning (compression can legitimately expand); the decoded size
+    // is still enforced separately.
+    // NB: stream handles don't proxy hasKey/getKey on this qpdf version —
+    // the dict must be addressed via getDict().
+    try
+      {
+        QPDFObjectHandle dict = stream_obj.getDict();
+        if(dict.hasKey("/Length") && dict.getKey("/Length").isInteger())
+          {
+            long long raw_len = dict.getKey("/Length").getIntValue();
+            if(raw_len > max_size * 10)
+              LOG_S(WARNING) << "attachment raw Length " << raw_len << " is much larger than max_size " << max_size;
+          }
+      }
+    catch(const std::exception& exc)
+      {
+        LOG_S(WARNING) << "failed to read attachment /Length: " << exc.what();
+      }
+  }
+
+  nlohmann::json pdf_decoder<DOCUMENT>::get_attachments()
+  {
+    ensure_attachments_loaded();
+    return attachments_to_json(attachment_records);
+  }
+
+  std::shared_ptr<Buffer> pdf_decoder<DOCUMENT>::get_attachment_data(int index, long long max_size)
+  {
+    QPDFObjectHandle stream_obj = require_attachment_stream(index, max_size);
+    warn_if_raw_length_exceeds(stream_obj, max_size);
+
+    std::shared_ptr<Buffer> buf;
+    try
+      {
+        buf = stream_obj.getStreamData(qpdf_dl_all);
+      }
+    catch(const std::exception& exc)
+      {
+        throw std::runtime_error(std::string("failed to decode attachment stream: ") + exc.what());
+      }
+
+    if(!buf)
+      throw std::runtime_error("failed to get stream data for attachment " + std::to_string(index));
+
+    if(static_cast<long long>(buf->getSize()) > max_size)
+      throw std::runtime_error("decoded attachment size " + std::to_string(buf->getSize()) + " exceeds max_size " + std::to_string(max_size));
+
+    return buf;
+  }
+
+  void pdf_decoder<DOCUMENT>::write_attachment_data(int index, long long max_size, const std::string& path)
+  {
+    QPDFObjectHandle stream_obj = require_attachment_stream(index, max_size);
+    warn_if_raw_length_exceeds(stream_obj, max_size);
+
+    std::ofstream out(path, std::ios::binary);
+    if(!out)
+      throw std::runtime_error("failed to open attachment output file: " + path);
+
+    struct LimitedFilePipeline : public Pipeline
+    {
+      std::ofstream& out;
+      long long max_size;
+      long long written = 0;
+      LimitedFilePipeline(std::ofstream& o, long long m) : Pipeline("attachment-pipe", nullptr), out(o), max_size(m) {}
+      void write(unsigned char const* data, size_t len) override
+      {
+        written += static_cast<long long>(len);
+        if(written > max_size)
+          throw std::runtime_error("decoded attachment size " + std::to_string(written) + " exceeds max_size " + std::to_string(max_size));
+        out.write(reinterpret_cast<char const*>(data), len);
+        if(!out)
+          throw std::runtime_error("failed to write attachment data to file");
+      }
+      void finish() override { out.flush(); }
+    };
+
+    LimitedFilePipeline pipeline(out, max_size);
+    try
+      {
+        if(!stream_obj.pipeStreamData(&pipeline, 0, qpdf_dl_all))
+          throw std::runtime_error("failed to pipe attachment stream data for index " + std::to_string(index));
+        pipeline.finish();
+      }
+    catch(const std::exception&)
+      {
+        throw;
+      }
+
+    if(!out)
+      throw std::runtime_error("failed to write attachment data to file: " + path);
   }
 
   bool pdf_decoder<DOCUMENT>::process_document_from_file(std::string& _filename,
@@ -241,6 +401,12 @@ namespace pdflib
   {
     buffer = _buffer;
     password = _password;
+
+    // Reset cached state
+    attachment_records.clear();
+    attachments_loaded = false;
+    annots_loaded = false;
+    json_annots = nlohmann::json::value_t::null;
 
     LOG_S(INFO) << "start processing buffer of size " << buffer->size() << " by qpdf ...";
     

--- a/src/parse/qpdf/attachments.h
+++ b/src/parse/qpdf/attachments.h
@@ -1,0 +1,336 @@
+#ifndef QPDF_ATTACHMENTS_H
+#define QPDF_ATTACHMENTS_H
+
+#include <array>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <qpdf/QPDF.hh>
+#include <qpdf/QPDFObjectHandle.hh>
+#include <qpdf/QPDFObjGen.hh>
+
+#include <parse/qpdf/logger.h>
+#include <parse/qpdf/qpdf_compat.h>
+#include <parse/utils/string.h>
+
+namespace pdflib
+{
+
+struct AttachmentAnnotation
+{
+  int page_no = -1; // 0-based
+  std::array<double, 4> bbox = {0, 0, 0, 0};
+};
+
+struct AttachmentRecord
+{
+  std::string name;
+  std::string mime_type; // empty if missing
+  long long size = 0;
+  // QPDF object identity of the EF stream. A non-indirect (0,0) value is the
+  // sentinel for a direct (non-indirect) EF stream: the stream dict is
+  // embedded inline in the FileSpec and has no indirect object ID, so it
+  // cannot be re-fetched via getObjectByID / getObjectByObjGen.
+  // Direct streams are intentionally distinct per dedup logic and are not
+  // cached; get_attachment_data() detects this sentinel and throws.
+  // An indirect stream genuinely at object 0 is not possible in a valid PDF
+  // (object 0 is the free-list head), so 0 is unambiguous here.
+  QPDFObjGen obj_gen;
+  std::vector<AttachmentAnnotation> annotations;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+inline QPDFObjectHandle getStreamDict(QPDFObjectHandle oh)
+{
+  return oh.isStream() ? oh.getDict() : oh;
+}
+
+inline std::string extract_attachment_name(QPDFObjectHandle fs)
+{
+  try
+    {
+      if(fs.hasKey("/UF") && fs.getKey("/UF").isString())
+        {
+          std::string v = fs.getKey("/UF").getUTF8Value();
+          if(!v.empty())
+            return utils::string::fix_into_valid_utf8(v);
+        }
+      if(fs.hasKey("/F") && fs.getKey("/F").isString())
+        {
+          std::string v = fs.getKey("/F").getUTF8Value();
+          if(!v.empty())
+            return utils::string::fix_into_valid_utf8(v);
+        }
+    }
+  catch(const std::exception& exc)
+    {
+      LOG_S(WARNING) << "failed to extract attachment name: " << exc.what();
+    }
+  return "attachment";
+}
+
+inline std::string extract_attachment_mime(QPDFObjectHandle stream_obj)
+{
+  try
+    {
+      QPDFObjectHandle dict = getStreamDict(stream_obj);
+      if(dict.hasKey("/Subtype") && dict.getKey("/Subtype").isName())
+        {
+          std::string m = dict.getKey("/Subtype").getName();
+          if(!m.empty() && m[0]=='/')
+            m = m.substr(1);
+          return utils::string::fix_into_valid_utf8(m);
+        }
+    }
+  catch(const std::exception& exc)
+    {
+      LOG_S(WARNING) << "failed to extract mime: " << exc.what();
+    }
+  return "";
+}
+
+inline long long extract_attachment_size(QPDFObjectHandle stream_obj)
+{
+  try
+    {
+      QPDFObjectHandle dict = getStreamDict(stream_obj);
+      if(dict.hasKey("/Params") && dict.getKey("/Params").isDictionary())
+        {
+          QPDFObjectHandle params = dict.getKey("/Params");
+          if(params.hasKey("/Size") && params.getKey("/Size").isInteger())
+            return params.getKey("/Size").getIntValue();
+        }
+      if(dict.hasKey("/DL") && dict.getKey("/DL").isInteger())
+        return dict.getKey("/DL").getIntValue();
+      if(dict.hasKey("/Length") && dict.getKey("/Length").isInteger())
+        return dict.getKey("/Length").getIntValue();
+    }
+  catch(const std::exception& exc)
+    {
+      LOG_S(WARNING) << "failed to extract size: " << exc.what();
+    }
+  return 0;
+}
+
+inline bool extract_rect(QPDFObjectHandle rect, std::array<double,4>& out)
+{
+  if(!rect.isArray() || rect.getArrayNItems()!=4)
+    return false;
+  try
+    {
+      for(int i=0;i<4;++i)
+        out[i] = rect.getArrayItem(i).getNumericValue();
+      return true;
+    }
+  catch(const std::exception& exc)
+    {
+      LOG_S(WARNING) << "malformed Rect: " << exc.what();
+      return false;
+    }
+}
+
+// One annotation entry for an attachment; bbox zeroed when /Rect is malformed.
+inline AttachmentAnnotation make_attachment_annotation(int page_no, QPDFObjectHandle rect)
+{
+  AttachmentAnnotation ann;
+  ann.page_no = page_no;
+  if(!extract_rect(rect, ann.bbox))
+    ann.bbox = {0,0,0,0};
+  return ann;
+}
+
+// ---------------------------------------------------------------------------
+// Core extraction — metadata only, never calls getStreamData()
+// ---------------------------------------------------------------------------
+
+inline std::vector<AttachmentRecord> extract_attachment_records(QPDF& pdf, QPDFObjectHandle& root)
+{
+  std::vector<AttachmentRecord> records;
+  std::map<QPDFObjGen, size_t> obj_to_index;
+
+  auto process_filespec = [&](QPDFObjectHandle fs, int page_no, QPDFObjectHandle rect) {
+    if(!fs.isDictionary())
+      {
+        LOG_S(WARNING) << "FileSpec is not a dict, skipping";
+        return;
+      }
+
+    std::string name = extract_attachment_name(fs);
+
+    if(!fs.hasKey("/EF") || !fs.getKey("/EF").isDictionary())
+      {
+        LOG_S(WARNING) << "FileSpec missing /EF for '" << name << "', skipping";
+        return;
+      }
+
+    QPDFObjectHandle ef_dict = fs.getKey("/EF");
+    QPDFObjectHandle stream_obj;
+
+    if(ef_dict.hasKey("/UF") && ef_dict.getKey("/UF").isStream())
+      stream_obj = ef_dict.getKey("/UF");
+    else if(ef_dict.hasKey("/F") && ef_dict.getKey("/F").isStream())
+      stream_obj = ef_dict.getKey("/F");
+    else
+      {
+        LOG_S(WARNING) << "EF dict has no stream for '" << name << "', skipping";
+        return;
+      }
+
+    if(!stream_obj.isStream())
+      {
+        LOG_S(WARNING) << "EF entry is not a stream for '" << name << "'";
+        return;
+      }
+
+    QPDFObjGen og = stream_obj.getObjGen();
+    // Direct (non-indirect) EF streams are embedded inline in the FileSpec
+    // dict. Each occurrence is a distinct object by definition, so no dedup
+    // is attempted for them. Only indirect streams have a stable object
+    // identity that can be shared across FileSpecs/annotations.
+    bool is_dedupable = og.isIndirect();
+
+    std::string mime = extract_attachment_mime(stream_obj);
+    long long size = extract_attachment_size(stream_obj);
+
+    if(is_dedupable && obj_to_index.count(og))
+      {
+        size_t idx = obj_to_index[og];
+        if(page_no>=0)
+          records[idx].annotations.push_back(make_attachment_annotation(page_no, rect));
+        return;
+      }
+
+    AttachmentRecord rec;
+    rec.name = name;
+    rec.mime_type = mime;
+    rec.size = size;
+    rec.obj_gen = og;
+
+    if(page_no>=0)
+      rec.annotations.push_back(make_attachment_annotation(page_no, rect));
+
+    records.push_back(std::move(rec));
+    if(is_dedupable)
+      obj_to_index[og] = records.size()-1;
+  };
+
+  try
+    {
+      if(root.hasKey("/Names") && root.getKey("/Names").isDictionary())
+        {
+          QPDFObjectHandle names = root.getKey("/Names");
+          if(names.hasKey("/EmbeddedFiles") && names.getKey("/EmbeddedFiles").isDictionary())
+            {
+              QPDFObjectHandle ef_tree = names.getKey("/EmbeddedFiles");
+              std::function<void(QPDFObjectHandle)> walk = [&](QPDFObjectHandle node){
+                if(!node.isDictionary()) return;
+                if(node.hasKey("/Names") && node.getKey("/Names").isArray())
+                  {
+                    QPDFObjectHandle arr = node.getKey("/Names");
+                    int n = arr.getArrayNItems();
+                    for(int i=1;i<n;i+=2)
+                      {
+                        try { process_filespec(arr.getArrayItem(i), -1, QPDFObjectHandle::newNull()); }
+                        catch(const std::exception& exc) { LOG_S(WARNING) << "walk Names failed: " << exc.what(); }
+                      }
+                  }
+                if(node.hasKey("/Nums") && node.getKey("/Nums").isArray())
+                  {
+                    QPDFObjectHandle arr = node.getKey("/Nums");
+                    int n = arr.getArrayNItems();
+                    for(int i=1;i<n;i+=2)
+                      {
+                        try { process_filespec(arr.getArrayItem(i), -1, QPDFObjectHandle::newNull()); }
+                        catch(const std::exception& exc) { LOG_S(WARNING) << "walk Nums failed: " << exc.what(); }
+                      }
+                  }
+                if(node.hasKey("/Kids") && node.getKey("/Kids").isArray())
+                  {
+                    QPDFObjectHandle kids = node.getKey("/Kids");
+                    for(int i=0;i<kids.getArrayNItems();++i)
+                      {
+                        try { walk(kids.getArrayItem(i)); }
+                        catch(const std::exception& exc) { LOG_S(WARNING) << "walk Kids failed: " << exc.what(); }
+                      }
+                  }
+              };
+              walk(ef_tree);
+            }
+        }
+    }
+  catch(const std::exception& exc)
+    {
+      LOG_S(WARNING) << "failed walking EmbeddedFiles tree: " << exc.what();
+    }
+
+  try
+    {
+      std::vector<QPDFObjectHandle> pages = pdf.getAllPages();
+      for(size_t p=0; p<pages.size(); ++p)
+        {
+          QPDFObjectHandle page = pages[p];
+          int page_no = static_cast<int>(p);
+          if(!page.hasKey("/Annots"))
+            continue;
+          QPDFObjectHandle annots = page.getKey("/Annots");
+          if(!annots.isArray())
+            continue;
+          for(int i=0;i<annots.getArrayNItems();++i)
+            {
+              try
+                {
+                  QPDFObjectHandle annot = annots.getArrayItem(i);
+                  if(!annot.isDictionary()) continue;
+                  if(!annot.hasKey("/Subtype") || !annot.getKey("/Subtype").isName()) continue;
+                  if(annot.getKey("/Subtype").getName() != "/FileAttachment") continue;
+                  if(!annot.hasKey("/FS")) continue;
+                  QPDFObjectHandle fs = annot.getKey("/FS");
+                  QPDFObjectHandle rect = annot.hasKey("/Rect") ? annot.getKey("/Rect") : QPDFObjectHandle::newNull();
+                  process_filespec(fs, page_no, rect);
+                }
+              catch(const std::exception& exc)
+                {
+                  LOG_S(WARNING) << "failed processing annot on page " << p << ": " << exc.what();
+                }
+            }
+        }
+    }
+  catch(const std::exception& exc)
+    {
+      LOG_S(WARNING) << "failed walking page annots: " << exc.what();
+    }
+
+  return records;
+}
+
+inline nlohmann::json attachments_to_json(const std::vector<AttachmentRecord>& records)
+{
+  nlohmann::json arr = nlohmann::json::array();
+  for(const auto& r : records)
+    {
+      nlohmann::json item;
+      item["name"] = r.name;
+      item["mime_type"] = r.mime_type.empty() ? nlohmann::json(nullptr) : nlohmann::json(r.mime_type);
+      item["size"] = r.size;
+      nlohmann::json anns = nlohmann::json::array();
+      for(const auto& a : r.annotations)
+        {
+          nlohmann::json ja;
+          ja["page_no"] = a.page_no;
+          ja["bbox"] = nlohmann::json::array({a.bbox[0], a.bbox[1], a.bbox[2], a.bbox[3]});
+          anns.push_back(ja);
+        }
+      item["annotations"] = anns;
+      arr.push_back(std::move(item));
+    }
+  return arr;
+}
+
+} // namespace pdflib
+
+#endif

--- a/src/pybind/docling_parser.h
+++ b/src/pybind/docling_parser.h
@@ -57,6 +57,9 @@ namespace docling
 
     nlohmann::json get_meta_xml(std::string key);
     nlohmann::json get_table_of_contents(std::string key);
+    nlohmann::json get_attachments(std::string key);
+    pybind11::bytes get_attachment_data(std::string key, int index, long long max_size);
+    void write_attachment_data(std::string key, int index, long long max_size, std::string path);
 
     std::shared_ptr<pdflib::pdf_decoder<pdflib::PAGE>> get_page_decoder(std::string key,
                                                                         int page,
@@ -427,6 +430,35 @@ namespace docling
       }
 
     return (itr->second)->get_table_of_contents();
+  }
+
+  nlohmann::json docling_parser::get_attachments(std::string key)
+  {
+    LOG_S(INFO) << __FUNCTION__;
+
+    auto itr = doc_decoders.find(key);
+    if(itr==doc_decoders.end())
+      throw std::runtime_error("key not found: " + key);
+
+    return (itr->second)->get_attachments();
+  }
+
+  pybind11::bytes docling_parser::get_attachment_data(std::string key, int index, long long max_size)
+  {
+    auto itr = doc_decoders.find(key);
+    if(itr==doc_decoders.end())
+      throw std::runtime_error("key not found: " + key);
+
+    auto buf = (itr->second)->get_attachment_data(index, max_size);
+    return pybind11::bytes(reinterpret_cast<const char*>(buf->getBuffer()), buf->getSize());
+  }
+
+  void docling_parser::write_attachment_data(std::string key, int index, long long max_size, std::string path)
+  {
+    auto itr = doc_decoders.find(key);
+    if(itr==doc_decoders.end())
+      throw std::runtime_error("key not found: " + key);
+    (itr->second)->write_attachment_data(index, max_size, path);
   }
 
   std::shared_ptr<pdflib::pdf_decoder<pdflib::PAGE>> docling_parser::get_page_decoder(std::string key,

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,254 @@
+"""Attachment extraction tests — binary data on PdfAttachment."""
+
+import logging
+from io import BytesIO
+
+import pytest
+
+import docling_parse.pdf_parser as _parser_module
+from docling_parse.pdf_parser import DoclingPdfParser
+
+
+def _build_pdf(objects: dict[int, bytes]) -> bytes:
+    """Build a minimal PDF from obj_num -> raw_content bytes."""
+    header = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
+    parts: list[bytes] = [header]
+    offsets: dict[int, int] = {}
+    for num in sorted(objects.keys()):
+        offsets[num] = sum(len(p) for p in parts)
+        parts.append(f"{num} 0 obj\n".encode())
+        parts.append(objects[num])
+        if not objects[num].endswith(b"\n"):
+            parts.append(b"\n")
+        parts.append(b"endobj\n")
+    xref_offset = sum(len(p) for p in parts)
+    max_obj = max(objects.keys())
+    parts.append(f"xref\n0 {max_obj + 1}\n".encode())
+    parts.append(b"0000000000 65535 f \n")
+    for i in range(1, max_obj + 1):
+        off = offsets.get(i, 0)
+        parts.append(f"{off:010d} 00000 n \n".encode())
+    parts.append(f"trailer\n<< /Size {max_obj + 1} /Root 1 0 R >>\n".encode())
+    parts.append(f"startxref\n{xref_offset}\n%%EOF\n".encode())
+    return b"".join(parts)
+
+
+def _pdf_single_no_annot(
+    data: bytes = b"Hello Attachment\n", name: str = "hello.txt"
+) -> bytes:
+    ef_len = len(data)
+    return _build_pdf(
+        {
+            1: b"<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles << /Names [ ("
+            + name.encode()
+            + b") 4 0 R ] >> >> >>",
+            2: b"<< /Type /Pages /Kids [ 3 0 R ] /Count 1 >>",
+            3: b"<< /Type /Page /Parent 2 0 R /MediaBox [ 0 0 612 792 ] >>",
+            4: b"<< /Type /Filespec /F ("
+            + name.encode()
+            + b") /UF ("
+            + name.encode()
+            + b") /EF << /F 5 0 R /UF 5 0 R >> >>",
+            5: b"<< /Type /EmbeddedFile /Subtype /text#2fplain /Length "
+            + str(ef_len).encode()
+            + b" /Params << /Size "
+            + str(ef_len).encode()
+            + b" >> >>\nstream\n"
+            + data
+            + b"\nendstream",
+        }
+    )
+
+
+def _pdf_one_file_two_annots(data: bytes = b"Hello\n", name: str = "doc.txt") -> bytes:
+    ef_len = len(data)
+    return _build_pdf(
+        {
+            1: b"<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles << /Names [ ("
+            + name.encode()
+            + b") 4 0 R ] >> >> >>",
+            2: b"<< /Type /Pages /Kids [ 3 0 R 6 0 R 7 0 R ] /Count 3 >>",
+            3: b"<< /Type /Page /Parent 2 0 R /MediaBox [ 0 0 612 792 ] /Annots [ 8 0 R ] >>",
+            4: b"<< /Type /Filespec /F ("
+            + name.encode()
+            + b") /UF ("
+            + name.encode()
+            + b") /EF << /F 5 0 R /UF 5 0 R >> >>",
+            5: b"<< /Type /EmbeddedFile /Length "
+            + str(ef_len).encode()
+            + b" /Params << /Size "
+            + str(ef_len).encode()
+            + b" >> >>\nstream\n"
+            + data
+            + b"\nendstream",
+            6: b"<< /Type /Page /Parent 2 0 R /MediaBox [ 0 0 612 792 ] >>",
+            7: b"<< /Type /Page /Parent 2 0 R /MediaBox [ 0 0 612 792 ] /Annots [ 9 0 R ] >>",
+            8: b"<< /Type /Annot /Subtype /FileAttachment /Rect [ 100 100 120 120 ] /FS 4 0 R /Name /Paperclip >>",
+            9: b"<< /Type /Annot /Subtype /FileAttachment /Rect [ 200 200 220 220 ] /FS 4 0 R /Name /Paperclip >>",
+        }
+    )
+
+
+def _pdf_same_name_different_bytes(name: str = "dup.txt") -> bytes:
+    data_a = b"hello"
+    data_b = b"world"
+    return _build_pdf(
+        {
+            1: b"<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles << /Names [ ("
+            + name.encode()
+            + b") 4 0 R ("
+            + name.encode()
+            + b") 6 0 R ] >> >> >>",
+            2: b"<< /Type /Pages /Kids [ 3 0 R ] /Count 1 >>",
+            3: b"<< /Type /Page /Parent 2 0 R /MediaBox [ 0 0 612 792 ] >>",
+            4: b"<< /Type /Filespec /F (" + name.encode() + b") /EF << /F 5 0 R >> >>",
+            5: b"<< /Length "
+            + str(len(data_a)).encode()
+            + b" /Params << /Size "
+            + str(len(data_a)).encode()
+            + b" >> >>\nstream\n"
+            + data_a
+            + b"\nendstream",
+            6: b"<< /Type /Filespec /F (" + name.encode() + b") /EF << /F 7 0 R >> >>",
+            7: b"<< /Length "
+            + str(len(data_b)).encode()
+            + b" /Params << /Size "
+            + str(len(data_b)).encode()
+            + b" >> >>\nstream\n"
+            + data_b
+            + b"\nendstream",
+        }
+    )
+
+
+def _load(pdf_bytes: bytes):
+    parser = DoclingPdfParser(loglevel="fatal")
+    return parser.load(path_or_stream=BytesIO(pdf_bytes))
+
+
+def test_single_attachment_no_annot():
+    doc = _load(_pdf_single_no_annot())
+    atts = doc.get_attachments()
+    assert len(atts) == 1
+    att = atts[0]
+    assert att.name == "hello.txt"
+    assert att.mime_type == "text/plain"
+    assert att.size == len(b"Hello Attachment\n")
+    assert att.annotations == []
+    assert att.data == b"Hello Attachment\n"
+
+
+def test_one_file_two_annots():
+    doc = _load(_pdf_one_file_two_annots())
+    atts = doc.get_attachments()
+    assert len(atts) == 1
+    att = atts[0]
+    assert att.name == "doc.txt"
+    assert len(att.annotations) == 2
+    pages = sorted(a.page_no for a in att.annotations)
+    assert pages == [1, 3]
+    annots_sorted = sorted(att.annotations, key=lambda a: a.page_no)
+    b0 = annots_sorted[0].bbox
+    b1 = annots_sorted[1].bbox
+    assert (b0.r_x0, b0.r_y0, b0.r_x1, b0.r_y1, b0.r_x2, b0.r_y2, b0.r_x3, b0.r_y3) == (
+        100.0,
+        100.0,
+        120.0,
+        100.0,
+        120.0,
+        120.0,
+        100.0,
+        120.0,
+    )
+    assert (b1.r_x0, b1.r_y0, b1.r_x1, b1.r_y1, b1.r_x2, b1.r_y2, b1.r_x3, b1.r_y3) == (
+        200.0,
+        200.0,
+        220.0,
+        200.0,
+        220.0,
+        220.0,
+        200.0,
+        220.0,
+    )
+    assert att.data == b"Hello\n"
+
+
+def test_same_name_different_bytes():
+    doc = _load(_pdf_same_name_different_bytes())
+    atts = doc.get_attachments()
+    assert len(atts) == 2
+    assert [a.name for a in atts] == ["dup.txt", "dup.txt"]
+    assert atts[0].data == b"hello"
+    assert atts[1].data == b"world"
+
+
+def test_get_attachments_cached():
+    doc = _load(_pdf_single_no_annot())
+    first = doc.get_attachments()
+    second = doc.get_attachments()
+    assert first is second
+
+
+def test_attachment_above_cap_has_no_data(monkeypatch, caplog):
+    monkeypatch.setattr(_parser_module, "_MAX_ATTACHMENT_DATA_BYTES", 1024)
+    with caplog.at_level(logging.WARNING, logger="docling_parse.pdf_parser"):
+        doc = _load(_pdf_single_no_annot(data=b"x" * 2048, name="big.bin"))
+        atts = doc.get_attachments()
+    assert len(atts) == 1
+    assert atts[0].size == 2048
+    assert atts[0].data is None
+    assert any("big.bin" in r.message for r in caplog.records)
+
+
+def test_attachment_at_cap_is_decoded(monkeypatch):
+    monkeypatch.setattr(_parser_module, "_MAX_ATTACHMENT_DATA_BYTES", 1024)
+    doc = _load(_pdf_single_no_annot(data=b"y" * 1024, name="exact.bin"))
+    atts = doc.get_attachments()
+    assert atts[0].data == b"y" * 1024
+
+
+def test_get_attachment_data_primitive_requires_max_size():
+    doc = _load(_pdf_single_no_annot())
+    assert doc.get_attachment_data(0, max_size=10_000) == b"Hello Attachment\n"
+    with pytest.raises(TypeError):
+        doc.get_attachment_data(0)  # type: ignore[call-arg]
+
+
+def _pdf_no_attachments() -> bytes:
+    return _build_pdf(
+        {
+            1: b"<< /Type /Catalog /Pages 2 0 R >>",
+            2: b"<< /Type /Pages /Kids [ 3 0 R ] /Count 1 >>",
+            3: b"<< /Type /Page /Parent 2 0 R /MediaBox [ 0 0 612 792 ] >>",
+        }
+    )
+
+
+def test_page_attachments_anchored_vs_unanchored():
+    doc = _load(_pdf_one_file_two_annots())
+    page1 = doc.get_page(1)
+    page2 = doc.get_page(2)
+    page3 = doc.get_page(3)
+    assert [a.name for a in page1.attachments] == ["doc.txt"]
+    assert page1.attachments[0].data == b"Hello\n"
+    assert page2.attachments == []
+    assert [a.name for a in page3.attachments] == ["doc.txt"]
+
+    doc2 = _load(_pdf_single_no_annot())
+    assert [a.name for a in doc2.get_page(1).attachments] == []
+    assert [a.name for a in doc2.get_attachments()] == ["hello.txt"]
+
+
+def test_iterate_pages_carries_attachments():
+    doc = _load(_pdf_one_file_two_annots())
+    pages = dict(doc.iterate_pages())
+    assert sorted(pages) == [1, 2, 3]
+    assert [a.name for a in pages[1].attachments] == ["doc.txt"]
+    assert pages[2].attachments == []
+    assert [a.name for a in pages[3].attachments] == ["doc.txt"]
+
+
+def test_empty_pdf_no_attachments():
+    doc = _load(_pdf_no_attachments())
+    assert doc.get_attachments() == []
+    assert doc.get_page(1).attachments == []


### PR DESCRIPTION
## Summary

Extract PDF embedded-file attachments and expose them on the parse-level page model (`SegmentedPdfPage`), exactly per the maintainer's direction to split the attachment feature into small PRs.

- `PdfDocument.get_attachments() -> list[PdfAttachment]` — **eagerly decodes** each attachment's binary payload into `PdfAttachment.data`, capped at 200 MB. Attachments above the cap (or that fail to decode) are still reported with their metadata but `data=None`, plus a warning.
- `PdfDocument.get_page()` / `get_page_with_timings()` / `iterate_pages()` populate `page.attachments` — each page carries the `PdfAttachment`s anchored to it via `FileAttachmentAnnotation` (`page_no` + `bbox`). Unanchored attachments (from `Catalog/Names/EmbeddedFiles`) live only at document level.
- C++ (qpdf) extraction of name / MIME / size / per-page annotation positions is kept from the earlier attempt.
- The streaming/spooling APIs (`get_attachment_stream`, `_AttachmentDeletingFile`) are **deferred** to the docling PR and are NOT part of this one. `get_attachment_data(index, *, max_size)` stays as the internal decode primitive.

## ⚠️ Depends on docling-core PR #1 — not mergeable until it ships

This PR **hard-depends** on [docling-project/docling-core#734](https://github.com/docling-project/docling-core/pull/734) — "page-level attachment types".

- Core PR #1 adds `FileAttachmentAnnotation`, `PdfAttachment` (including the `data: bytes` field), and the `attachments` list on `SegmentedPdfPage` / `ParsedPdfDocument` in `docling_core.types.doc.page`.
- This PR imports those types directly and sets `PdfAttachment.data` and `SegmentedPdfPage.attachments`; it does **not** compile/run against any currently-released `docling-core`.
- The `pyproject.toml` dependency is therefore bumped to **`docling-core>=2.92.0,<3.0.0`** (the release that ships core PR #1). CI will **not** pass until that release exists.

**Landing order:** core #734 → this PR (parse #313) → core `AttachmentItem` PR → docling integration.

## Testing

- `tests/test_attachments.py` (10 tests): binary data on `PdfAttachment`, 200 MB cap behavior (`data=None` + warning above the cap), per-page `page.attachments` (anchored vs unanchored), `iterate_pages` wiring, empty doc, caching, `get_attachment_data` primitive contract.
- Smoke regression: `test_attachments.py` + `test_parse.py` — 31 passed.
- ruff format/check clean.
