### PR TITLE
fix: re-sync test data when the pinned dataset revision changes

### DIFF
--- a/tests/data_utils.py
+++ b/tests/data_utils.py
@@ -19,8 +19,17 @@ RENDER_GROUNDTRUTH_PAGES_DIR = RENDER_GROUNDTRUTH_DIR / "pages"
 def ensure_test_data_downloaded(force: bool = False) -> Path:
     TEST_DATA_DIR.mkdir(parents=True, exist_ok=True)
 
+    # A non-empty data dir is only current if it was synced at the pinned
+    # revision; otherwise a checkout that predates a HF_DATASET_REVISION bump
+    # would keep testing against stale groundtruth.
+    revision_marker = TEST_DATA_DIR / ".hf_revision"
+
     if not force and any(TEST_DATA_DIR.iterdir()):
-        return TEST_DATA_DIR
+        cached_revision = (
+            revision_marker.read_text().strip() if revision_marker.exists() else None
+        )
+        if cached_revision == HF_DATASET_REVISION:
+            return TEST_DATA_DIR
 
     snapshot_download(
         repo_id=HF_DATASET_REPO_ID,
@@ -29,4 +38,5 @@ def ensure_test_data_downloaded(force: bool = False) -> Path:
         local_dir=str(TEST_DATA_DIR),
         force_download=force,
     )
+    revision_marker.write_text(HF_DATASET_REVISION + "\n")
     return TEST_DATA_DIR


### PR DESCRIPTION
## What

`ensure_test_data_downloaded()` skips the download whenever `tests/data` is non-empty, so checkouts that predate a `HF_DATASET_REVISION` bump silently keep testing against stale groundtruth.

After #310 bumped the dataset revision, any pre-existing clone fails `test_reference_documents_from_filenames` with phantom text mismatches — e.g. `type3_fonts.pdf` asserting `CongEEict` (old groundtruth) against `Conflict` (current parser output) — which are easy to misattribute to local changes. CI is unaffected (fresh checkout every run), so the failure only bites contributors.

## How

Record the synced revision in a `tests/data/.hf_revision` marker and re-run `snapshot_download()` when the marker is missing or differs from the pinned revision. Since `snapshot_download` is incremental against the HF cache, an up-to-date checkout only pays for changed files; existing clones without the marker re-sync once (~seconds when files are already current).

The marker lives inside `tests/data/`, which is already gitignored.

## Verified

- No marker (existing clone): incremental re-sync, marker written with the pinned revision
- Marker matches: instant skip, no network
- Stale marker: re-sync triggered, marker updated
- `force=True` path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)