### PR TITLE
fix: make Blend2D font fallback portable across distros

### DIFF
--- a/src/render/blend2d_font_resolver.h
+++ b/src/render/blend2d_font_resolver.h
@@ -10,6 +10,8 @@
 #endif
 #include <loguru.hpp>
 
+#include <resources.h>
+
 #include <algorithm>
 #include <array>
 #include <cctype>
@@ -141,6 +143,12 @@ namespace pdflib
                                 const std::filesystem::path& suffix = {});
     static std::vector<std::filesystem::path> system_font_directories();
     static std::vector<std::filesystem::path> fallback_font_candidates();
+    static bool is_font_file(const std::filesystem::path& p);
+    static void scan_for_fallback_fonts(std::vector<std::filesystem::path>& paths);
+    // Latin fallbacks cannot draw CJK (.notdef / "tofu"); detect CJK requests
+    // so the resolver can prefer a CJK-capable face.
+    static bool is_cjk_font_request(const std::string& name);
+    static std::vector<std::filesystem::path> cjk_fallback_candidates();
 
     static std::string bl_string_to_std(const BLString& s);
     static std::string font_ref_key(const font_face_ref& ref);
@@ -164,6 +172,7 @@ namespace pdflib
       const std::vector<font_face_ref>& refs,
       const font_request& request) const;
     std::optional<font_face_ref> find_first_existing_fallback() const;
+    std::optional<font_face_ref> find_first_existing_cjk_fallback() const;
     std::optional<font_face_ref> fuzzy_find_font(const font_request& request,
                                                  float font_similarity_cutoff) const;
 
@@ -173,6 +182,7 @@ namespace pdflib
     std::unordered_map<std::string, std::vector<font_face_ref>> name_index_;
     std::unordered_map<std::string, indexed_font_face> face_metadata_;
     std::vector<std::filesystem::path> fallback_candidates_;
+    std::vector<std::filesystem::path> cjk_candidates_;
 
     mutable std::shared_mutex match_cache_mutex_;
     std::unordered_map<match_cache_key,
@@ -226,9 +236,32 @@ namespace pdflib
     if (not font_ref.has_value() or font_ref->path.empty())
       {
         warm();
-        LOG_S(WARNING) << "blend2d font resolver: using fallback font"
-                       << " selected_key=`" << cache_key << "`";
-        font_ref = find_first_existing_fallback();
+        // Prefer a CJK-capable face before the Latin fallback (.notdef boxes).
+        if (is_cjk_font_request(cache_key) or is_cjk_font_request(font_name)
+            or is_cjk_font_request(base_font))
+          {
+            font_ref = find_first_existing_cjk_fallback();
+            if (font_ref.has_value() and not font_ref->path.empty())
+              {
+                LOG_S(WARNING) << "blend2d font resolver: using CJK fallback font"
+                               << " selected_key=`" << cache_key << "`"
+                               << " path=`" << font_ref->path << "`";
+              }
+            else
+              {
+                LOG_S(WARNING) << "blend2d font resolver: CJK request but no CJK-capable"
+                               << " font installed; glyphs will render as .notdef boxes."
+                               << " Install e.g. google-noto-sans-cjk-fonts, or set"
+                               << " DOCLING_PARSE_CJK_FALLBACK_FONT."
+                               << " selected_key=`" << cache_key << "`";
+              }
+          }
+        if (not font_ref.has_value() or font_ref->path.empty())
+          {
+            LOG_S(WARNING) << "blend2d font resolver: using fallback font"
+                           << " selected_key=`" << cache_key << "`";
+            font_ref = find_first_existing_fallback();
+          }
       }
 
     if (not font_ref.has_value() or font_ref->path.empty())
@@ -458,6 +491,8 @@ namespace pdflib
 
 #if defined(_WIN32)
     append_env_path(dirs, "WINDIR", "Fonts");
+    // SystemRoot covers stripped environments where WINDIR is unset.
+    append_env_path(dirs, "SystemRoot", "Fonts");
     append_env_path(dirs, "LOCALAPPDATA", std::filesystem::path("Microsoft") / "Windows" / "Fonts");
 #elif defined(__APPLE__)
     dirs.emplace_back("/System/Library/Fonts");
@@ -472,28 +507,244 @@ namespace pdflib
     append_env_path(dirs, "HOME", ".fonts");
 #endif
 
+    // Package-shipped fonts last so a real system font of the same name wins,
+    // while still allowing NAME matching (e.g. Times -> Liberation Serif).
+    {
+      std::error_code ec;
+      const std::filesystem::path bundled =
+        resource_utils::get_resources_dir(false) / "fonts" / "fallback";
+      if (std::filesystem::is_directory(bundled, ec)) { dirs.push_back(bundled); }
+    }
+
     return dirs;
   }
 
   inline std::vector<std::filesystem::path> blend2d_font_resolver::fallback_font_candidates()
   {
-    std::vector<std::filesystem::path> paths;
+    // Portable fallback order: env override, package-shipped fonts, well-known
+    // paths per OS/distro, then a bounded scan of system_font_directories().
+    // Hardcoding only Debian layout left RHEL-family hosts with outline boxes.
+    namespace fs = std::filesystem;
+    std::vector<fs::path> paths;
+
+    if (auto override_path = getenv_string("DOCLING_PARSE_FALLBACK_FONT"))
+      {
+        paths.emplace_back(*override_path);
+      }
+
+    // Bundled fonts: sans before serif before mono (not alphabetical), so a
+    // failed name match does not substitute LiberationMono for proportional text.
+    {
+      std::error_code ec;
+      const fs::path bundled =
+        resource_utils::get_resources_dir(false) / "fonts" / "fallback";
+      if (fs::is_directory(bundled, ec))
+        {
+          std::vector<fs::path> found;
+          for (const auto& entry : fs::directory_iterator(bundled, ec))
+            {
+              if (is_font_file(entry.path())) { found.push_back(entry.path()); }
+            }
+          std::sort(found.begin(), found.end());
+
+          auto rank = [](const fs::path& p)
+          {
+            std::string s = p.stem().string();
+            std::transform(s.begin(), s.end(), s.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            if (s.find("mono") != std::string::npos) { return 2; }
+            if (s.find("serif") != std::string::npos) { return 1; }
+            return 0;  // sans / everything else
+          };
+          std::stable_sort(found.begin(), found.end(),
+                           [&rank](const fs::path& a, const fs::path& b)
+                           { return rank(a) < rank(b); });
+          paths.insert(paths.end(), found.begin(), found.end());
+        }
+    }
 
 #if defined(_WIN32)
-    append_env_path(paths, "WINDIR", std::filesystem::path("Fonts") / "arial.ttf");
-    append_env_path(paths, "WINDIR", std::filesystem::path("Fonts") / "times.ttf");
-    append_env_path(paths, "WINDIR", std::filesystem::path("Fonts") / "cour.ttf");
+    for (const char* env : {"WINDIR", "SystemRoot"})
+      {
+        for (const char* name : {"arial.ttf", "segoeui.ttf", "calibri.ttf",
+                                 "tahoma.ttf", "verdana.ttf", "times.ttf", "cour.ttf"})
+          {
+            append_env_path(paths, env, fs::path("Fonts") / name);
+          }
+      }
 #elif defined(__APPLE__)
     paths.emplace_back("/System/Library/Fonts/Helvetica.ttc");
     paths.emplace_back("/System/Library/Fonts/Supplemental/Arial.ttf");
     paths.emplace_back("/Library/Fonts/Arial.ttf");
+    paths.emplace_back("/System/Library/Fonts/SFNS.ttf");
 #else
+    // Debian / Ubuntu
     paths.emplace_back("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf");
     paths.emplace_back("/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf");
+    paths.emplace_back("/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf");
     paths.emplace_back("/usr/share/fonts/truetype/freefont/FreeSans.ttf");
+    paths.emplace_back("/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf");
+    // RHEL / Fedora / CentOS (fonts live under per-package directories)
+    paths.emplace_back("/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf");
+    paths.emplace_back("/usr/share/fonts/dejavu/DejaVuSans.ttf");
+    paths.emplace_back("/usr/share/fonts/liberation-fonts/LiberationSans-Regular.ttf");
+    paths.emplace_back("/usr/share/fonts/liberation-sans/LiberationSans-Regular.ttf");
+    paths.emplace_back("/usr/share/fonts/google-noto/NotoSans-Regular.ttf");
+    // Arch
+    paths.emplace_back("/usr/share/fonts/TTF/DejaVuSans.ttf");
+    paths.emplace_back("/usr/share/fonts/TTF/LiberationSans-Regular.ttf");
+    // openSUSE
+    paths.emplace_back("/usr/share/fonts/truetype/DejaVuSans.ttf");
+    // Alpine
+    paths.emplace_back("/usr/share/fonts/ttf-dejavu/DejaVuSans.ttf");
 #endif
 
+    // Bounded scan for unusual layouts; last resort is any font file found.
+    scan_for_fallback_fonts(paths);
+
     return paths;
+  }
+
+  inline bool blend2d_font_resolver::is_cjk_font_request(const std::string& name)
+  {
+    // Non-ASCII names (e.g. Shift-JIS MS PGothic) or known CJK family tokens.
+    for (unsigned char c : name)
+      {
+        if (c >= 0x80) { return true; }
+      }
+
+    std::string s;
+    s.reserve(name.size());
+    for (char c : name)
+      {
+        if (std::isalnum(static_cast<unsigned char>(c)))
+          {
+            s.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+          }
+      }
+
+    static const std::array<const char*, 24> tokens = {
+      "mincho", "gothic", "meiryo", "yugothic", "yumincho", "hiragino",
+      "simsun", "simhei", "simkai", "nsimsun", "fangsong", "kaiti", "songti",
+      "heiti", "msyahei", "msyh", "msung", "mingliu", "pmingliu", "batang",
+      "gulim", "dotum", "malgun", "nanum",
+    };
+    for (const char* t : tokens)
+      {
+        if (s.find(t) != std::string::npos) { return true; }
+      }
+    return false;
+  }
+
+  inline std::vector<std::filesystem::path> blend2d_font_resolver::cjk_fallback_candidates()
+  {
+    namespace fs = std::filesystem;
+    std::vector<fs::path> paths;
+
+    if (auto override_path = getenv_string("DOCLING_PARSE_CJK_FALLBACK_FONT"))
+      {
+        paths.emplace_back(*override_path);
+      }
+
+    // Filename stems with CJK coverage, best first.
+    static const std::array<const char*, 12> wanted = {
+      "notosanscjk", "notoserifcjk", "notosanscjkjp", "notosanscjksc",
+      "sourcehansans", "sourcehanserif", "droidsansfallback", "wqy-zenhei",
+      "wqy-microhei", "arphic", "ipagp", "ipag",
+    };
+
+    constexpr std::size_t max_entries = 20000;
+    std::size_t seen = 0;
+    std::vector<fs::path> ranked(wanted.size());
+
+    for (const auto& dir : system_font_directories())
+      {
+        std::error_code ec;
+        if (not fs::is_directory(dir, ec)) { continue; }
+        fs::recursive_directory_iterator it(
+          dir, fs::directory_options::skip_permission_denied, ec);
+        fs::recursive_directory_iterator end;
+        for (; it != end and seen < max_entries; it.increment(ec))
+          {
+            if (ec) { break; }
+            ++seen;
+            const fs::path& p = it->path();
+            if (not is_font_file(p)) { continue; }
+            std::string stem = p.stem().string();
+            std::transform(stem.begin(), stem.end(), stem.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            for (std::size_t i = 0; i < wanted.size(); i++)
+              {
+                if (ranked[i].empty() and stem.find(wanted[i]) != std::string::npos)
+                  {
+                    ranked[i] = p;
+                  }
+              }
+          }
+        if (seen >= max_entries) { break; }
+      }
+
+    for (const auto& p : ranked)
+      {
+        if (not p.empty()) { paths.push_back(p); }
+      }
+    return paths;
+  }
+
+  inline bool blend2d_font_resolver::is_font_file(const std::filesystem::path& p)
+  {
+    const std::string ext = normalize_font_name(p.extension().string());
+    return ext == "ttf" or ext == "otf" or ext == "ttc";
+  }
+
+  inline void blend2d_font_resolver::scan_for_fallback_fonts(
+                                                             std::vector<std::filesystem::path>& paths)
+  {
+    namespace fs = std::filesystem;
+
+    // Ubiquitous faces, best first; match against lowercased filename stems.
+    static const std::array<const char*, 10> preferred = {
+      "liberationsans-regular", "dejavusans", "notosans-regular",
+      "freesans", "arial", "helvetica", "cantarell-regular",
+      "opensans-regular", "roboto-regular", "ubuntu-r",
+    };
+
+    constexpr std::size_t max_entries = 20000;
+    std::size_t seen = 0;
+
+    std::vector<fs::path> ranked(preferred.size());
+    fs::path any_font;
+
+    for (const auto& dir : system_font_directories())
+      {
+        std::error_code ec;
+        if (not fs::is_directory(dir, ec)) { continue; }
+        fs::recursive_directory_iterator it(
+          dir, fs::directory_options::skip_permission_denied, ec);
+        fs::recursive_directory_iterator end;
+        for (; it != end and seen < max_entries; it.increment(ec))
+          {
+            if (ec) { break; }
+            ++seen;
+            const fs::path& p = it->path();
+            if (not is_font_file(p)) { continue; }
+            if (any_font.empty()) { any_font = p; }
+            std::string stem = p.stem().string();
+            std::transform(stem.begin(), stem.end(), stem.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            for (std::size_t i = 0; i < preferred.size(); i++)
+              {
+                if (ranked[i].empty() and stem == preferred[i]) { ranked[i] = p; }
+              }
+          }
+        if (seen >= max_entries) { break; }
+      }
+
+    for (const auto& p : ranked)
+      {
+        if (not p.empty()) { paths.push_back(p); }
+      }
+    if (not any_font.empty()) { paths.push_back(any_font); }
   }
 
   inline std::string blend2d_font_resolver::bl_string_to_std(const BLString& s)
@@ -861,6 +1112,7 @@ namespace pdflib
     namespace fs = std::filesystem;
     const std::vector<fs::path> font_dirs = system_font_directories();
     fallback_candidates_ = fallback_font_candidates();
+    cjk_candidates_ = cjk_fallback_candidates();
 
     LOG_S(INFO) << "blend2d font resolver: scanning font directories";
     for (const auto& dir : font_dirs)
@@ -892,8 +1144,7 @@ namespace pdflib
               }
 
             const auto p = it->path();
-            const std::string ext = normalize_font_name(p.extension().string());
-            if (ext == "ttf" or ext == "otf" or ext == "ttc")
+            if (is_font_file(p))
               {
                 index_font_file(p, discovery_order);
               }
@@ -1123,6 +1374,30 @@ namespace pdflib
     namespace fs = std::filesystem;
 
     for (const auto& fallback : fallback_candidates_)
+      {
+        if (fs::exists(fallback))
+          {
+            const std::string norm_path = fallback.string();
+            for (const auto& [key, face] : face_metadata_)
+              {
+                if (face.ref.path == norm_path)
+                  {
+                    return face.ref;
+                  }
+              }
+            return font_face_ref{norm_path, 0};
+          }
+      }
+
+    return std::nullopt;
+  }
+
+  inline std::optional<blend2d_font_resolver::font_face_ref>
+  blend2d_font_resolver::find_first_existing_cjk_fallback() const
+  {
+    namespace fs = std::filesystem;
+
+    for (const auto& fallback : cjk_candidates_)
       {
         if (fs::exists(fallback))
           {


### PR DESCRIPTION
## Summary
- Broaden Blend2D system/fallback font discovery beyond Debian-only paths so non-embedded PDF fonts render on RHEL/Fedora and other distro layouts (well-known paths + bounded directory scan).
- Support `DOCLING_PARSE_FALLBACK_FONT` / `DOCLING_PARSE_CJK_FALLBACK_FONT` overrides, and optionally pick up fonts from `pdf_resources/fonts/fallback/` if present.
- Detect CJK font requests (non-ASCII names or known family tokens) and prefer a CJK-capable system face before the Latin fallback (avoids `.notdef` boxes when Noto CJK etc. are installed).
