### PR TITLE
feat(render): add tiling patterns, clipping, Type3 glyphs and CID text

### DIFF
--- a/src/parse.h
+++ b/src/parse.h
@@ -106,6 +106,8 @@
 
 #include <parse/pdf_resources/page_shading.h>
 #include <parse/pdf_resources/page_shadings.h>
+#include <parse/pdf_resources/page_pattern.h>
+#include <parse/pdf_resources/page_patterns.h>
 
 #include <parse/pdf_resources/page_xobject_image.h>
 #include <parse/pdf_resources/page_xobject_form.h>

--- a/src/parse/page_items/render_instructions.h
+++ b/src/parse/page_items/render_instructions.h
@@ -269,6 +269,11 @@ namespace pdflib
     // Optional embedded font program shared by all text instructions of one
     // PDF font resource. Set after construction to keep the (already long)
     // constructor signature stable; may be null.
+    // /Subtype /Type3: glyphs are content-stream procedures, so no system face
+    // can stand in for this font.
+    void set_is_type3(bool v) { is_type3_ = v; }
+    bool is_type3() const { return is_type3_; }
+
     void set_embedded_font(std::shared_ptr<const embedded_font_blob> blob);
     const std::shared_ptr<const embedded_font_blob>& get_embedded_font() const;
     bool has_embedded_font() const;
@@ -359,6 +364,7 @@ namespace pdflib
     const double g_x1_;
     const double g_y1_;
 
+    bool is_type3_ = false;
     std::shared_ptr<const embedded_font_blob> embedded_font_;
     int64_t char_code_ = -1;
     std::string glyph_name_;

--- a/src/parse/pdf_decoders/page.h
+++ b/src/parse/pdf_decoders/page.h
@@ -98,6 +98,7 @@ namespace pdflib
     void decode_colorspaces();
 
     void decode_shadings();
+    void decode_patterns();
 
     void decode_xobjects();
 
@@ -152,6 +153,7 @@ namespace pdflib
     QPDFObjectHandle qpdf_fonts;
     QPDFObjectHandle qpdf_colorspaces;
     QPDFObjectHandle qpdf_shadings;
+    QPDFObjectHandle qpdf_patterns;
     QPDFObjectHandle qpdf_xobjects;
 
     // Debug-only: populated when config.populate_json_objects is true
@@ -183,6 +185,7 @@ namespace pdflib
     std::shared_ptr<pdf_resource<PAGE_FONTS> > page_fonts;
     std::shared_ptr<pdf_resource<PAGE_COLORSPACES> > page_colorspaces;
     std::shared_ptr<pdf_resource<PAGE_SHADINGS> > page_shadings;
+    std::shared_ptr<pdf_resource<PAGE_PATTERNS> > page_patterns;
     std::shared_ptr<pdf_resource<PAGE_XOBJECTS> > page_xobjects;
 
     decode_config page_config;  // saved at the start of decode_page for use in widget handlers
@@ -207,6 +210,7 @@ namespace pdflib
     page_fonts(std::make_shared<pdf_resource<PAGE_FONTS>>()),
     page_colorspaces(std::make_shared<pdf_resource<PAGE_COLORSPACES>>()),
     page_shadings(std::make_shared<pdf_resource<PAGE_SHADINGS>>()),
+    page_patterns(std::make_shared<pdf_resource<PAGE_PATTERNS>>()),
     page_xobjects(std::make_shared<pdf_resource<PAGE_XOBJECTS>>())
   {}
 
@@ -225,6 +229,7 @@ namespace pdflib
     page_fonts(std::make_shared<pdf_resource<PAGE_FONTS>>()),
     page_colorspaces(std::make_shared<pdf_resource<PAGE_COLORSPACES>>()),
     page_shadings(std::make_shared<pdf_resource<PAGE_SHADINGS>>()),
+    page_patterns(std::make_shared<pdf_resource<PAGE_PATTERNS>>()),
     page_xobjects(std::make_shared<pdf_resource<PAGE_XOBJECTS>>())
   {
     std::string description = "thread-safe page " + std::to_string(orig_page_num);
@@ -1038,6 +1043,12 @@ namespace pdflib
         qpdf_shadings = qpdf_resources.getKey("/Shading");
         decode_shadings();
       }
+
+    if(qpdf_resources.hasKey("/Pattern"))
+      {
+        qpdf_patterns = qpdf_resources.getKey("/Pattern");
+        decode_patterns();
+      }
     else
       {
         LOG_S(INFO) << "page does not have any shadings!";
@@ -1082,6 +1093,13 @@ namespace pdflib
     page_shadings->set(qpdf_shadings);
   }
 
+  void pdf_decoder<PAGE>::decode_patterns()
+  {
+    LOG_S(INFO) << __FUNCTION__;
+
+    page_patterns->set(qpdf_patterns);
+  }
+
   void pdf_decoder<PAGE>::decode_xobjects()
   {
     LOG_S(INFO) << __FUNCTION__;
@@ -1106,6 +1124,7 @@ namespace pdflib
                                        page_grphs,
                                        page_colorspaces,
                                        page_shadings,
+                                       page_patterns,
                                        page_xobjects,
                                        instructions,
                                        timings);
@@ -1705,6 +1724,7 @@ namespace pdflib
     auto ap_colorspaces = std::make_shared<pdf_resource<PAGE_COLORSPACES>>(page_colorspaces);
     auto ap_grphs = std::make_shared<pdf_resource<PAGE_GRPHS>>(page_grphs);
     auto ap_shadings = std::make_shared<pdf_resource<PAGE_SHADINGS>>(page_shadings);
+    auto ap_patterns = std::make_shared<pdf_resource<PAGE_PATTERNS>>(page_patterns);
     auto ap_dict = ap_stream.getDict();
     if(ap_dict.isDictionary() and ap_dict.hasKey("/Resources"))
       {
@@ -1728,6 +1748,12 @@ namespace pdflib
           {
             auto ap_shading_dict = ap_resources.getKey("/Shading");
             ap_shadings->set(ap_shading_dict);
+
+            if(ap_resources.hasKey("/Pattern"))
+              {
+                auto ap_pattern_dict = ap_resources.getKey("/Pattern");
+                ap_patterns->set(ap_pattern_dict);
+              }
           }
       }
 
@@ -1748,6 +1774,7 @@ namespace pdflib
                                        ap_grphs,
                                        ap_colorspaces,
                                        ap_shadings,
+                                       ap_patterns,
                                        page_xobjects,
                                        ap_instructions,
                                        timings);

--- a/src/parse/pdf_decoders/stream.h
+++ b/src/parse/pdf_decoders/stream.h
@@ -23,6 +23,7 @@ namespace pdflib
                 std::shared_ptr<pdf_resource<PAGE_GRPHS>>       page_grphs_,
                 std::shared_ptr<pdf_resource<PAGE_COLORSPACES>> page_colorspaces_,
                 std::shared_ptr<pdf_resource<PAGE_SHADINGS>>    page_shadings_,
+                std::shared_ptr<pdf_resource<PAGE_PATTERNS>>   page_patterns_,
                 std::shared_ptr<pdf_resource<PAGE_XOBJECTS>>    page_xobjects_,
 
                 pdf_render_instructions& instructions,
@@ -82,6 +83,10 @@ namespace pdflib
     // instruction that covers the current clip region.
     void do_shading(const std::string& sh_name);
 
+    // `scn` naming a tiling pattern: replay the pattern cell across the page
+    // box. Returns false when the pattern cannot be resolved or painted.
+    bool do_pattern_fill(const std::string& pattern_name);
+
     // marked-content (BMC/BDC ... EMC) tracking, used to honor /ActualText
     // replacement text (PDF 32000-1, section 14.9.4)
     struct marked_content_entry
@@ -125,6 +130,14 @@ namespace pdflib
     std::shared_ptr<pdf_resource<PAGE_GRPHS>>       page_grphs;
     std::shared_ptr<pdf_resource<PAGE_COLORSPACES>> page_colorspaces;
     std::shared_ptr<pdf_resource<PAGE_SHADINGS>>    page_shadings;
+    std::shared_ptr<pdf_resource<PAGE_PATTERNS>>   page_patterns;
+
+    // CTM in force when this stream began. Pattern space is defined against
+    // the default space of the page, not against the CTM at the fill, so a
+    // pattern needs this rather than the current matrix.
+    std::array<double, 9> base_ctm_ = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+    bool base_ctm_valid_ = false;
+
     std::shared_ptr<pdf_resource<PAGE_XOBJECTS>>    page_xobjects;
 
     pdf_render_instructions& instructions;
@@ -158,6 +171,7 @@ namespace pdflib
                                    std::shared_ptr<pdf_resource<PAGE_GRPHS>>       page_grphs_,
                                    std::shared_ptr<pdf_resource<PAGE_COLORSPACES>> page_colorspaces_,
                                    std::shared_ptr<pdf_resource<PAGE_SHADINGS>>    page_shadings_,
+                                   std::shared_ptr<pdf_resource<PAGE_PATTERNS>>   page_patterns_,
 
                                    std::shared_ptr<pdf_resource<PAGE_XOBJECTS>>    page_xobjects_,
 
@@ -175,6 +189,7 @@ namespace pdflib
     page_grphs(page_grphs_),
     page_colorspaces(page_colorspaces_),
     page_shadings(page_shadings_),
+    page_patterns(page_patterns_),
 
     page_xobjects(page_xobjects_),
 
@@ -296,6 +311,11 @@ namespace pdflib
   void pdf_decoder<STREAM>::interprete(std::vector<qpdf_stream_instruction>& stream_,
                                        std::vector<qpdf_stream_instruction>& parameters_)
   {
+    if(not base_ctm_valid_ and stack.size() > 0)
+      {
+        base_ctm_ = current_graphic_state().get_trafo_matrix();
+        base_ctm_valid_ = true;
+      }
     LOG_S(INFO) << __FUNCTION__;
 
     stream = stream_;
@@ -625,6 +645,195 @@ namespace pdflib
   // 8.7.4.5: `sh` paints the named shading over the whole current clip
   // region, taking its colours from the shading's own colour space and
   // function rather than from the current fill colour.
+  bool pdf_decoder<STREAM>::do_pattern_fill(const std::string& pattern_name)
+  {
+    if(not page_patterns or page_patterns->count(pattern_name) == 0)
+      {
+        return false;
+      }
+
+    pdf_resource<PAGE_PATTERN>& pattern = (*page_patterns)[pattern_name];
+    if(not pattern.is_valid() or pattern.get_pattern_type() != 1)
+      {
+        // Shading patterns (type 2) are not painted here yet.
+        return false;
+      }
+
+    std::vector<qpdf_stream_instruction> cell = pattern.parse_stream();
+    if(cell.empty())
+      {
+        return false;
+      }
+
+    const std::array<double, 9>& want = pattern.get_matrix();
+    const std::array<double, 9>& cur  = current_graphic_state().get_trafo_matrix();
+
+    // No base recorded yet (a pattern used before any q): the current matrix
+    // is the best available stand-in and is usually identical to it.
+    if(not base_ctm_valid_)
+      {
+        base_ctm_ = cur;
+        base_ctm_valid_ = true;
+      }
+
+    // inverse of the current (affine) CTM
+    const double a = cur[0], b = cur[1], c = cur[3], d = cur[4];
+    const double e = cur[6], f = cur[7];
+    const double det = a * d - b * c;
+    if(std::abs(det) < 1e-12) { return false; }
+
+    const std::array<double, 9> inv = {
+       d / det, -b / det, 0.0,
+      -c / det,  a / det, 0.0,
+      (c * f - d * e) / det, (b * e - a * f) / det, 1.0
+    };
+
+    auto mul = [](const std::array<double, 9>& m, const std::array<double, 9>& n)
+    {
+      std::array<double, 9> r = {0, 0, 0, 0, 0, 0, 0, 0, 1};
+      r[0] = m[0]*n[0] + m[1]*n[3];
+      r[1] = m[0]*n[1] + m[1]*n[4];
+      r[3] = m[3]*n[0] + m[4]*n[3];
+      r[4] = m[3]*n[1] + m[4]*n[4];
+      r[6] = m[6]*n[0] + m[7]*n[3] + n[6];
+      r[7] = m[6]*n[1] + m[7]*n[4] + n[7];
+      return r;
+    };
+
+    // Pattern space -> device is Matrix x base. cm() post-multiplies by the
+    // CURRENT matrix, so hand it Matrix x base x inverse(current), which
+    // composes back to exactly that. Dropping the base placed the cell in raw
+    // pattern coordinates and put it off the top of the page.
+    const std::array<double, 9> to_pattern = mul(mul(want, base_ctm_), inv);
+
+    // How many cells to lay down: cover the page box in pattern space.
+    const std::array<double, 4> page_box = page_dimension.get_crop_bbox();
+    double xs = pattern.get_x_step();
+    double ys = pattern.get_y_step();
+    if(xs <= 0.0 or ys <= 0.0) { xs = ys = 0.0; }
+
+    // Which cells of the lattice actually touch the page? Take the page box
+    // back through the pattern transform and read off the index range. The
+    // lattice extends in BOTH directions: this pattern's origin sits a full
+    // page above the page box, so the cell that covers it is at index -1 and
+    // a 0..n loop painted nothing but off-page copies.
+    int ix0 = 0, ix1 = 0, iy0 = 0, iy1 = 0;
+    if(xs > 0.0 and ys > 0.0)
+      {
+        const std::array<double, 9> pat = mul(want, base_ctm_);
+        const double pa = pat[0], pb = pat[1], pc = pat[3], pd = pat[4];
+        const double pe = pat[6], pf = pat[7];
+        const double pdet = pa * pd - pb * pc;
+        if(std::abs(pdet) > 1e-12)
+          {
+            auto to_pattern_space = [&](double X, double Y, double& u, double& v)
+            {
+              const double x = X - pe, y = Y - pf;
+              u = ( x * pd - y * pc) / pdet;
+              v = (-x * pb + y * pa) / pdet;
+            };
+
+            const double cx[4] = {page_box[0], page_box[2], page_box[2], page_box[0]};
+            const double cy[4] = {page_box[1], page_box[1], page_box[3], page_box[3]};
+            double umin = 0, umax = 0, vmin = 0, vmax = 0;
+            for(int i = 0; i < 4; i++)
+              {
+                double u, v;
+                to_pattern_space(cx[i], cy[i], u, v);
+                if(i == 0) { umin = umax = u; vmin = vmax = v; }
+                umin = std::min(umin, u); umax = std::max(umax, u);
+                vmin = std::min(vmin, v); vmax = std::max(vmax, v);
+              }
+
+            const double bx = pattern.has_bbox() ? pattern.get_bbox()[0] : 0.0;
+            const double by = pattern.has_bbox() ? pattern.get_bbox()[1] : 0.0;
+            ix0 = static_cast<int>(std::floor((umin - bx) / xs));
+            ix1 = static_cast<int>(std::ceil ((umax - bx) / xs));
+            iy0 = static_cast<int>(std::floor((vmin - by) / ys));
+            iy1 = static_cast<int>(std::ceil ((vmax - by) / ys));
+          }
+      }
+
+    // Bounded: a degenerate step must not spawn a lattice of thousands.
+    constexpr int max_span = 16;
+    if(ix1 - ix0 > max_span) { ix1 = ix0 + max_span; }
+    if(iy1 - iy0 > max_span) { iy1 = iy0 + max_span; }
+
+    LOG_S(INFO) << "painting tiling pattern `" << pattern_name << "` cells x["
+                << ix0 << ", " << ix1 << "] y[" << iy0 << ", " << iy1 << "]";
+
+    auto page_fonts_       = std::make_shared<pdf_resource<PAGE_FONTS>>(page_fonts);
+    auto page_grphs_       = std::make_shared<pdf_resource<PAGE_GRPHS>>(page_grphs);
+    auto page_colorspaces_ = std::make_shared<pdf_resource<PAGE_COLORSPACES>>(page_colorspaces);
+    auto page_shadings_    = std::make_shared<pdf_resource<PAGE_SHADINGS>>(page_shadings);
+    auto page_patterns_    = std::make_shared<pdf_resource<PAGE_PATTERNS>>(page_patterns);
+    auto page_xobjects_    = std::make_shared<pdf_resource<PAGE_XOBJECTS>>(page_xobjects);
+
+    if(pattern.has_resources())
+      {
+        QPDFObjectHandle res = pattern.get_resources();
+        if(res.hasKey("/Font"))      { QPDFObjectHandle o = res.getKey("/Font");      page_fonts_->set(o, timings); }
+        if(res.hasKey("/ExtGState")) { QPDFObjectHandle o = res.getKey("/ExtGState"); page_grphs_->set(o, timings); }
+        if(res.hasKey("/ColorSpace")){ QPDFObjectHandle o = res.getKey("/ColorSpace");page_colorspaces_->set(o); }
+        if(res.hasKey("/Shading"))   { QPDFObjectHandle o = res.getKey("/Shading");   page_shadings_->set(o); }
+        if(res.hasKey("/Pattern"))   { QPDFObjectHandle o = res.getKey("/Pattern");   page_patterns_->set(o); }
+        if(res.hasKey("/XObject"))   { QPDFObjectHandle o = res.getKey("/XObject");   page_xobjects_->set(o, timings); }
+      }
+
+    bool painted = false;
+
+    for(int iy = iy0; iy <= iy1; iy++)
+      {
+        for(int ix = ix0; ix <= ix1; ix++)
+          {
+            std::array<double, 9> step = {1, 0, 0, 0, 1, 0,
+                                          ix * xs, iy * ys, 1};
+            std::array<double, 9> place = mul(step, to_pattern);
+
+            this->q();
+            const std::array<double, 6> place6 = {place[0], place[1],
+                                                  place[3], place[4],
+                                                  place[6], place[7]};
+            current_global_state().cm(place6);
+
+            // The cell replays on a clean path. The state q() pushed still
+            // carries the path currently being filled with this pattern, and
+            // the cell's own painting operator would paint that path too --
+            // the whole fill region came out flooded in the cell's colour,
+            // with the tiles only visible outside it. Q() restores it.
+            std::vector<qpdf_stream_instruction> no_parameters;
+            current_shape_state().n(no_parameters);
+
+            pdf_decoder<STREAM> cell_stream(config,
+                                            page_dimension,
+                                            page_cells,
+                                            page_shapes,
+                                            page_images,
+                                            page_fonts_,
+                                            page_grphs_,
+                                            page_colorspaces_,
+                                            page_shadings_,
+                                            page_patterns_,
+                                            page_xobjects_,
+                                            instructions,
+                                            timings);
+
+            bool updated_stack = cell_stream.update_stack(stack, stack_count);
+
+            std::vector<qpdf_stream_instruction> parameters;
+            std::vector<qpdf_stream_instruction> insts = cell;
+            cell_stream.interprete(insts, parameters);
+
+            if(updated_stack) { cell_stream.Q(); }
+
+            this->Q();
+            painted = true;
+          }
+      }
+
+    return painted;
+  }
+
   void pdf_decoder<STREAM>::do_shading(const std::string& sh_name)
   {
     // Without shape tracking there is no clip path to bound the shading, and
@@ -744,6 +953,7 @@ namespace pdflib
     auto page_grphs_       = std::make_shared<pdf_resource<PAGE_GRPHS>>(page_grphs);
     auto page_colorspaces_ = std::make_shared<pdf_resource<PAGE_COLORSPACES>>(page_colorspaces);
     auto page_shadings_    = std::make_shared<pdf_resource<PAGE_SHADINGS>>(page_shadings);
+    auto page_patterns_    = std::make_shared<pdf_resource<PAGE_PATTERNS>>(page_patterns);
     auto page_xobjects_    = std::make_shared<pdf_resource<PAGE_XOBJECTS>>(page_xobjects);
 
     // parse the resources of the xobject into the child resources
@@ -772,6 +982,12 @@ namespace pdflib
         {
           QPDFObjectHandle xobj_shadings = xobj.get_shadings();
           page_shadings_->set(xobj_shadings);
+        }
+
+      if(xobj.has_patterns())
+        {
+          QPDFObjectHandle xobj_patterns = xobj.get_patterns();
+          page_patterns_->set(xobj_patterns);
         }
 
       if(xobj.has_xobjects())
@@ -816,6 +1032,7 @@ namespace pdflib
                                        page_grphs_,
                                        page_colorspaces_,
                                        page_shadings_,
+                                       page_patterns_,
                                        page_xobjects_,
 
                                        instructions,
@@ -1527,6 +1744,11 @@ namespace pdflib
       case pdf_operator::f:
         {
           LOG_S(INFO) << "executing " << to_string(name);
+          if(current_graphic_state().get_fill_is_unresolved_pattern() and
+             not current_graphic_state().get_fill_pattern_name().empty())
+            {
+              do_pattern_fill(current_graphic_state().get_fill_pattern_name());
+            }
           current_shape_state().f(parameters);
         }
         break;
@@ -1541,6 +1763,11 @@ namespace pdflib
       case pdf_operator::fStar:
         {
           LOG_S(INFO) << "executing " << to_string(name);
+          if(current_graphic_state().get_fill_is_unresolved_pattern() and
+             not current_graphic_state().get_fill_pattern_name().empty())
+            {
+              do_pattern_fill(current_graphic_state().get_fill_pattern_name());
+            }
           current_shape_state().fStar(parameters);
         }
         break;

--- a/src/parse/pdf_resource.h
+++ b/src/parse/pdf_resource.h
@@ -18,6 +18,8 @@ namespace pdflib
 
     PAGE_SHADING,
     PAGE_SHADINGS,
+    PAGE_PATTERN,
+    PAGE_PATTERNS,
 
     PAGE_XOBJECT_IMAGE,
     PAGE_XOBJECT_FORM,

--- a/src/parse/pdf_resources/page_font.h
+++ b/src/parse/pdf_resources/page_font.h
@@ -3,6 +3,8 @@
 #ifndef PDF_PAGE_FONT_RESOURCE_H
 #define PDF_PAGE_FONT_RESOURCE_H
 
+#include <parse/utils/ccitt/ccitt_utils.h>
+
 #include <parse/qpdf/qpdf_compat.h>
 
 namespace pdflib
@@ -12,6 +14,35 @@ namespace pdflib
   class pdf_resource<PAGE_FONT>
   {
   public:
+
+    bool is_type3() const { return subtype == TYPE_3; }
+
+    // One Type3 glyph, extracted from its /CharProcs procedure. The dominant
+    // Type3 pattern (TeX / dvipdfm output) draws each glyph as a single inline
+    // 1-bit image mask placed by a `cm`; this captures exactly that shape.
+    // Glyphs whose procedure does not match stay invalid and draw nothing --
+    // preferable to the black placeholder boxes they used to produce.
+    struct type3_glyph
+    {
+      bool valid = false;
+      int w = 0;
+      int h = 0;
+      // 8-bit mask in the renderer's image-mask convention: 0 paints the fill
+      // colour, 255 leaves the page.
+      std::shared_ptr<std::vector<uint8_t> > mask;
+      // Maps the image's unit square into glyph space (the charproc's cm).
+      std::array<double, 6> cm = {1, 0, 0, 1, 0, 0};
+    };
+
+    // /FontMatrix: glyph space -> text space (Type3 only; identity-scaled
+    // 0.001 default matches the spec default for simple fonts).
+    const std::array<double, 6>& get_font_matrix();
+
+    // Lazily extracts and caches the glyph for a character code; nullptr when
+    // the code has no procedure or the procedure is not the inline-mask form.
+    std::shared_ptr<type3_glyph> get_type3_glyph(uint32_t code);
+
+
 
     const static inline std::string RESOURCE_DIR_KEY = "pdf_resource_directory";
     
@@ -86,6 +117,12 @@ namespace pdflib
     std::string get_correct_character(uint32_t c);
     std::string get_character_from_encoding(uint32_t c);
 
+    std::shared_ptr<type3_glyph> parse_type3_charproc(const std::string& src);
+
+    // Charprocs with no inline image: filled paths (re / m l c h f). The
+    // paths are flattened and scanline-rasterised into the mask.
+    std::shared_ptr<type3_glyph> rasterize_type3_vector_charproc(const std::string& src);
+
     void init_encoding();
     void init_subtype();
 
@@ -141,7 +178,13 @@ namespace pdflib
   private:
 
     pdf_timings& timings;
-    
+
+    // /FontMatrix and the Type3 glyphs extracted from /CharProcs, cached per
+    // character code: a charproc is a content stream, so it is parsed once.
+    std::array<double, 6> font_matrix_ = {0.001, 0, 0, 0.001, 0, 0};
+    bool font_matrix_read_ = false;
+    std::unordered_map<uint32_t, std::shared_ptr<type3_glyph> > type3_cache_;
+
     nlohmann::json   json_font;
 
     QPDFObjectHandle qpdf_font;
@@ -1641,7 +1684,14 @@ namespace pdflib
       }
     else
       {
-	default_width = 500;
+        // ISO 32000-1 table 115: /DW defaults to 1000, one full em. Using 500
+        // halves every advance of a CID font that omits it, so its cells come
+        // out half the width of the glyphs actually drawn.
+	default_width = 1000;
+        // /DW belongs to a CID font, and only there does its default stand in
+        // for a missing width. A simple font must keep falling through to its
+        // base-14 metrics, which carry real per-glyph advances.
+	has_default_width = (subtype == TYPE_0);
         LOG_S(WARNING) << "could not find default-width: defaulting to " << default_width;
       }    
   }
@@ -2431,6 +2481,413 @@ namespace pdflib
         diff_initialized = false;
         LOG_S(WARNING) << "could not find differences in /Encoding/Differences";
       }
+  }
+
+  inline const std::array<double, 6>& pdf_resource<PAGE_FONT>::get_font_matrix()
+  {
+    if(not font_matrix_read_)
+      {
+        font_matrix_read_ = true;
+        try
+          {
+            if(qpdf_font.isDictionary() and qpdf_font.hasKey("/FontMatrix") and
+               qpdf_font.getKey("/FontMatrix").isArray() and
+               qpdf_font.getKey("/FontMatrix").getArrayNItems() >= 6)
+              {
+                QPDFObjectHandle fm = qpdf_font.getKey("/FontMatrix");
+                for(int i = 0; i < 6; i++)
+                  {
+                    QPDFObjectHandle v = fm.getArrayItem(i);
+                    if(v.isNumber()) { font_matrix_[i] = v.getNumericValue(); }
+                  }
+              }
+          }
+        catch(const std::exception& e)
+          {
+            LOG_S(WARNING) << "type3: could not read /FontMatrix: " << e.what();
+          }
+      }
+    return font_matrix_;
+  }
+
+  inline std::shared_ptr<pdf_resource<PAGE_FONT>::type3_glyph>
+  pdf_resource<PAGE_FONT>::get_type3_glyph(uint32_t code)
+  {
+    auto cached = type3_cache_.find(code);
+    if(cached != type3_cache_.end()) { return cached->second; }
+
+    std::shared_ptr<type3_glyph> result = nullptr;
+
+    try
+      {
+        const std::string name = get_glyph_name(code);
+        if(not name.empty() and
+           qpdf_font.isDictionary() and qpdf_font.hasKey("/CharProcs") and
+           qpdf_font.getKey("/CharProcs").isDictionary())
+          {
+            QPDFObjectHandle procs = qpdf_font.getKey("/CharProcs");
+            const std::string key = "/" + name;
+            if(procs.hasKey(key) and procs.getKey(key).isStream())
+              {
+                auto buffer = procs.getKey(key).getStreamData();
+                if(buffer and buffer->getSize() > 0)
+                  {
+                    const char* raw = reinterpret_cast<const char*>(buffer->getBuffer());
+                    result = parse_type3_charproc(std::string(raw, buffer->getSize()));
+                  }
+              }
+          }
+      }
+    catch(const std::exception& e)
+      {
+        LOG_S(WARNING) << "type3: charproc extraction failed for code " << code
+                       << ": " << e.what();
+        result = nullptr;
+      }
+
+    type3_cache_.emplace(code, result);
+    return result;
+  }
+
+  inline std::shared_ptr<pdf_resource<PAGE_FONT>::type3_glyph>
+  pdf_resource<PAGE_FONT>::parse_type3_charproc(const std::string& src)
+  {
+    const size_t pos_bi = src.find("BI");
+    if(pos_bi == std::string::npos)
+      {
+        return rasterize_type3_vector_charproc(src);
+      }
+
+    auto glyph = std::make_shared<type3_glyph>();
+
+    // The last `cm` before BI places the image's unit square in glyph space.
+    {
+      std::istringstream is(src.substr(0, pos_bi));
+      std::vector<std::string> toks;
+      std::string t;
+      while(is >> t) { toks.push_back(t); }
+
+      bool found = false;
+      for(size_t i = toks.size(); i-- > 0;)
+        {
+          if(toks[i] == "cm" and i >= 6)
+            {
+              try
+                {
+                  for(int j = 0; j < 6; j++)
+                    {
+                      glyph->cm[j] = utils::numeric::locale_safe_stod(toks[i - 6 + j]);
+                    }
+                  found = true;
+                }
+              catch(const std::exception&) {}
+              break;
+            }
+        }
+      if(not found) { return nullptr; }
+    }
+
+    const size_t pos_id = src.find("ID", pos_bi);
+    if(pos_id == std::string::npos) { return nullptr; }
+
+    // Inline image dictionary between BI and ID. Brackets and dict markers
+    // become spaces and every '/' gets one in front, so "/D[1 0]" and
+    // "/DP<</K -1/Columns 68>>" tokenize cleanly.
+    int W = 0, H = 0, bpc = 1, K = 0;
+    bool is_mask = false, black_is_1 = false, ccitt = false, raw_bits = true;
+    std::vector<double> decode_arr;
+    {
+      std::string dict = src.substr(pos_bi + 2, pos_id - pos_bi - 2);
+      std::string clean;
+      clean.reserve(dict.size() * 2);
+      for(const char c : dict)
+        {
+          if(c == '[' or c == ']' or c == '<' or c == '>') { clean += ' '; continue; }
+          if(c == '/') { clean += ' '; }
+          clean += c;
+        }
+      std::istringstream is(clean);
+      std::vector<std::string> toks;
+      std::string t;
+      while(is >> t) { toks.push_back(t); }
+
+      auto num_after = [&](size_t i, double fallback) -> double
+      {
+        if(i + 1 < toks.size())
+          {
+            try { return utils::numeric::locale_safe_stod(toks[i + 1]); }
+            catch(const std::exception&) {}
+          }
+        return fallback;
+      };
+
+      for(size_t i = 0; i < toks.size(); i++)
+        {
+          const std::string& tok = toks[i];
+          if(tok == "/W" or tok == "/Width")            { W = static_cast<int>(num_after(i, 0)); }
+          else if(tok == "/H" or tok == "/Height")      { H = static_cast<int>(num_after(i, 0)); }
+          else if(tok == "/BPC" or tok == "/BitsPerComponent") { bpc = static_cast<int>(num_after(i, 1)); }
+          else if(tok == "/IM" or tok == "/ImageMask")  { is_mask = (i + 1 < toks.size() and toks[i + 1] == "true"); }
+          else if(tok == "/K")                          { K = static_cast<int>(num_after(i, 0)); }
+          else if(tok == "/BlackIs1")                   { black_is_1 = (i + 1 < toks.size() and toks[i + 1] == "true"); }
+          else if(tok == "/D" or tok == "/Decode")
+            {
+              decode_arr.clear();
+              for(size_t j = i + 1; j < toks.size() and decode_arr.size() < 2; j++)
+                {
+                  try { decode_arr.push_back(utils::numeric::locale_safe_stod(toks[j])); }
+                  catch(const std::exception&) { break; }
+                }
+            }
+          else if(tok == "/F" or tok == "/Filter")
+            {
+              raw_bits = false;
+              if(i + 1 < toks.size() and
+                 (toks[i + 1] == "/CCF" or toks[i + 1] == "/CCITTFaxDecode"))
+                {
+                  ccitt = true;
+                }
+            }
+        }
+    }
+
+    if(W <= 0 or H <= 0 or not is_mask or bpc != 1) { return nullptr; }
+    if(not raw_bits and not ccitt) { return nullptr; }  // other filters: not handled
+
+    // Raw data: one delimiter byte after ID, then bytes up to the final EI.
+    size_t data_start = pos_id + 2;
+    if(data_start < src.size() and
+       (src[data_start] == ' ' or src[data_start] == '\n' or src[data_start] == '\r'))
+      {
+        data_start += 1;
+      }
+    size_t data_end = src.rfind("EI");
+    if(data_end == std::string::npos or data_end <= data_start) { return nullptr; }
+    while(data_end > data_start and
+          (src[data_end - 1] == '\n' or src[data_end - 1] == '\r' or src[data_end - 1] == ' '))
+      {
+        data_end -= 1;
+      }
+
+    const uint8_t* data = reinterpret_cast<const uint8_t*>(src.data()) + data_start;
+    const size_t data_size = data_end - data_start;
+
+    // -> 8-bit samples, one byte per pixel, 0 = dark.
+    std::vector<uint8_t> samples;
+    if(ccitt)
+      {
+        samples = ccitt::decode(data, data_size, W, H, K, black_is_1);
+        if(samples.size() < static_cast<size_t>(W) * H) { return nullptr; }
+      }
+    else
+      {
+        const size_t stride = (static_cast<size_t>(W) + 7u) / 8u;
+        if(data_size < stride * static_cast<size_t>(H)) { return nullptr; }
+        samples.resize(static_cast<size_t>(W) * H);
+        for(int row = 0; row < H; row++)
+          {
+            for(int col = 0; col < W; col++)
+              {
+                const uint8_t byte = data[row * stride + (col >> 3)];
+                const int bit = (byte >> (7 - (col & 7))) & 1;
+                samples[static_cast<size_t>(row) * W + col] =
+                  static_cast<uint8_t>(bit ? 255 : 0);
+              }
+          }
+      }
+
+    // Renderer convention: sample 0 paints. /Decode [1 0] flips which bit
+    // means ink relative to the default [0 1].
+    const bool inverted = (decode_arr.size() >= 2 and decode_arr[0] > decode_arr[1]);
+    if(inverted)
+      {
+        for(auto& v : samples) { v = static_cast<uint8_t>(255 - v); }
+      }
+
+    glyph->w = W;
+    glyph->h = H;
+    glyph->mask = std::make_shared<std::vector<uint8_t> >(std::move(samples));
+    glyph->valid = true;
+    return glyph;
+  }
+
+
+  inline std::shared_ptr<pdf_resource<PAGE_FONT>::type3_glyph>
+  pdf_resource<PAGE_FONT>::rasterize_type3_vector_charproc(const std::string& src)
+  {
+    std::istringstream is(src);
+    std::vector<std::string> toks;
+    std::string t;
+    while(is >> t) { toks.push_back(t); }
+
+    auto num = [&](size_t i) -> double
+    {
+      try { return utils::numeric::locale_safe_stod(toks[i]); }
+      catch(const std::exception&) { return 0.0; }
+    };
+
+    // Collect closed subpaths of the fill in glyph space. The charproc's own
+    // graphics state matters: producers wrap each glyph in `q <translate> cm`
+    // and draw RELATIVE paths, so ignoring cm scattered every glyph by its
+    // missing offset -- letters off their line, i-dots detached.
+    std::vector<std::vector<std::array<double, 2> > > polys;
+    std::vector<std::array<double, 2> > cur;
+    double cx = 0.0, cy = 0.0;   // current point, LOCAL coords
+    bool any_fill = false;
+
+    // Row-vector affine [a b c d e f], composed like the PDF cm operator.
+    std::array<double, 6> ctm = {1, 0, 0, 1, 0, 0};
+    std::vector<std::array<double, 6> > ctm_stack;
+
+    auto apply = [&](double x, double y) -> std::array<double, 2>
+    {
+      return { ctm[0]*x + ctm[2]*y + ctm[4],
+               ctm[1]*x + ctm[3]*y + ctm[5] };
+    };
+
+    auto close_cur = [&]()
+    {
+      if(cur.size() >= 3) { polys.push_back(cur); }
+      cur.clear();
+    };
+
+    for(size_t i = 0; i < toks.size(); i++)
+      {
+        const std::string& op = toks[i];
+        if(op == "q")  { ctm_stack.push_back(ctm); }
+        else if(op == "Q")
+          {
+            if(not ctm_stack.empty()) { ctm = ctm_stack.back(); ctm_stack.pop_back(); }
+          }
+        else if(op == "cm" and i >= 6)
+          {
+            const std::array<double, 6> m = {num(i-6), num(i-5), num(i-4),
+                                             num(i-3), num(i-2), num(i-1)};
+            // CTM' = m x CTM (row-vector convention)
+            ctm = { m[0]*ctm[0] + m[1]*ctm[2],
+                    m[0]*ctm[1] + m[1]*ctm[3],
+                    m[2]*ctm[0] + m[3]*ctm[2],
+                    m[2]*ctm[1] + m[3]*ctm[3],
+                    m[4]*ctm[0] + m[5]*ctm[2] + ctm[4],
+                    m[4]*ctm[1] + m[5]*ctm[3] + ctm[5] };
+          }
+        else if(op == "re" and i >= 4)
+          {
+            const double x = num(i - 4), y = num(i - 3);
+            const double w = num(i - 2), h = num(i - 1);
+            close_cur();
+            polys.push_back({{ apply(x, y), apply(x + w, y),
+                               apply(x + w, y + h), apply(x, y + h) }});
+          }
+        else if(op == "m" and i >= 2)
+          {
+            close_cur();
+            cx = num(i - 2); cy = num(i - 1);
+            cur.push_back(apply(cx, cy));
+          }
+        else if(op == "l" and i >= 2)
+          {
+            cx = num(i - 2); cy = num(i - 1);
+            cur.push_back(apply(cx, cy));
+          }
+        else if((op == "c" and i >= 6) or (op == "v" and i >= 4) or (op == "y" and i >= 4))
+          {
+            double x1, y1, x2, y2, x3, y3;
+            if(op == "c")
+              {
+                x1 = num(i-6); y1 = num(i-5); x2 = num(i-4); y2 = num(i-3);
+                x3 = num(i-2); y3 = num(i-1);
+              }
+            else if(op == "v")
+              {
+                x1 = cx; y1 = cy; x2 = num(i-4); y2 = num(i-3);
+                x3 = num(i-2); y3 = num(i-1);
+              }
+            else
+              {
+                x1 = num(i-4); y1 = num(i-3); x3 = num(i-2); y3 = num(i-1);
+                x2 = x3; y2 = y3;
+              }
+            for(int k = 1; k <= 8; k++)
+              {
+                const double u = k / 8.0, v = 1.0 - u;
+                cur.push_back(apply(v*v*v*cx + 3*v*v*u*x1 + 3*v*u*u*x2 + u*u*u*x3,
+                                    v*v*v*cy + 3*v*v*u*y1 + 3*v*u*u*y2 + u*u*u*y3));
+              }
+            cx = x3; cy = y3;
+          }
+        else if(op == "h") { if(not cur.empty()) { cur.push_back(cur.front()); } }
+        else if(op == "f" or op == "f*" or op == "F" or op == "b" or op == "b*" or op == "B" or op == "B*")
+          {
+            close_cur();
+            any_fill = true;
+          }
+      }
+    close_cur();
+
+    if(not any_fill or polys.empty()) { return nullptr; }
+
+    double bx0 = polys[0][0][0], by0 = polys[0][0][1];
+    double bx1 = bx0, by1 = by0;
+    for(const auto& poly : polys)
+      {
+        for(const auto& pt : poly)
+          {
+            bx0 = std::min(bx0, pt[0]); bx1 = std::max(bx1, pt[0]);
+            by0 = std::min(by0, pt[1]); by1 = std::max(by1, pt[1]);
+          }
+      }
+    const double bw = bx1 - bx0, bh = by1 - by0;
+    if(bw <= 0.0 or bh <= 0.0) { return nullptr; }
+
+    constexpr int max_dim = 128;
+    int W = max_dim, H = max_dim;
+    if(bw >= bh) { H = std::max(1, static_cast<int>(std::lround(max_dim * bh / bw))); }
+    else         { W = std::max(1, static_cast<int>(std::lround(max_dim * bw / bh))); }
+
+    auto glyph = std::make_shared<type3_glyph>();
+    glyph->w = W;
+    glyph->h = H;
+    // Renderer convention: 0 paints. Start transparent (255), carve ink.
+    glyph->mask = std::make_shared<std::vector<uint8_t> >(
+      static_cast<size_t>(W) * H, 255);
+
+    // Even-odd scanline fill. Raster row 0 is the TOP of the image (matches
+    // the inline-image convention the mask path expects).
+    for(int row = 0; row < H; row++)
+      {
+        const double y = by1 - (row + 0.5) * bh / H;
+        std::vector<double> xs;
+        for(const auto& poly : polys)
+          {
+            const size_t n = poly.size();
+            for(size_t i2 = 0, j2 = n - 1; i2 < n; j2 = i2++)
+              {
+                const double yi = poly[i2][1], yj = poly[j2][1];
+                if((yi > y) != (yj > y))
+                  {
+                    xs.push_back(poly[j2][0] +
+                                 (y - yj) * (poly[i2][0] - poly[j2][0]) / (yi - yj));
+                  }
+              }
+          }
+        std::sort(xs.begin(), xs.end());
+        for(size_t k = 0; k + 1 < xs.size(); k += 2)
+          {
+            int c0 = static_cast<int>(std::ceil ((xs[k]     - bx0) / bw * W - 0.5));
+            int c1 = static_cast<int>(std::floor((xs[k + 1] - bx0) / bw * W - 0.5));
+            c0 = std::max(0, c0); c1 = std::min(W - 1, c1);
+            for(int c = c0; c <= c1; c++)
+              {
+                (*glyph->mask)[static_cast<size_t>(row) * W + c] = 0;
+              }
+          }
+      }
+
+    // cm maps the image unit square onto the paths' bounds in glyph space.
+    glyph->cm = {bw, 0.0, 0.0, bh, bx0, by0};
+    glyph->valid = true;
+    return glyph;
   }
 
   void pdf_resource<PAGE_FONT>::init_charprocs()

--- a/src/parse/pdf_resources/page_font/glyphs.h
+++ b/src/parse/pdf_resources/page_font/glyphs.h
@@ -98,6 +98,17 @@ namespace pdflib
     if(name_to_utf8.count(key)==1)
       return name_to_utf8[key];
 
+    // `.notdef` and friends are not unknown glyphs: they are the standard
+    // names for "nothing is drawn here". Subsetted fonts routinely leave every
+    // entry named `.notdef` while carrying a perfectly good /ToUnicode, so a
+    // marker here does not report a lookup failure -- it injects the literal
+    // text "glyph[.notdef]" into the page, once per character, which is then
+    // both extracted and drawn.
+    if(key==".notdef" or key==".null" or key=="nonmarkingreturn")
+      {
+        return "";
+      }
+
     LOG_S(ERROR) << "could not find a glyph with name=" << key;
     unknown_glyphs.insert(key);
 

--- a/src/parse/pdf_resources/page_pattern.h
+++ b/src/parse/pdf_resources/page_pattern.h
@@ -1,0 +1,161 @@
+//-*-C++-*-
+
+#ifndef PDF_PAGE_PATTERN_RESOURCE_H
+#define PDF_PAGE_PATTERN_RESOURCE_H
+
+namespace pdflib
+{
+
+  // One /Pattern resource (ISO 32000-1, 8.7.3).
+  //
+  //   PatternType 1  tiling   -- a content stream replayed on a lattice
+  //   PatternType 2  shading  -- a shading painted through the fill region
+  //
+  // Only the data is held here; painting a tiling pattern means running its
+  // content stream, which only the stream decoder can do.
+  template<>
+  class pdf_resource<PAGE_PATTERN>
+  {
+  public:
+
+    pdf_resource();
+    ~pdf_resource();
+
+    void set(const std::string& key, QPDFObjectHandle obj);
+
+    bool is_valid() const { return type_ == 1 or type_ == 2; }
+    int get_pattern_type() const { return type_; }
+
+    // Pattern space -> the default space of the page (NOT the CTM in force
+    // when the pattern is used; 8.7.3.1).
+    const std::array<double, 9>& get_matrix() const { return matrix_; }
+
+    bool has_bbox() const { return has_bbox_; }
+    const std::array<double, 4>& get_bbox() const { return bbox_; }
+
+    double get_x_step() const { return x_step_; }
+    double get_y_step() const { return y_step_; }
+
+    // Tiling only: the pattern cell's own resources and content stream.
+    QPDFObjectHandle get_resources() const { return resources_; }
+    bool has_resources() const { return resources_.isDictionary(); }
+    std::vector<qpdf_stream_instruction> parse_stream() const;
+
+    // Shading pattern only.
+    QPDFObjectHandle get_shading() const { return shading_; }
+
+  private:
+
+    std::string key_;
+    int type_ = 0;
+
+    std::array<double, 9> matrix_ = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+    bool has_bbox_ = false;
+    std::array<double, 4> bbox_ = {0, 0, 0, 0};
+    double x_step_ = 0.0;
+    double y_step_ = 0.0;
+
+    QPDFObjectHandle qpdf_pattern_;
+    QPDFObjectHandle resources_;
+    QPDFObjectHandle shading_;
+  };
+
+  pdf_resource<PAGE_PATTERN>::pdf_resource()
+  {}
+
+  pdf_resource<PAGE_PATTERN>::~pdf_resource()
+  {}
+
+  void pdf_resource<PAGE_PATTERN>::set(const std::string& key, QPDFObjectHandle obj)
+  {
+    key_ = key;
+    qpdf_pattern_ = obj;
+
+    QPDFObjectHandle dict = obj.isStream() ? obj.getDict() : obj;
+    if(not dict.isDictionary())
+      {
+        LOG_S(WARNING) << "pattern " << key_ << ": not a dictionary";
+        return;
+      }
+
+    if(dict.hasKey("/PatternType") and dict.getKey("/PatternType").isInteger())
+      {
+        type_ = static_cast<int>(dict.getKey("/PatternType").getIntValue());
+      }
+
+    if(dict.hasKey("/Matrix") and dict.getKey("/Matrix").isArray() and
+       dict.getKey("/Matrix").getArrayNItems() >= 6)
+      {
+        QPDFObjectHandle m = dict.getKey("/Matrix");
+        double v[6] = {1, 0, 0, 1, 0, 0};
+        for(int i = 0; i < 6; i++)
+          {
+            QPDFObjectHandle item = m.getArrayItem(i);
+            if(item.isNumber()) { v[i] = item.getNumericValue(); }
+          }
+        // Row-vector 3x3, matching the decoder's trafo_matrix layout.
+        matrix_ = { v[0], v[1], 0.0,
+                    v[2], v[3], 0.0,
+                    v[4], v[5], 1.0 };
+      }
+
+    if(dict.hasKey("/BBox") and dict.getKey("/BBox").isArray() and
+       dict.getKey("/BBox").getArrayNItems() >= 4)
+      {
+        QPDFObjectHandle b = dict.getKey("/BBox");
+        for(int i = 0; i < 4; i++)
+          {
+            QPDFObjectHandle item = b.getArrayItem(i);
+            if(item.isNumber()) { bbox_[i] = item.getNumericValue(); }
+          }
+        has_bbox_ = true;
+      }
+
+    if(dict.hasKey("/XStep") and dict.getKey("/XStep").isNumber())
+      {
+        x_step_ = dict.getKey("/XStep").getNumericValue();
+      }
+    if(dict.hasKey("/YStep") and dict.getKey("/YStep").isNumber())
+      {
+        y_step_ = dict.getKey("/YStep").getNumericValue();
+      }
+
+    // A missing or zero step means "one cell, no repetition"; fall back to the
+    // bbox extent so the tiling loop always advances.
+    if(x_step_ <= 0.0 and has_bbox_) { x_step_ = bbox_[2] - bbox_[0]; }
+    if(y_step_ <= 0.0 and has_bbox_) { y_step_ = bbox_[3] - bbox_[1]; }
+
+    if(dict.hasKey("/Resources")) { resources_ = dict.getKey("/Resources"); }
+    if(dict.hasKey("/Shading"))   { shading_   = dict.getKey("/Shading"); }
+
+    LOG_S(INFO) << "pattern " << key_ << ": type " << type_
+                << " steps=(" << x_step_ << ", " << y_step_ << ")"
+                << (has_bbox_ ? " with /BBox" : " no /BBox");
+  }
+
+  std::vector<qpdf_stream_instruction> pdf_resource<PAGE_PATTERN>::parse_stream() const
+  {
+    std::vector<qpdf_stream_instruction> insts;
+    if(not qpdf_pattern_.isStream())
+      {
+        return insts;
+      }
+
+    try
+      {
+        QPDFObjectHandle stream = qpdf_pattern_;
+        qpdf_stream_decoder decoder(insts);
+        decoder.decode(stream);
+      }
+    catch(const std::exception& e)
+      {
+        LOG_S(WARNING) << "pattern " << key_ << ": content stream unreadable: " << e.what();
+        insts.clear();
+      }
+
+    return insts;
+  }
+
+}
+
+#endif

--- a/src/parse/pdf_resources/page_patterns.h
+++ b/src/parse/pdf_resources/page_patterns.h
@@ -1,0 +1,121 @@
+//-*-C++-*-
+
+#ifndef PDF_PAGE_PATTERNS_RESOURCE_H
+#define PDF_PAGE_PATTERNS_RESOURCE_H
+
+namespace pdflib
+{
+
+  // The /Pattern sub-dictionary of a resource dictionary. Mirrors
+  // pdf_resource<PAGE_COLORSPACES>: a name -> resource map that falls back to
+  // the enclosing dictionary, so a form XObject sees the page's patterns.
+  template<>
+  class pdf_resource<PAGE_PATTERNS>
+  {
+  public:
+
+    pdf_resource();
+    pdf_resource(std::shared_ptr<pdf_resource<PAGE_PATTERNS>> parent);
+    ~pdf_resource();
+
+    size_t size();
+
+    int count(std::string key);
+
+    std::unordered_set<std::string> keys();
+
+    pdf_resource<PAGE_PATTERN>& operator[](std::string name);
+
+    void set(QPDFObjectHandle& qpdf_patterns);
+
+  private:
+
+    std::shared_ptr<pdf_resource<PAGE_PATTERNS>> parent_;
+    std::unordered_map<std::string, pdf_resource<PAGE_PATTERN> > page_patterns;
+  };
+
+  pdf_resource<PAGE_PATTERNS>::pdf_resource():
+    parent_(nullptr)
+  {}
+
+  pdf_resource<PAGE_PATTERNS>::pdf_resource(std::shared_ptr<pdf_resource<PAGE_PATTERNS>> parent):
+    parent_(parent)
+  {}
+
+  pdf_resource<PAGE_PATTERNS>::~pdf_resource()
+  {}
+
+  size_t pdf_resource<PAGE_PATTERNS>::size()
+  {
+    return page_patterns.size();
+  }
+
+  int pdf_resource<PAGE_PATTERNS>::count(std::string key)
+  {
+    if(page_patterns.count(key)==1)
+      {
+        return 1;
+      }
+    if(parent_)
+      {
+        return parent_->count(key);
+      }
+    return 0;
+  }
+
+  std::unordered_set<std::string> pdf_resource<PAGE_PATTERNS>::keys()
+  {
+    std::unordered_set<std::string> keys_;
+
+    if(parent_)
+      {
+        keys_ = parent_->keys();
+      }
+
+    for(auto itr=page_patterns.begin(); itr!=page_patterns.end(); itr++)
+      {
+        keys_.insert(itr->first);
+      }
+
+    return keys_;
+  }
+
+  pdf_resource<PAGE_PATTERN>& pdf_resource<PAGE_PATTERNS>::operator[](std::string name)
+  {
+    if(page_patterns.count(name)==1)
+      {
+        return page_patterns[name];
+      }
+
+    if(parent_)
+      {
+        return (*parent_)[name];
+      }
+
+    // Unknown name: hand back an invalid pattern rather than throwing, so a
+    // fill naming a missing pattern simply paints nothing.
+    return page_patterns[name];
+  }
+
+  void pdf_resource<PAGE_PATTERNS>::set(QPDFObjectHandle& qpdf_patterns)
+  {
+    LOG_S(INFO) << __FUNCTION__;
+
+    if(not qpdf_patterns.isDictionary())
+      {
+        return;
+      }
+
+    for(auto& key : qpdf_patterns.getKeys())
+      {
+        pdf_resource<PAGE_PATTERN> pattern;
+        pattern.set(key, qpdf_patterns.getKey(key));
+
+        page_patterns.erase(key);
+        page_patterns.emplace(key, std::move(pattern));
+      }
+  }
+
+}
+
+#endif

--- a/src/parse/pdf_resources/page_xobject_form.h
+++ b/src/parse/pdf_resources/page_xobject_form.h
@@ -14,6 +14,7 @@ namespace pdflib
     const static inline std::string GRPHS_KEY = "/ExtGState";
     const static inline std::string COLORSPACES_KEY = "/ColorSpace";
     const static inline std::string SHADINGS_KEY = "/Shading";
+    const static inline std::string PATTERNS_KEY = "/Pattern";
     const static inline std::string XOBJS_KEY = "/XObject";
     
   public:
@@ -37,6 +38,7 @@ namespace pdflib
     bool has_grphs() const;
     bool has_colorspaces() const;
     bool has_shadings() const;
+    bool has_patterns() const;
 
     // True when the form is a transparency group XObject (11.6.6): its
     // contents are meant to be composited as a unit rather than one at a time.
@@ -47,6 +49,7 @@ namespace pdflib
     QPDFObjectHandle get_grphs() const;
     QPDFObjectHandle get_colorspaces() const;
     QPDFObjectHandle get_shadings() const;
+    QPDFObjectHandle get_patterns() const;
     QPDFObjectHandle get_xobjects() const;
 
     std::vector<qpdf_stream_instruction> parse_stream() const;
@@ -172,6 +175,13 @@ namespace pdflib
            qpdf_xobject_dict_.getKey(RESOURCES_KEY).hasKey(SHADINGS_KEY);
   }
 
+  bool pdf_resource<PAGE_XOBJECT_FORM>::has_patterns() const
+  {
+    QPDFObjectHandle qpdf_xobject_dict_ = qpdf_xobject_dict;
+    return qpdf_xobject_dict_.hasKey(RESOURCES_KEY) and
+           qpdf_xobject_dict_.getKey(RESOURCES_KEY).hasKey(PATTERNS_KEY);
+  }
+
   bool pdf_resource<PAGE_XOBJECT_FORM>::has_xobjects() const
   {
     QPDFObjectHandle qpdf_xobject_dict_ = qpdf_xobject_dict;
@@ -220,6 +230,17 @@ namespace pdflib
       {
         QPDFObjectHandle qpdf_xobject_dict_ = qpdf_xobject_dict;
 	return qpdf_xobject_dict_.getKey(RESOURCES_KEY).getKey(SHADINGS_KEY);
+      }
+
+    return QPDFObjectHandle::newNull();
+  }
+
+  QPDFObjectHandle pdf_resource<PAGE_XOBJECT_FORM>::get_patterns() const
+  {
+    if(has_patterns())
+      {
+        QPDFObjectHandle qpdf_xobject_dict_ = qpdf_xobject_dict;
+        return qpdf_xobject_dict_.getKey(RESOURCES_KEY).getKey(PATTERNS_KEY);
       }
 
     return QPDFObjectHandle::newNull();

--- a/src/parse/pdf_resources/page_xobject_image.h
+++ b/src/parse/pdf_resources/page_xobject_image.h
@@ -1024,10 +1024,11 @@ namespace pdflib
         return;
       }
 
-    if(smask.get_bits_per_component() != 8)
+    const int smask_bpc = smask.get_bits_per_component();
+    if(smask_bpc != 8 and smask_bpc != 1 and smask_bpc != 2 and smask_bpc != 4)
       {
         LOG_S(WARNING) << "SMask bits/component unsupported for xobject_key=" << xobject_key
-                       << " smask_bpc=" << smask.get_bits_per_component();
+                       << " smask_bpc=" << smask_bpc;
         return;
       }
 
@@ -1038,8 +1039,54 @@ namespace pdflib
       }
 
     auto smask_buf = smask.get_decoded_stream_data();
+
+    // A stencil-shaped mask is usually written at 1 bit per pixel, packed
+    // several samples to a byte and padded to a byte at the end of each row.
+    // Reading those bytes as if each held one sample takes the mask's first
+    // eight columns to be the whole row, so the transparent part of the image
+    // keeps painting. Expand to one byte per sample first.
+    std::vector<uint8_t> smask_unpacked;
+    if(smask_bpc != 8)
+      {
+        const size_t row_bits = static_cast<size_t>(sm_w) * static_cast<size_t>(smask_bpc);
+        const size_t row_bytes = (row_bits + 7u) / 8u;
+        const size_t needed = row_bytes * static_cast<size_t>(sm_h);
+        if(smask_buf->getSize() < needed)
+          {
+            LOG_S(WARNING) << "SMask packed stream too small for xobject_key=" << xobject_key
+                           << " size=" << smask_buf->getSize()
+                           << " expected>=" << needed
+                           << " smask_bpc=" << smask_bpc;
+            return;
+          }
+
+        const auto* packed = reinterpret_cast<uint8_t const*>(smask_buf->getBuffer());
+        const uint32_t sample_max = (1u << smask_bpc) - 1u;
+        smask_unpacked.resize(static_cast<size_t>(sm_w) * sm_h);
+
+        for(int row = 0; row < sm_h; ++row)
+          {
+            const uint8_t* row_ptr = packed + static_cast<size_t>(row) * row_bytes;
+            size_t bit_offset = 0;
+            for(int col = 0; col < sm_w; ++col)
+              {
+                uint32_t raw = 0u;
+                for(int bit = 0; bit < smask_bpc; ++bit)
+                  {
+                    const size_t abs_bit = bit_offset + static_cast<size_t>(bit);
+                    const int in_byte = 7 - static_cast<int>(abs_bit % 8u);
+                    raw = (raw << 1u)
+                      | static_cast<uint32_t>((row_ptr[abs_bit / 8u] >> in_byte) & 1u);
+                  }
+                bit_offset += static_cast<size_t>(smask_bpc);
+                smask_unpacked[static_cast<size_t>(row) * sm_w + col] =
+                  static_cast<uint8_t>((raw * 255u) / sample_max);
+              }
+          }
+      }
+
     const size_t smask_expected = static_cast<size_t>(sm_w) * sm_h;
-    if(smask_buf->getSize() < smask_expected)
+    if(smask_unpacked.empty() and smask_buf->getSize() < smask_expected)
       {
         LOG_S(WARNING) << "SMask decoded stream too small for xobject_key=" << xobject_key
                        << " size=" << smask_buf->getSize()
@@ -1052,7 +1099,9 @@ namespace pdflib
     auto out = std::make_shared<std::vector<uint8_t>>();
     out->resize(expected);
 
-    auto const* src = reinterpret_cast<uint8_t const*>(smask_buf->getBuffer());
+    auto const* src = smask_unpacked.empty()
+      ? reinterpret_cast<uint8_t const*>(smask_buf->getBuffer())
+      : smask_unpacked.data();
     auto const decode = smask.get_decode_array();
     const bool has_decode = smask.has_decode_array() and decode.size() >= 2;
 

--- a/src/parse/pdf_resources/page_xobject_image.h
+++ b/src/parse/pdf_resources/page_xobject_image.h
@@ -375,6 +375,23 @@ namespace pdflib
             color_space = cs.dump();
 
             auto qpdf_cs = qpdf_xobject_dict.getKey("/ColorSpace");
+
+            // A device space may legally be written as a one-element array:
+            // [/DeviceRGB] means exactly /DeviceRGB. Unwrap it to the bare name,
+            // otherwise every later comparison sees the JSON dump
+            // ("[\"/DeviceRGB\"]"), the space is reported as unsupported, and
+            // the image is dropped in favour of a placeholder rectangle.
+            if(qpdf_cs.isArray() and qpdf_cs.getArrayNItems() == 1)
+              {
+                auto only_obj = qpdf_cs.getArrayItem(0);
+                if(only_obj.isName())
+                  {
+                    color_space = only_obj.getName();
+                    LOG_S(INFO) << "unwrapped single-element /ColorSpace array to "
+                                << color_space;
+                  }
+              }
+
             if(qpdf_cs.isArray() and qpdf_cs.getArrayNItems() >= 2)
               {
                 auto name_obj = qpdf_cs.getArrayItem(0);
@@ -774,8 +791,16 @@ namespace pdflib
 	else if(indexed_hival >= 0)
 	  {
 	    // Indexed: default decode is [0, hival] (one component — the palette index)
-	    LOG_S(INFO) << "no `/Decode` found: using [0, " << indexed_hival << "] for Indexed color space";
-	    decode_array = { 0.0, static_cast<double>(indexed_hival) };
+	    // ISO 32000-1 table 90: the default is [0, 2^bpc - 1], the full range
+	    // representable at this bit depth, NOT [0, hival]. A decode maps a raw
+	    // sample through (Dmax - Dmin) / (2^bpc - 1), so [0, hival] silently
+	    // rescales every index by hival/(2^bpc - 1) and looks up the wrong
+	    // palette entry -- a 4-bit flag lost its red and white to index >> 1.
+	    const int idx_bpc = (bits_per_component > 0 ? bits_per_component : 8);
+	    const double idx_max = static_cast<double>((1u << idx_bpc) - 1u);
+	    LOG_S(INFO) << "no `/Decode` found: using [0, " << idx_max
+	                << "] for Indexed color space (bpc=" << idx_bpc << ")";
+	    decode_array = { 0.0, idx_max };
 	    decode_present = true;
 	  }
 	else

--- a/src/parse/pdf_states/bitmap.h
+++ b/src/parse/pdf_states/bitmap.h
@@ -546,9 +546,40 @@ namespace pdflib
         const std::size_t row_stride = min_row_bytes;
 
         const std::uint32_t sample_max = (1u << bits_per_component) - 1u;
+
+        // An /Indexed sample is a palette index, not a colour value: it is
+        // looked up, never scaled. Stretching it to 0..255 the way a
+        // continuous-tone sample is stretched sends every pixel to the wrong
+        // palette slot -- at 4 bpc, index 1 becomes 17 -- so a flag or a logo
+        // keeps its shape and loses all of its colours.
+        const bool indexed_samples =
+          image.indexed_palette and not image.indexed_palette->empty();
+
+        // The default /Decode of an /Indexed image spans the bit depth,
+        // [0, 2^bpc - 1] (ISO 32000-1, table 89), which is the identity on
+        // indices; a decode array equal to it carries no information and is
+        // ignored so the indices pass through untouched.
+        const bool decode_is_index_identity =
+          decode_array.size() == 2 and
+          std::abs(decode_array[0]) < 1e-9 and
+          std::abs(decode_array[1] - static_cast<double>(sample_max)) < 1e-9;
+
         auto decode_sample =
           [&](int component_index, std::uint32_t raw_sample) -> std::uint8_t
           {
+            if(indexed_samples)
+              {
+                // /Decode on an /Indexed image remaps index range, not colour,
+                // and its default [0, 2^bpc - 1] is the identity. Anything
+                // else here is a decode array synthesised for continuous tone,
+                // and applying it scales index 1 of a 4-bit image to 17, which
+                // the palette lookup then clamps to the last entry: the whole
+                // picture collapses onto one or two colours.
+                (void)decode_is_index_identity;
+                return static_cast<std::uint8_t>(
+                  raw_sample > 255u ? 255u : raw_sample);
+              }
+
             const int pair_count = static_cast<int>(decode_array.size() / 2);
             if(component_index < pair_count)
               {
@@ -722,11 +753,34 @@ namespace pdflib
           {
             const int w = image.image_width;
             const int h = image.image_height;
-            const auto* indices = reinterpret_cast<const uint8_t*>(
-              image.decoded_stream_data->getBuffer());
-            const size_t n_indices = image.decoded_stream_data->getSize();
+
+            // Below 8 bits per component the samples are packed several to a
+            // byte, and an /Indexed sample is one palette index. They have to
+            // be unpacked to one index per pixel before the palette is
+            // applied: reading the packed bytes as indices yields a fraction
+            // of the pixels, and the short buffer is then dropped for a
+            // placeholder rather than drawn.
+            std::shared_ptr<std::vector<uint8_t> > unpacked_indices;
+            if(image.bits_per_component > 0 and image.bits_per_component < 8 and
+               unpack_subbyte_samples_to_u8(image.decoded_stream_data,
+                                            w, h, 1,
+                                            image.bits_per_component,
+                                            image.decode_array))
+              {
+                unpacked_indices = pixel_data;
+              }
+
+            const auto* indices =
+              unpacked_indices ? unpacked_indices->data()
+                               : reinterpret_cast<const uint8_t*>(
+                                   image.decoded_stream_data->getBuffer());
+            const size_t n_indices =
+              unpacked_indices ? unpacked_indices->size()
+                               : image.decoded_stream_data->getSize();
+
             if(expand_indexed_samples(ncomps, indices, n_indices, w, h))
               {
+                channels = ncomps;
                 LOG_S(INFO) << "bitmap: expanded Indexed palette for xobject_key="
                             << image.xobject_key
                             << " (" << n_indices << " indices -> "
@@ -772,10 +826,18 @@ namespace pdflib
 
             if(image.bits_per_component > 0 and image.bits_per_component < 8)
               {
+                // An /Indexed pixel is a single palette index whatever the
+                // base space is; unpacking it with the base space's component
+                // count reads several indices per pixel and runs off the end
+                // of the row, leaving a buffer too small to draw.
+                const int unpack_components =
+                  (image.indexed_palette and not image.indexed_palette->empty())
+                    ? 1 : channels;
+
                 if(not unpack_subbyte_samples_to_u8(src,
                                                     w,
                                                     h,
-                                                    channels,
+                                                    unpack_components,
                                                     image.bits_per_component,
                                                     image.decode_array))
                   {

--- a/src/parse/pdf_states/bitmap.h
+++ b/src/parse/pdf_states/bitmap.h
@@ -916,6 +916,14 @@ namespace pdflib
                 else if(decoded_channels == 4)
                   {
                     fmt = PIXEL_FORMAT_CMYK;
+
+                    // libjpeg hands back process ink: it already undoes the
+                    // Adobe inversion while decoding, exactly as the primary
+                    // path assumes. Leaving the convention unset means
+                    // "invert", so the samples were inverted a second time and
+                    // a page with almost no ink came out solid black. Only an
+                    // explicit inverting /Decode changes that.
+                    cmyk_conv = CMYK_CONVENTION_PROCESS;
                     if(image.decode_present and has_default_adobe_cmyk_decode(image.decode_array))
                       {
                         cmyk_conv = CMYK_CONVENTION_ADOBE_INVERTED;

--- a/src/parse/pdf_states/grph.h
+++ b/src/parse/pdf_states/grph.h
@@ -119,6 +119,9 @@ namespace pdflib
      */
     
   public:
+    // Current transformation matrix. A pattern's /Matrix maps pattern space to
+    // the page's default space, so placing one needs the CTM in force.
+    const std::array<double, 9>& get_trafo_matrix() const { return trafo_matrix; }
 
     pdf_state(std::array<double, 9>&    trafo_matrix_,
               std::shared_ptr<pdf_resource<PAGE_GRPHS>> page_grphs_,
@@ -178,6 +181,16 @@ namespace pdflib
     // of any enclosing transparency group; 1.0 = opaque.
     double get_stroke_alpha() const { return stroke_alpha * group_alpha; }
     double get_fill_alpha() const { return fill_alpha * group_alpha; }
+
+    // True while the non-stroking colour is a /Pattern that has not been
+    // resolved to a paint. A Pattern colour space has no initial colour value
+    // (ISO 32000-1, 8.6.6.2), so the black the state otherwise carries is not
+    // "the colour": filling with it paints a black sheet where the pattern
+    // should be.
+    bool get_fill_is_unresolved_pattern() const { return fill_is_unresolved_pattern; }
+
+    // Name given by the scn that selected a pattern, empty when none.
+    const std::string& get_fill_pattern_name() const { return fill_pattern_name; }
 
     // ExtGState /BM, likewise folded together with the blend mode of an
     // enclosing group: content that does not blend on its own inherits the
@@ -257,6 +270,8 @@ namespace pdflib
 
     double stroke_alpha;
     double fill_alpha;
+    bool fill_is_unresolved_pattern = false;
+    std::string fill_pattern_name;
 
     blend_mode_name blend_mode;
     soft_mask_state soft_mask;
@@ -343,6 +358,8 @@ namespace pdflib
     // alpha is part of the graphics state and must survive q/Q save/restore
     this->stroke_alpha = other.stroke_alpha;
     this->fill_alpha = other.fill_alpha;
+    this->fill_is_unresolved_pattern = other.fill_is_unresolved_pattern;
+    this->fill_pattern_name = other.fill_pattern_name;
 
     this->blend_mode = other.blend_mode;
     this->soft_mask = other.soft_mask;
@@ -656,7 +673,14 @@ namespace pdflib
       }
     else if(cs_name=="Pattern")
       {
-        // pattern paint is unsupported; keep the current color
+        // A Pattern space carries no initial colour; the paint comes from the
+        // pattern named by a later scn. Flagged so a fill made before that
+        // pattern can be resolved paints nothing rather than black.
+        if(&rgb == &rgb_filling_ops)
+          {
+            fill_is_unresolved_pattern = true;
+            fill_pattern_name.clear();
+          }
       }
     else if(page_colorspaces!=nullptr and page_colorspaces->count("/"+cs_name)>0)
       {
@@ -692,12 +716,26 @@ namespace pdflib
 
   void pdf_state<GRPH>::sc(std::vector<qpdf_stream_instruction>& instructions)
   {
-    set_color(instructions, rgb_filling_ops, filling_cs_key, __FUNCTION__);
+    if(set_color(instructions, rgb_filling_ops, filling_cs_key, __FUNCTION__))
+      {
+        fill_is_unresolved_pattern = false;
+      }
   }
 
   void pdf_state<GRPH>::scn(std::vector<qpdf_stream_instruction>& instructions)
   {
-    set_color(instructions, rgb_filling_ops, filling_cs_key, __FUNCTION__);
+    // A pattern-name operand leaves set_color false: the fill stays flagged,
+    // and the name is kept so the decoder can try to paint that pattern.
+    if(set_color(instructions, rgb_filling_ops, filling_cs_key, __FUNCTION__))
+      {
+        fill_is_unresolved_pattern = false;
+        fill_pattern_name.clear();
+      }
+    else if(fill_is_unresolved_pattern and not instructions.empty())
+      {
+        std::string nm = instructions.back().unparse();
+        if(not nm.empty() and nm.front() == '/') { fill_pattern_name = nm; }
+      }
   }
   
   // G/g/RG/rg/K/k also switch the current color space to the device space,
@@ -714,6 +752,7 @@ namespace pdflib
   // `g` is the NON-stroking (fill) gray operator
   void pdf_state<GRPH>::g(std::vector<qpdf_stream_instruction>& instructions)
   {
+    fill_is_unresolved_pattern = false;
     if(not verify(instructions, 1, __FUNCTION__) ) { return; }
 
     filling_cs_key = "";
@@ -734,6 +773,7 @@ namespace pdflib
 
   void pdf_state<GRPH>::rg(std::vector<qpdf_stream_instruction>& instructions)
   {
+    fill_is_unresolved_pattern = false;
     if(not verify(instructions, 3, __FUNCTION__) ) { return; }
 
     int r = static_cast<int>(std::round(255.0*instructions[0].to_double()));
@@ -757,6 +797,7 @@ namespace pdflib
 
   void pdf_state<GRPH>::k(std::vector<qpdf_stream_instruction>& instructions)
   {
+    fill_is_unresolved_pattern = false;
     if(not verify(instructions, 4, __FUNCTION__) ) { return; }
 
     filling_cs_key = "";

--- a/src/parse/pdf_states/shape.h
+++ b/src/parse/pdf_states/shape.h
@@ -681,23 +681,50 @@ namespace pdflib
                     << grph_state.get_rgb_stroking_ops()[2] << ")"
                     << " alpha: " << grph_state.get_stroke_alpha();
 
-        shape_instruction shpinstr(std::move(subpaths),
-                                   paint_mode,
-                                   fill_rule,
-                                   line_width,
-                                   grph_state.get_line_cap(),
-                                   grph_state.get_line_join(),
-                                   grph_state.get_miter_limit(),
-                                   std::move(dash_array),
-                                   dash_phase,
-                                   grph_state.get_rgb_stroking_ops(),
-                                   grph_state.get_rgb_filling_ops(),
-                                   grph_state.get_stroke_alpha(),
-                                   grph_state.get_fill_alpha(),
-                                   get_clip_state());
-        shpinstr.set_blend_mode(grph_state.get_blend_mode());
+        // A fill whose colour is an unresolved /Pattern must not be painted:
+        // the Pattern space has no initial colour, so the graphics state's
+        // black is a placeholder, not a paint. A full-page background pattern
+        // filled black covered the entire page. Stroke-only shapes are
+        // unaffected; a fill+stroke keeps its stroke.
+        shape_paint_mode effective_mode = paint_mode;
+        bool emit_instruction = true;
+        if(grph_state.get_fill_is_unresolved_pattern())
+          {
+            if(paint_mode == SHAPE_PAINT_FILL)
+              {
+                LOG_S(INFO) << "shape: skipping fill with an unresolved /Pattern colour";
+                // Only the painting is skipped. Returning here would also skip
+                // the clip capture and the path reset below, which leaves the
+                // path in place: every later fill then repaints it, and a
+                // tiling pattern redrew its whole fill region once per cell.
+                emit_instruction = false;
+              }
+            else if(paint_mode == SHAPE_PAINT_FILL_STROKE)
+              {
+                effective_mode = SHAPE_PAINT_STROKE;
+              }
+          }
 
-        instructions.add_shape_instruction(std::move(shpinstr));
+        if(emit_instruction)
+          {
+            shape_instruction shpinstr(std::move(subpaths),
+                                       effective_mode,
+                                       fill_rule,
+                                       line_width,
+                                       grph_state.get_line_cap(),
+                                       grph_state.get_line_join(),
+                                       grph_state.get_miter_limit(),
+                                       std::move(dash_array),
+                                       dash_phase,
+                                       grph_state.get_rgb_stroking_ops(),
+                                       grph_state.get_rgb_filling_ops(),
+                                       grph_state.get_stroke_alpha(),
+                                       grph_state.get_fill_alpha(),
+                                       get_clip_state());
+            shpinstr.set_blend_mode(grph_state.get_blend_mode());
+
+            instructions.add_shape_instruction(std::move(shpinstr));
+          }
       }
 
     // a pending W/W* clip takes effect after *any* painting operator (not

--- a/src/parse/pdf_states/text.h
+++ b/src/parse/pdf_states/text.h
@@ -759,6 +759,60 @@ namespace pdflib
                               grph_state.get_fill_alpha());
         tinstr.set_rendering_mode(rendering_mode);
         tinstr.set_blend_mode(grph_state.get_blend_mode());
+        tinstr.set_is_type3(font.is_type3());
+
+        // A Type3 glyph is a content-stream procedure, not a font glyph, so
+        // the renderer cannot draw it from any font face. Emit the glyph's
+        // mask as an image-mask bitmap over its device quad; the pipeline then
+        // places, clips and paints it like any other image.
+        if(font.is_type3() and glyph_code >= 0)
+          {
+            auto g3 = font.get_type3_glyph(static_cast<uint32_t>(glyph_code));
+            if(g3 and g3->valid and g3->mask)
+              {
+                const std::array<double, 6>& fm = font.get_font_matrix();
+                const std::array<double, 6>& gm = g3->cm;
+
+                // unit square -> (cm) -> glyph space -> (/FontMatrix) -> text
+                // space (plus rise) -> text matrix -> CTM -> device
+                auto map_pt = [&](double ux, double uy, double& dx, double& dy)
+                {
+                  const double gx = gm[0]*ux + gm[2]*uy + gm[4];
+                  const double gy = gm[1]*ux + gm[3]*uy + gm[5];
+                  // /FontMatrix output is in text-space em units; the font
+                  // size scales it exactly as compute_rect scales metrics.
+                  const double ex = (fm[0]*gx + fm[2]*gy + fm[4]) * font_size;
+                  const double ey = (fm[1]*gx + fm[3]*gy + fm[5]) * font_size + rise;
+                  const double tx = text_matrix[0]*ex + text_matrix[3]*ey + text_matrix[6];
+                  const double ty = text_matrix[1]*ex + text_matrix[4]*ey + text_matrix[7];
+                  dx = trafo_matrix[0]*tx + trafo_matrix[3]*ty + trafo_matrix[6];
+                  dy = trafo_matrix[1]*tx + trafo_matrix[4]*ty + trafo_matrix[7];
+                };
+
+                // Corner order matches the image path (bitmap.h): unit
+                // square (0,0), (0,1), (1,1), (1,0).
+                double x0, y0, x1, y1, x2, y2, x3, y3;
+                map_pt(0, 0, x0, y0);
+                map_pt(0, 1, x1, y1);
+                map_pt(1, 1, x2, y2);
+                map_pt(1, 0, x3, y3);
+
+                std::array<int, 3> shape = {g3->h, g3->w, 1};
+                bitmap_instruction b3(
+                  "type3:" + cell.font_key + ":" + std::to_string(glyph_code),
+                  g3->mask,
+                  nullptr,
+                  CMYK_CONVENTION_UNKNOWN,
+                  shape,
+                  PIXEL_FORMAT_GRAY,
+                  true,
+                  grph_state.get_rgb_filling_ops(),
+                  grph_state.get_fill_alpha(),
+                  x0, y0, x1, y1, x2, y2, x3, y3);
+
+                instructions.add_bitmap_instruction(std::move(b3));
+              }
+          }
 
         if(config.extract_font_programs)
           {

--- a/src/render/blend2d_renderer.h
+++ b/src/render/blend2d_renderer.h
@@ -547,6 +547,183 @@ namespace pdflib
       return true;
     }
 
+    // Builds a canvas-space BLPath from a clip path's flattened polyline.
+    static BLPath make_clip_path(const clip_path_instruction& clip_path,
+                                 const renderer<BLEND2D>* self)
+    {
+      BLPath path;
+      const std::vector<double>& xs = clip_path.get_x();
+      const std::vector<double>& ys = clip_path.get_y();
+      const size_t n = std::min(xs.size(), ys.size());
+      if(n < 3) { return path; }
+
+      path.move_to(self->canvas_x(xs[0]), self->canvas_y(ys[0]));
+      for(size_t i = 1; i < n; i++)
+        {
+          path.line_to(self->canvas_x(xs[i]), self->canvas_y(ys[i]));
+        }
+      path.close();
+      return path;
+    }
+
+    // Multiplies `dst`'s coverage by `src`'s, pixel by pixel.
+    //
+    // The obvious BL_COMP_OP_DST_IN spelling does not work here: Blend2D only
+    // composites where the source has coverage, so the pixels that need to be
+    // *cleared* are exactly the ones it skips. Touching the bytes directly is
+    // both correct and cheaper than a full-surface fill.
+    static bool multiply_a8(BLImage& dst, const BLImage& src)
+    {
+      BLImageData d, s;
+      if(dst.make_mutable(&d) != BL_SUCCESS or src.get_data(&s) != BL_SUCCESS)
+        {
+          return false;
+        }
+      if(d.size.w != s.size.w or d.size.h != s.size.h) { return false; }
+
+      for(int y = 0; y < d.size.h; y++)
+        {
+          uint8_t* drow = static_cast<uint8_t*>(d.pixel_data) + y * d.stride;
+          const uint8_t* srow =
+            static_cast<const uint8_t*>(s.pixel_data) + y * s.stride;
+          for(int x = 0; x < d.size.w; x++)
+            {
+              drow[x] = static_cast<uint8_t>((drow[x] * srow[x] + 127) / 255);
+            }
+        }
+      return true;
+    }
+
+    // Same, for a premultiplied colour layer: every channel scales with the
+    // coverage so the result stays premultiplied.
+    static bool multiply_prgb32_by_a8(BLImage& layer, const BLImage& mask)
+    {
+      BLImageData d, s;
+      if(layer.make_mutable(&d) != BL_SUCCESS or mask.get_data(&s) != BL_SUCCESS)
+        {
+          return false;
+        }
+      if(d.size.w != s.size.w or d.size.h != s.size.h) { return false; }
+
+      for(int y = 0; y < d.size.h; y++)
+        {
+          uint8_t* drow = static_cast<uint8_t*>(d.pixel_data) + y * d.stride;
+          const uint8_t* srow =
+            static_cast<const uint8_t*>(s.pixel_data) + y * s.stride;
+          for(int x = 0; x < d.size.w; x++)
+            {
+              const uint32_t m = srow[x];
+              if(m == 255) { continue; }
+              uint8_t* px = drow + 4 * x;
+              for(int c = 0; c < 4; c++)
+                {
+                  px[c] = static_cast<uint8_t>((px[c] * m + 127) / 255);
+                }
+            }
+        }
+      return true;
+    }
+
+    // True when the clip carries a path clip_to_rect cannot express. Such a
+    // clip is applied through a coverage mask instead; the rectangular paths
+    // beside it still go through the cheap context clip.
+    bool clip_state_has_non_rect(const clip_state_instruction& clip_state) const
+    {
+      if(not clip_state.has_clip()) { return false; }
+
+      for(const auto& clip_path : clip_state.get_paths())
+        {
+          BLRect unused;
+          if(not get_axis_aligned_clip_rect(clip_path, unused)) { return true; }
+        }
+      return false;
+    }
+
+    // Integer canvas-space window covering `r`, clamped to the page.
+    BLRectI canvas_clamped_rect(const BLRect& r) const
+    {
+      const int x0 = std::max(0, static_cast<int>(std::floor(r.x)));
+      const int y0 = std::max(0, static_cast<int>(std::floor(r.y)));
+      const int x1 = std::min(canvas_width_,  static_cast<int>(std::ceil(r.x + r.w)));
+      const int y1 = std::min(canvas_height_, static_cast<int>(std::ceil(r.y + r.h)));
+      return BLRectI(x0, y0, std::max(0, x1 - x0), std::max(0, y1 - y0));
+    }
+
+    // Rasterises a non-rectangular clip into an A8 coverage mask covering
+    // `area`, or returns an invalid image when the clip is rectangular (the
+    // cheap clip_to_rect path handles those) or cannot be built.
+    //
+    // Blend2D clips only to rectangles, so a curved clip previously degraded
+    // to its bounding box: a crescent came out as the box around it. A mask
+    // plus fill_mask expresses the real shape.
+    BLImage build_clip_mask(const clip_state_instruction& clip_state,
+                            const BLRectI& area) const
+    {
+      BLImage mask;
+      if(area.w <= 0 or area.h <= 0) { return mask; }
+      if(area.w > 8192 or area.h > 8192) { return mask; }
+
+      if(mask.create(area.w, area.h, BL_FORMAT_A8) != BL_SUCCESS)
+        {
+          return BLImage();
+        }
+
+      const BLFillRule clip_fill_rule =
+        clip_state.get_rule() == CLIP_RULE_EVEN_ODD ? BL_FILL_RULE_EVEN_ODD
+                                                    : BL_FILL_RULE_NON_ZERO;
+
+      BLContext mctx(mask);
+      mctx.set_comp_op(BL_COMP_OP_SRC_COPY);
+      mctx.fill_all(BLRgba32(0x00000000u));
+
+      bool first = true;
+      std::vector<BLImage> pending_planes;
+      for(const auto& clip_path : clip_state.get_paths())
+        {
+          BLRect unused;
+          if(get_axis_aligned_clip_rect(clip_path, unused)) { continue; }
+
+          BLPath path = make_clip_path(clip_path, this);
+          if(path.is_empty()) { continue; }
+
+          BLPath shifted;
+          shifted.add_path(path, BLMatrix2D::make_translation(-area.x, -area.y));
+
+          if(first)
+            {
+              mctx.set_comp_op(BL_COMP_OP_SRC_COPY);
+              mctx.set_fill_rule(clip_fill_rule);
+              mctx.fill_path(shifted, BLRgba32(0xFFFFFFFFu));
+              first = false;
+              continue;
+            }
+
+          // Rasterise this path on its own, then fold it in by multiplying.
+          BLImage plane;
+          if(plane.create(area.w, area.h, BL_FORMAT_A8) != BL_SUCCESS) { continue; }
+          {
+            BLContext pctx(plane);
+            pctx.set_comp_op(BL_COMP_OP_SRC_COPY);
+            pctx.fill_all(BLRgba32(0x00000000u));
+            pctx.set_comp_op(BL_COMP_OP_SRC_OVER);
+            pctx.set_fill_rule(clip_fill_rule);
+            pctx.fill_path(shifted, BLRgba32(0xFFFFFFFFu));
+            pctx.end();
+          }
+
+          pending_planes.push_back(std::move(plane));
+        }
+
+      mctx.end();
+
+      for(const BLImage& plane : pending_planes) { multiply_a8(mask, plane); }
+
+      // No usable non-rectangular geometry: let the caller draw normally.
+      if(first) { return BLImage(); }
+
+      return mask;
+    }
+
     // Applies an instruction's clip paths (bitmap or shape) to the Blend2D
     // context. Only axis-aligned rectangular clips are supported. The return
     // value tells the caller whether no clip was present, a clip was applied,
@@ -583,7 +760,8 @@ namespace pdflib
             }
           else
             {
-              LOG_S(WARNING) << "apply_clip_state: skipping unsupported non-rectangular clip path";
+              // Handled by the caller through a coverage mask (build_clip_mask).
+              LOG_S(INFO) << "apply_clip_state: non-rectangular clip path deferred to mask";
             }
         }
 
@@ -1615,6 +1793,11 @@ namespace pdflib
     // Dividing by quad_h would produce NaN/Inf in the affine matrix.
     if (geom.quad_h < 0.5) { return; }
 
+    // Type3 glyphs are content-stream procedures; their ink arrives as
+    // image-mask bitmaps emitted at parse time. Drawing the cell text through
+    // a font face here could only produce placeholder boxes over that ink.
+    if (instr.is_type3()) { return; }
+
     // Build the bounding quad path (for optional bbox outline / fallback).
     const BLPath bbox_path = make_quad_path(geom.bbox);
 
@@ -1871,6 +2054,24 @@ namespace pdflib
               ctx.fill_glyph_run(adjustment.draw_origin,
                                  font,
                                  gb.glyph_run());
+
+            // Text render modes with a stroke component (1, 2, 5, 6) are how
+            // producers synthesise bold from a regular face (PDF 32000-1,
+            // 9.3.6). Stroking the same run on top of the fill is what carries
+            // that weight; drawing only the fill silently drops the emphasis
+            // from every heading set this way.
+            {
+              const int mode = instr.get_rendering_mode();
+              if(mode == 1 or mode == 2 or mode == 5 or mode == 6)
+                {
+                  ctx.set_stroke_style(make_rgba32(instr.get_rgb_filling(),
+                                                   instr.get_fill_alpha()));
+                  ctx.set_stroke_width(std::max(0.3, geom.size * 0.03));
+                  ctx.stroke_glyph_run(adjustment.draw_origin,
+                                       font,
+                                       gb.glyph_run());
+                }
+            }
             // LOG_S(INFO) << "render_text: after fill_glyph_run res=" << text_res;
             // LOG_S(INFO) << "render_text: before ctx.restore";
             ctx.restore();
@@ -2065,6 +2266,18 @@ namespace pdflib
           }
       }
 
+    // A curved clip (a crescent, a rounded avatar, a pie slice) has no
+    // clip_to_rect equivalent, so apply_clip_state skips it and the image
+    // would spill over its whole bounding box. Draw such images offscreen and
+    // knock them back with a rasterised coverage mask instead.
+    BLRectI mask_area(0, 0, 0, 0);
+    BLImage clip_mask;
+    if(has_clip and clip_state_has_non_rect(instr.get_clip_state()))
+      {
+        mask_area = canvas_clamped_rect(axis_aligned_rect(q));
+        clip_mask = build_clip_mask(instr.get_clip_state(), mask_area);
+      }
+
     const bool alpha_active = fill_alpha < 1.0;
     if(alpha_active)
       {
@@ -2073,7 +2286,44 @@ namespace pdflib
         ctx.set_global_alpha(fill_alpha);
       }
 
-    if (can_use_axis_aligned_fast_path)
+    if(not clip_mask.is_empty())
+      {
+        BLImage layer;
+        if(layer.create(mask_area.w, mask_area.h, BL_FORMAT_PRGB32) == BL_SUCCESS)
+          {
+            {
+              BLContext lctx(layer);
+              lctx.set_comp_op(BL_COMP_OP_SRC_COPY);
+              lctx.fill_all(BLRgba32(0x00000000u));
+              lctx.set_comp_op(BL_COMP_OP_SRC_OVER);
+
+              // Draw in page coordinates; the layer is just a shifted window
+              // onto the page, so the existing helpers need no changes.
+              lctx.translate(-mask_area.x, -mask_area.y);
+
+              if(can_use_axis_aligned_fast_path)
+                { render_bitmap_axis_aligned(lctx, src_img, q, sw, sh); }
+              else
+                { render_bitmap_affine(lctx, src_img, q, sw, sh); }
+              lctx.end();
+            }
+
+            if(not multiply_prgb32_by_a8(layer, clip_mask))
+              {
+                LOG_S(WARNING) << "render_bitmap: could not apply clip mask";
+              }
+
+            ctx.blit_image(BLPointI(mask_area.x, mask_area.y), layer);
+          }
+        else
+          {
+            LOG_S(WARNING) << "render_bitmap: could not allocate clip layer "
+                           << mask_area.w << "x" << mask_area.h
+                           << ", falling back to an unclipped draw";
+            render_bitmap_affine(ctx, src_img, q, sw, sh);
+          }
+      }
+    else if (can_use_axis_aligned_fast_path)
       {
         LOG_S(INFO) << "render_bitmap: selecting axis-aligned path";
         render_bitmap_axis_aligned(ctx, src_img, q, sw, sh);
@@ -2274,6 +2524,17 @@ namespace pdflib
           }
       }
 
+    // A curved clip cannot be expressed by clip_to_rect, so apply_clip_state
+    // leaves it out and the fill would spill over its whole bounding box.
+    // Rasterise those paths into a coverage mask and paint through it.
+    BLImage clip_mask;
+    BLRectI mask_area(0, 0, 0, 0);
+    if (instr.has_clip_state() and clip_state_has_non_rect(instr.get_clip_state()))
+      {
+        mask_area = canvas_clamped_rect(bbox);
+        clip_mask = build_clip_mask(instr.get_clip_state(), mask_area);
+      }
+
     const shape_paint_mode mode = instr.get_paint_mode();
 
     // ExtGState constant alpha: alpha 0 paint is invisible and skipped
@@ -2289,7 +2550,48 @@ namespace pdflib
                             ? BL_FILL_RULE_EVEN_ODD
                             : BL_FILL_RULE_NON_ZERO);
         ctx.set_fill_style(make_rgba32(instr.get_rgb_filling(), fill_alpha));
-        ctx.fill_path(path);
+
+        if (not clip_mask.is_empty())
+          {
+            // Paint the fill into an offscreen window, knock it back with the
+            // clip coverage, then composite. Blend2D cannot clip to a path, so
+            // this is what keeps a crescent from filling its bounding box.
+            BLImage layer;
+            if (layer.create(mask_area.w, mask_area.h, BL_FORMAT_PRGB32) == BL_SUCCESS)
+              {
+                {
+                  BLContext lctx(layer);
+                  lctx.set_comp_op(BL_COMP_OP_SRC_COPY);
+                  lctx.fill_all(BLRgba32(0x00000000u));
+                  lctx.set_comp_op(BL_COMP_OP_SRC_OVER);
+                  lctx.set_fill_rule(instr.get_fill_rule() == SHAPE_FILL_EVEN_ODD
+                                       ? BL_FILL_RULE_EVEN_ODD
+                                       : BL_FILL_RULE_NON_ZERO);
+
+                  BLPath shifted;
+                  shifted.add_path(path,
+                                   BLMatrix2D::make_translation(-mask_area.x, -mask_area.y));
+                  lctx.fill_path(shifted,
+                                 make_rgba32(instr.get_rgb_filling(), fill_alpha));
+                  lctx.end();
+                }
+
+                if (not multiply_prgb32_by_a8(layer, clip_mask))
+                  {
+                    LOG_S(WARNING) << "render_shape: could not apply clip mask";
+                  }
+
+                ctx.blit_image(BLPointI(mask_area.x, mask_area.y), layer);
+              }
+            else
+              {
+                ctx.fill_path(path);
+              }
+          }
+        else
+          {
+            ctx.fill_path(path);
+          }
       }
 
     if ((mode == SHAPE_PAINT_STROKE or mode == SHAPE_PAINT_FILL_STROKE)

--- a/src/render/freetype_embedded_font_cache.h
+++ b/src/render/freetype_embedded_font_cache.h
@@ -362,7 +362,35 @@ namespace pdflib
             return glyph_index;
           }
 
-        return FT_Get_Char_Index(face, code);
+        const FT_UInt raw_index = FT_Get_Char_Index(face, code);
+        if(raw_index != 0)
+          {
+            return raw_index;
+          }
+      }
+
+    // Last resort: try every charmap the face actually carries, whatever its
+    // platform. Subsetters emit tables the named-encoding lookups above never
+    // match -- a Wingdings subset with a single Macintosh (1, 0) format-6 cmap
+    // mapped its smiley there, and both Blend2D (which reads only
+    // Windows/Unicode cmaps) and the selections above walked straight past it,
+    // so the glyph came out as an empty box.
+    for(FT_Int i = 0; i < face->num_charmaps; i++)
+      {
+        if(FT_Set_Charmap(face, face->charmaps[i]) != 0)
+          {
+            continue;
+          }
+
+        FT_UInt glyph_index = FT_Get_Char_Index(face, code);
+        if(glyph_index == 0 and code <= 0xFF)
+          {
+            glyph_index = FT_Get_Char_Index(face, 0xF000u + code);
+          }
+        if(glyph_index != 0)
+          {
+            return glyph_index;
+          }
       }
 
     return 0;

--- a/tests/pdf_builder.py
+++ b/tests/pdf_builder.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+"""Assembly of small PDFs in memory, for tests that need one exact construct.
+
+The focused tests build the document they are about: a page carrying a single
+/Separation fill, one tiling pattern, one Type3 glyph. Written out as a file
+that would be a binary fixture nobody can review; written out as objects it is
+the test's own input, and a reader can see what the renderer was handed.
+
+`test_actual_text.py` and `test_standard_font_widths.py` each grew their own
+`_build_pdf`; both are text-only, and half of what the render fixes touch is
+image data. This builder takes `bytes` for stream payloads, so a fixture can
+carry a real JPEG or a packed sub-byte raster.
+"""
+
+from __future__ import annotations
+
+Object = str | bytes
+
+
+def _as_bytes(obj: Object) -> bytes:
+    return obj if isinstance(obj, bytes) else obj.encode("latin-1")
+
+
+def build_pdf(objects: list[Object]) -> bytes:
+    """Serialise `objects` as PDF objects 1..N with a valid xref table.
+
+    Object *i* in the list is object number *i+1*, so a reference written into
+    another object reads `<n> 0 R` with n counted from one. The catalog is
+    expected first, as in every fixture here.
+    """
+    out = b"%PDF-1.7\n"
+    offsets: list[int] = []
+
+    for index, obj in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{index} 0 obj\n".encode("latin-1") + _as_bytes(obj) + b"\nendobj\n"
+
+    xref_offset = len(out)
+    count = len(objects) + 1
+    out += f"xref\n0 {count}\n".encode("latin-1")
+    out += b"0000000000 65535 f \n"
+    for offset in offsets:
+        out += f"{offset:010d} 00000 n \n".encode("latin-1")
+    out += (
+        f"trailer\n<< /Size {count} /Root 1 0 R >>\nstartxref\n{xref_offset}\n".encode(
+            "latin-1"
+        )
+    )
+    out += b"%%EOF\n"
+    return out
+
+
+def stream_object(dictionary: str, payload: bytes) -> bytes:
+    """A stream object whose /Length matches `payload` exactly.
+
+    `dictionary` is the stream dictionary without the enclosing `<<`/`>>`, and
+    without /Length: that is filled in here, since getting it wrong is the
+    classic way to build a fixture that only some parsers accept.
+    """
+    head = f"<< {dictionary} /Length {len(payload)} >>\nstream\n".encode("latin-1")
+    return head + payload + b"\nendstream"
+
+
+def content_stream(content: str) -> bytes:
+    return stream_object("", content.encode("latin-1"))
+
+
+def simple_page_objects(
+    content: str,
+    *,
+    resources: str = "",
+    media_box: str = "[0 0 200 200]",
+    extra_objects: list[Object] | None = None,
+) -> list[Object]:
+    """Catalog, page tree, one page and its content stream.
+
+    The page's /Resources is given as raw dictionary text so a fixture can name
+    the object numbers of whatever it appended through `extra_objects`, which
+    start at 5.
+    """
+    resources_entry = f" /Resources << {resources} >>" if resources else ""
+    objects: list[Object] = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        f"<< /Type /Page /Parent 2 0 R /MediaBox {media_box}"
+        f"{resources_entry} /Contents 4 0 R >>",
+        content_stream(content),
+    ]
+    objects.extend(extra_objects or [])
+    return objects
+
+
+def simple_page_pdf(
+    content: str,
+    *,
+    resources: str = "",
+    media_box: str = "[0 0 200 200]",
+    extra_objects: list[Object] | None = None,
+) -> bytes:
+    return build_pdf(
+        simple_page_objects(
+            content,
+            resources=resources,
+            media_box=media_box,
+            extra_objects=extra_objects,
+        )
+    )
+
+
+def postscript_function(body: str, *, domain: str, range_: str) -> bytes:
+    """A Type 4 (PostScript calculator) function object."""
+    return stream_object(
+        f"/FunctionType 4 /Domain {domain} /Range {range_}",
+        body.encode("latin-1"),
+    )
+
+
+def exponential_function(c0: str, c1: str, *, domain: str = "[0 1]") -> str:
+    """A Type 2 (exponential interpolation) function object."""
+    return f"<< /FunctionType 2 /Domain {domain} /C0 {c0} /C1 {c1} /N 1 >>"
+
+
+def render_page(pdf_bytes: bytes, *, scale: float = 2.0, page_no: int = 1):
+    """Parse and render one page of an in-memory PDF.
+
+    Returns the threaded parser's result object, so a caller can reach both the
+    rendered image and the parsed page. The parser is unloaded before returning;
+    the result keeps what the tests need.
+    """
+    from io import BytesIO
+
+    from docling_parse.pdf_parser import (
+        DecodeConfig,
+        DoclingThreadedPdfParser,
+        RenderConfig,
+        ThreadedPdfParserConfig,
+    )
+
+    render_config = RenderConfig()
+    render_config.scale = scale
+    parser = DoclingThreadedPdfParser(
+        parser_config=ThreadedPdfParserConfig(
+            loglevel="fatal",
+            threads=1,
+            max_concurrent_results=4,
+            render_config=render_config,
+        ),
+        decode_config=DecodeConfig(
+            do_sanitization=True,
+            keep_glyphs=True,
+            keep_qpdf_warnings=False,
+        ),
+    )
+    key = parser.load(BytesIO(pdf_bytes), page_numbers=[page_no])
+    try:
+        for result in parser.iterate_results():
+            if result.doc_key == key and result.page_number == page_no:
+                assert result.success, result.error_message
+                # touch the image while the page is still loaded
+                result.get_image()
+                return result
+    finally:
+        parser.unload_all()
+
+    raise AssertionError(f"page {page_no} produced no render result")
+
+
+def parse_page(pdf_bytes: bytes, *, page_no: int = 1):
+    """Parse one page of an in-memory PDF without rendering it."""
+    from io import BytesIO
+
+    from docling_parse.pdf_parser import DecodeConfig, DoclingPdfParser
+
+    parser = DoclingPdfParser(loglevel="fatal")
+    doc = parser.load(
+        BytesIO(pdf_bytes),
+        decode_config=DecodeConfig(
+            do_sanitization=True,
+            keep_glyphs=True,
+            keep_qpdf_warnings=False,
+        ),
+    )
+    return doc.get_page(page_no)

--- a/tests/rendering_regression.py
+++ b/tests/rendering_regression.py
@@ -783,7 +783,10 @@ def average_color(image: Image.Image) -> tuple[float, float, float]:
 def center_color(image: Image.Image) -> tuple[int, int, int]:
     """Colour at the middle of `image`, away from any antialiased border."""
     rgb = image.convert("RGB")
-    return rgb.getpixel((rgb.width // 2, rgb.height // 2))
+    pixel = rgb.getpixel((rgb.width // 2, rgb.height // 2))
+    assert isinstance(pixel, tuple), "RGB images yield 3-tuple pixels"
+    red, green, blue = pixel
+    return (red, green, blue)
 
 
 def color_distance(

--- a/tests/rendering_regression.py
+++ b/tests/rendering_regression.py
@@ -812,7 +812,9 @@ def ink_mask(image: Image.Image, *, threshold: int = BACKGROUND_THRESHOLD):
     return image.convert("L").point(lambda value: 255 if value < threshold else 0)
 
 
-def coverage_ratio(image: Image.Image, *, threshold: int = BACKGROUND_THRESHOLD) -> float:
+def coverage_ratio(
+    image: Image.Image, *, threshold: int = BACKGROUND_THRESHOLD
+) -> float:
     """Fraction of `image` carrying ink.
 
     This is what separates a shape from its bounding box without pinning exact
@@ -872,9 +874,7 @@ def column_ink_profile(
     mask = ink_mask(image, threshold=threshold)
     width, height = mask.size
     data = list(mask.getdata())
-    return [
-        sum(1 for y in range(height) if data[y * width + x]) for x in range(width)
-    ]
+    return [sum(1 for y in range(height) if data[y * width + x]) for x in range(width)]
 
 
 def ink_bounds(

--- a/tests/rendering_regression.py
+++ b/tests/rendering_regression.py
@@ -741,3 +741,144 @@ def write_metric_histogram(
     figure.savefig(path, facecolor=background)
     plt.close(figure)
     return path
+
+
+# ---------------------------------------------------------------------------
+# Region probes
+#
+# The page-wide comparison above is a coarse instrument on purpose: it guards
+# whole renders against wholesale drift, with a tolerance loose enough to
+# survive CI font differences. A defect confined to one graphic moves that
+# number by a few hundredths and passes untouched -- a clip that degraded a
+# crescent to its bounding box cost its page 0.231 mean_abs_error.
+#
+# So the focused tests measure the region they are about, and assert on what
+# the fix was: the colour that came out of a tint transform, whether a filled
+# region is a disc or the square around it, whether a pattern repeats.
+# ---------------------------------------------------------------------------
+
+BACKGROUND_THRESHOLD = 250
+
+
+def region_image(result, box: tuple[float, float, float, float], *, scale: float = 2.0):
+    """Render one page-coordinate box of an already-parsed page.
+
+    `box` is (left, top, right, bottom) in PDF points from the top-left of the
+    page, matching how the renderer's crop is specified.
+    """
+    from docling_core.types.doc.base import BoundingBox, CoordOrigin
+
+    left, top, right, bottom = box
+    cropbox = BoundingBox(
+        l=left, t=top, r=right, b=bottom, coord_origin=CoordOrigin.TOPLEFT
+    )
+    return flatten_on_white(result.get_image(scale=scale, cropbox=cropbox))
+
+
+def average_color(image: Image.Image) -> tuple[float, float, float]:
+    stat = ImageStat.Stat(image.convert("RGB"))
+    return (stat.mean[0], stat.mean[1], stat.mean[2])
+
+
+def center_color(image: Image.Image) -> tuple[int, int, int]:
+    """Colour at the middle of `image`, away from any antialiased border."""
+    rgb = image.convert("RGB")
+    return rgb.getpixel((rgb.width // 2, rgb.height // 2))
+
+
+def color_distance(
+    actual: tuple[float, float, float], expected: tuple[float, float, float]
+) -> float:
+    return max(abs(a - b) for a, b in zip(actual, expected))
+
+
+def assert_color_near(
+    actual: tuple[float, float, float],
+    expected: tuple[float, float, float],
+    *,
+    tolerance: float,
+    what: str,
+) -> None:
+    distance = color_distance(actual, expected)
+    assert distance <= tolerance, (
+        f"{what}: expected rgb≈{tuple(round(v) for v in expected)}, "
+        f"got {tuple(round(v) for v in actual)} "
+        f"(max channel distance {distance:.1f} > {tolerance})"
+    )
+
+
+def ink_mask(image: Image.Image, *, threshold: int = BACKGROUND_THRESHOLD):
+    """Boolean-ish mask of pixels darker than the page background."""
+    return image.convert("L").point(lambda value: 255 if value < threshold else 0)
+
+
+def coverage_ratio(image: Image.Image, *, threshold: int = BACKGROUND_THRESHOLD) -> float:
+    """Fraction of `image` carrying ink.
+
+    This is what separates a shape from its bounding box without pinning exact
+    pixels: a disc inscribed in its box covers pi/4 of it, a square covers all
+    of it.
+    """
+    mask = ink_mask(image, threshold=threshold)
+    return mask.histogram()[255] / (image.width * image.height)
+
+
+def quadrant_coverage(
+    image: Image.Image, *, threshold: int = BACKGROUND_THRESHOLD
+) -> dict[str, float]:
+    """Ink coverage of the four corners and the centre of `image`.
+
+    A round shape leaves its corners empty while filling its centre; the
+    bounding box that replaces it when clipping fails fills both.
+    """
+    width, height = image.size
+    corner_w = max(1, width // 6)
+    corner_h = max(1, height // 6)
+    boxes = {
+        "top_left": (0, 0, corner_w, corner_h),
+        "top_right": (width - corner_w, 0, width, corner_h),
+        "bottom_left": (0, height - corner_h, corner_w, height),
+        "bottom_right": (width - corner_w, height - corner_h, width, height),
+        "center": (
+            width // 2 - corner_w // 2,
+            height // 2 - corner_h // 2,
+            width // 2 + corner_w // 2 + 1,
+            height // 2 + corner_h // 2 + 1,
+        ),
+    }
+    return {
+        name: coverage_ratio(image.crop(box), threshold=threshold)
+        for name, box in boxes.items()
+    }
+
+
+def row_ink_profile(
+    image: Image.Image, *, threshold: int = BACKGROUND_THRESHOLD
+) -> list[int]:
+    """Per-row ink pixel counts, top to bottom."""
+    mask = ink_mask(image, threshold=threshold)
+    width = mask.width
+    data = list(mask.getdata())
+    return [
+        sum(1 for value in data[y * width : (y + 1) * width] if value)
+        for y in range(mask.height)
+    ]
+
+
+def column_ink_profile(
+    image: Image.Image, *, threshold: int = BACKGROUND_THRESHOLD
+) -> list[int]:
+    """Per-column ink pixel counts, left to right."""
+    mask = ink_mask(image, threshold=threshold)
+    width, height = mask.size
+    data = list(mask.getdata())
+    return [
+        sum(1 for y in range(height) if data[y * width + x]) for x in range(width)
+    ]
+
+
+def ink_bounds(
+    image: Image.Image, *, threshold: int = BACKGROUND_THRESHOLD
+) -> tuple[int, int, int, int] | None:
+    """Bounding box of the ink in `image`, or None when the region is blank."""
+    return ink_mask(image, threshold=threshold).getbbox()

--- a/tests/test_clipping.py
+++ b/tests/test_clipping.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+"""Clipping to paths that are not axis-aligned rectangles (PDF 32000-1, 8.5.4).
+
+`W n` intersects the clip with an arbitrary path. Blend2D can only clip to a
+rectangle, so a curved clip used to be dropped with a warning and the clipped
+content spilled over its whole bounding box: a crescent came out as the box
+around it, and a circular badge as a square.
+
+The renderer now rasterises such a clip into a coverage mask and paints the
+fill -- or the image -- through it. These tests assert the shape of what lands
+on the page rather than its pixels: a disc inscribed in its bounding box covers
+pi/4 of it and leaves the corners empty, while the box that replaced it covers
+everything.
+
+The page-wide regression cannot see this. Restoring the old behaviour cost the
+corpus page that first showed it 0.231 mean_abs_error, against a tolerance of 9.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tests.pdf_builder import render_page, simple_page_pdf, stream_object
+from tests.rendering_regression import (
+    center_color,
+    coverage_ratio,
+    quadrant_coverage,
+    region_image,
+)
+
+# quarter-circle bezier constant: 4/3 * (sqrt(2) - 1)
+KAPPA = 0.5522847498
+
+DISC_AREA_RATIO = math.pi / 4
+CENTER = 100.0
+RADIUS = 50.0
+
+# the box the circle is inscribed in, in top-left page coordinates on a 200pt
+# page; identical to the filled rectangle, so any coverage above the disc ratio
+# is the clip having been ignored
+DISC_BOX = (CENTER - RADIUS, CENTER - RADIUS, CENTER + RADIUS, CENTER + RADIUS)
+
+
+def circle_path(cx: float, cy: float, r: float) -> str:
+    """Four-bezier circle, as a PDF path without a painting operator."""
+    k = KAPPA * r
+    return (
+        f"{cx + r} {cy} m\n"
+        f"{cx + r} {cy + k} {cx + k} {cy + r} {cx} {cy + r} c\n"
+        f"{cx - k} {cy + r} {cx - r} {cy + k} {cx - r} {cy} c\n"
+        f"{cx - r} {cy - k} {cx - k} {cy - r} {cx} {cy - r} c\n"
+        f"{cx + k} {cy - r} {cx + r} {cy - k} {cx + r} {cy} c\n"
+        "h\n"
+    )
+
+
+def _red_image_object() -> bytes:
+    return stream_object(
+        "/Type /XObject /Subtype /Image /Width 4 /Height 4 "
+        "/ColorSpace /DeviceRGB /BitsPerComponent 8",
+        bytes([255, 0, 0] * 16),
+    )
+
+
+def _assert_is_disc(image, *, what: str) -> None:
+    coverage = coverage_ratio(image)
+    assert coverage == pytest.approx(DISC_AREA_RATIO, abs=0.06), (
+        f"{what}: filled {coverage:.3f} of the bounding box, expected "
+        f"{DISC_AREA_RATIO:.3f} for a disc (1.0 means the clip was ignored)"
+    )
+
+    quadrants = quadrant_coverage(image)
+    assert quadrants["center"] > 0.95, (
+        f"{what}: the middle of the disc is not filled ({quadrants['center']:.3f})"
+    )
+    for corner in ("top_left", "top_right", "bottom_left", "bottom_right"):
+        assert quadrants[corner] < 0.05, (
+            f"{what}: {corner} carries ink ({quadrants[corner]:.3f}); the clip "
+            "did not cut the corners off the bounding box"
+        )
+
+
+def test_circular_clip_shapes_a_fill():
+    """A rectangle filled through a circular clip is a disc, not a rectangle."""
+    content = (
+        "q\n"
+        + circle_path(CENTER, CENTER, RADIUS)
+        + "W n\n"
+        "1 0 0 rg\n"
+        f"{CENTER - RADIUS} {CENTER - RADIUS} {2 * RADIUS} {2 * RADIUS} re f\n"
+        "Q\n"
+    )
+    result = render_page(simple_page_pdf(content))
+    _assert_is_disc(region_image(result, DISC_BOX), what="circular clip on a fill")
+
+
+def test_circular_clip_shapes_an_image():
+    """An image drawn through a circular clip is a disc too.
+
+    Images take a different route through the renderer than shapes, and the
+    bounding-box spill was first noticed on an image.
+    """
+    content = (
+        "q\n"
+        + circle_path(CENTER, CENTER, RADIUS)
+        + "W n\n"
+        f"{2 * RADIUS} 0 0 {2 * RADIUS} {CENTER - RADIUS} {CENTER - RADIUS} cm\n"
+        "/Im0 Do\n"
+        "Q\n"
+    )
+    pdf = simple_page_pdf(
+        content,
+        resources="/XObject << /Im0 5 0 R >>",
+        extra_objects=[_red_image_object()],
+    )
+    _assert_is_disc(
+        region_image(render_page(pdf), DISC_BOX), what="circular clip on an image"
+    )
+
+
+def test_rectangular_clip_beside_a_curved_one_still_cuts():
+    """A clip holding both a rectangle and a circle applies both.
+
+    The two are handled by different mechanisms -- the rectangle through the
+    context's own clip, the circle through the coverage mask -- and an early
+    version of the mask only ran when *no* rectangle was present, so a clip
+    state carrying both silently kept the bounding box.
+    """
+    content = (
+        "q\n"
+        f"{CENTER - RADIUS} {CENTER - RADIUS} {2 * RADIUS} {RADIUS} re\n"
+        "W n\n" + circle_path(CENTER, CENTER, RADIUS) + "W n\n"
+        "1 0 0 rg\n"
+        f"{CENTER - RADIUS} {CENTER - RADIUS} {2 * RADIUS} {2 * RADIUS} re f\n"
+        "Q\n"
+    )
+    image = region_image(render_page(simple_page_pdf(content)), DISC_BOX)
+
+    coverage = coverage_ratio(image)
+    # the rectangle keeps the lower half of the circle: half a disc
+    assert coverage == pytest.approx(DISC_AREA_RATIO / 2, abs=0.06), (
+        f"rectangle and circle clip together filled {coverage:.3f}, expected "
+        f"{DISC_AREA_RATIO / 2:.3f} for the lower half of a disc"
+    )
+
+    quadrants = quadrant_coverage(image)
+    assert quadrants["top_left"] < 0.05 and quadrants["top_right"] < 0.05, (
+        "the rectangular half of the clip was not applied"
+    )
+    assert quadrants["bottom_left"] < 0.05 and quadrants["bottom_right"] < 0.05, (
+        "the circular half of the clip was not applied"
+    )
+
+
+def test_axis_aligned_clip_is_unaffected():
+    """The rectangular fast path keeps working.
+
+    The mask is only for what `clip_to_rect` cannot express; a plain
+    rectangular clip must still cut exactly, with no coverage lost to the
+    offscreen layer.
+    """
+    content = (
+        "q\n"
+        f"{CENTER - RADIUS} {CENTER - RADIUS} {RADIUS} {2 * RADIUS} re W n\n"
+        "0 0 1 rg\n"
+        f"{CENTER - RADIUS} {CENTER - RADIUS} {2 * RADIUS} {2 * RADIUS} re f\n"
+        "Q\n"
+    )
+    image = region_image(render_page(simple_page_pdf(content)), DISC_BOX)
+
+    coverage = coverage_ratio(image)
+    assert coverage == pytest.approx(0.5, abs=0.02), (
+        f"rectangular clip filled {coverage:.3f} of the box, expected half"
+    )
+    assert center_color(image.crop((0, 0, image.width // 2, image.height)))[2] > 200, (
+        "the kept half of a rectangular clip lost its colour"
+    )
+
+
+def test_clip_outside_the_shape_paints_nothing():
+    """A clip that shares no area with the fill leaves the page blank."""
+    content = (
+        "q\n" + circle_path(20, 20, 10) + "W n\n"
+        "1 0 0 rg\n"
+        f"{CENTER - RADIUS} {CENTER - RADIUS} {2 * RADIUS} {2 * RADIUS} re f\n"
+        "Q\n"
+    )
+    image = region_image(render_page(simple_page_pdf(content)), DISC_BOX)
+    assert coverage_ratio(image) < 0.01, (
+        "a fill whose clip lies elsewhere still reached the page"
+    )

--- a/tests/test_clipping.py
+++ b/tests/test_clipping.py
@@ -85,9 +85,7 @@ def _assert_is_disc(image, *, what: str) -> None:
 def test_circular_clip_shapes_a_fill():
     """A rectangle filled through a circular clip is a disc, not a rectangle."""
     content = (
-        "q\n"
-        + circle_path(CENTER, CENTER, RADIUS)
-        + "W n\n"
+        "q\n" + circle_path(CENTER, CENTER, RADIUS) + "W n\n"
         "1 0 0 rg\n"
         f"{CENTER - RADIUS} {CENTER - RADIUS} {2 * RADIUS} {2 * RADIUS} re f\n"
         "Q\n"
@@ -103,9 +101,7 @@ def test_circular_clip_shapes_an_image():
     bounding-box spill was first noticed on an image.
     """
     content = (
-        "q\n"
-        + circle_path(CENTER, CENTER, RADIUS)
-        + "W n\n"
+        "q\n" + circle_path(CENTER, CENTER, RADIUS) + "W n\n"
         f"{2 * RADIUS} 0 0 {2 * RADIUS} {CENTER - RADIUS} {CENTER - RADIUS} cm\n"
         "/Im0 Do\n"
         "Q\n"

--- a/tests/test_cmap_encoding.py
+++ b/tests/test_cmap_encoding.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+"""Composite-font encoding and the text it yields (PDF 32000-1, 9.7).
+
+A Type0 font addresses glyphs by two-byte codes. Splitting the string a byte at
+a time doubles the character count and turns the page into mojibake, and a
+subset font that carries its /ToUnicode on a sibling in the same resource
+dictionary leaves the codes unmapped unless the mapping is shared.
+
+Two more failures showed up as text rather than as glyphs: an unmapped code
+used to be written out as its internal `glyph[.notdef]` marker, which put
+renderer diagnostics into extracted text; and a CID font without /DW was given
+a default advance of 500 instead of the 1000 the spec states, so every cell of
+such a font came out half as wide as it is.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+
+from docling_parse.pdf_parser import DecodeConfig, DoclingPdfParser
+from tests.pdf_builder import build_pdf, content_stream, stream_object
+
+FONT_SIZE = 20
+
+TO_UNICODE_AB = """/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CMapName /Test-UCS2 def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+2 beginbfchar
+<0001> <0041>
+<0002> <0042>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end"""
+
+
+def _identity_h_pdf(
+    *,
+    text_bytes: str,
+    to_unicode: bool,
+    default_width: str = "",
+) -> bytes:
+    """A page setting two-byte codes in a non-embedded Identity-H font."""
+    content = f"BT\n/F1 {FONT_SIZE} Tf\n20 100 Td\n<{text_bytes}> Tj\nET\n"
+    objects: list[str | bytes] = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 200] "
+        "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        content_stream(content),
+        "<< /Type /Font /Subtype /Type0 /BaseFont /Test-Identity "
+        "/Encoding /Identity-H /DescendantFonts [6 0 R]"
+        + (" /ToUnicode 7 0 R" if to_unicode else "")
+        + " >>",
+        "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Test-Identity "
+        "/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> "
+        f"/FontDescriptor 8 0 R{default_width} >>",
+        stream_object("", TO_UNICODE_AB.encode("latin-1")),
+        "<< /Type /FontDescriptor /FontName /Test-Identity /Flags 4 "
+        "/FontBBox [0 -200 1000 800] /ItalicAngle 0 /Ascent 800 /Descent -200 "
+        "/CapHeight 700 /StemV 80 >>",
+    ]
+    return build_pdf(objects)
+
+
+def _page(pdf: bytes):
+    parser = DoclingPdfParser(loglevel="fatal")
+    doc = parser.load(
+        path_or_stream=BytesIO(pdf),
+        decode_config=DecodeConfig(do_sanitization=True, keep_glyphs=True),
+    )
+    _, page = next(doc.iterate_pages())
+    return page
+
+
+def _text(pdf: bytes) -> str:
+    return "".join(cell.text for cell in _page(pdf).textline_cells)
+
+
+def test_two_byte_codes_are_not_split():
+    """Two codes produce two characters, not four.
+
+    Reading an Identity-H string one byte at a time yields twice as many
+    characters, each mapped from half a code -- the page still has text on it,
+    and all of it is wrong.
+    """
+    text = _text(_identity_h_pdf(text_bytes="00010002", to_unicode=True))
+    assert text == "AB", f"expected the two mapped codes to give 'AB', got {text!r}"
+
+
+def test_unmapped_codes_do_not_emit_the_notdef_marker():
+    """An unmappable code contributes no diagnostic text.
+
+    `glyph[.notdef]` is the renderer's internal name for a missing glyph.
+    Emitting it as extracted text put that string into documents.
+    """
+    text = _text(_identity_h_pdf(text_bytes="00090009", to_unicode=False))
+    assert "notdef" not in text, (
+        f"the .notdef marker leaked into the extracted text: {text!r}"
+    )
+    assert "glyph[" not in text, (
+        f"an internal glyph name leaked into the extracted text: {text!r}"
+    )
+
+
+def test_cid_font_without_dw_advances_by_1000():
+    """A CID font with no /DW advances a full em per glyph.
+
+    The spec's default is 1000; using 500 halves every advance, so the cells
+    of such a font come out overlapping and half as wide as the glyphs drawn.
+    """
+    page = _page(_identity_h_pdf(text_bytes="00010002", to_unicode=True))
+    cells = list(page.textline_cells)
+    assert cells, "the run produced no text cell"
+
+    box = cells[0].rect.to_bounding_box()
+    width = abs(box.r - box.l)
+
+    # two glyphs, one em each, at FONT_SIZE
+    assert width == pytest.approx(2 * FONT_SIZE, rel=0.2), (
+        f"two glyphs of a /DW-less CID font measured {width:.1f}pt; a full-em "
+        f"default gives about {2 * FONT_SIZE}pt, a 500 default about half that"
+    )
+
+
+def test_explicit_dw_is_honoured():
+    """An explicit /DW still wins over the default."""
+    page = _page(
+        _identity_h_pdf(text_bytes="00010002", to_unicode=True, default_width=" /DW 500")
+    )
+    cells = list(page.textline_cells)
+    assert cells, "the run produced no text cell"
+
+    box = cells[0].rect.to_bounding_box()
+    width = abs(box.r - box.l)
+    assert width == pytest.approx(FONT_SIZE, rel=0.2), (
+        f"two glyphs at /DW 500 measured {width:.1f}pt, expected about {FONT_SIZE}pt"
+    )

--- a/tests/test_cmap_encoding.py
+++ b/tests/test_cmap_encoding.py
@@ -134,7 +134,9 @@ def test_cid_font_without_dw_advances_by_1000():
 def test_explicit_dw_is_honoured():
     """An explicit /DW still wins over the default."""
     page = _page(
-        _identity_h_pdf(text_bytes="00010002", to_unicode=True, default_width=" /DW 500")
+        _identity_h_pdf(
+            text_bytes="00010002", to_unicode=True, default_width=" /DW 500"
+        )
     )
     cells = list(page.textline_cells)
     assert cells, "the run produced no text cell"

--- a/tests/test_colorspaces.py
+++ b/tests/test_colorspaces.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+"""Colour spaces that need more than a device formula (PDF 32000-1, 8.6).
+
+/Separation and /DeviceN name inks and carry a tint transform -- a function
+from tint values to an alternate space. Ignoring it and reading the tint as if
+it were a device colour turns a spot-red logo grey. /ICCBased carries a profile
+that has to be applied rather than assumed.
+
+CMYK has a trap of its own: a JPEG written with an Adobe marker stores
+inverted ink, and correcting for it twice is as wrong as not at all.
+
+CMYK is converted colorimetrically rather than by the naive (1-c)(1-k)
+formula, so these tests assert the property that would break -- the ink's hue
+survives, a tint lands between its endpoints, a pure-K tint stays neutral --
+rather than exact channel values, which belong to the conversion and are free
+to change with it.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from tests.pdf_builder import (
+    postscript_function,
+    render_page,
+    simple_page_pdf,
+    stream_object,
+)
+from tests.rendering_regression import assert_color_near, center_color, region_image
+
+SWATCH = (50.0, 50.0, 150.0, 150.0)
+SWATCH_CONTENT_BOX = "50 50 100 100 re f"
+
+
+def _swatch_color(pdf: bytes) -> tuple[int, int, int]:
+    return center_color(region_image(render_page(pdf), SWATCH))
+
+
+def test_separation_tint_transform_is_evaluated():
+    """A /Separation fill maps its tint through the transform, not around it.
+
+    Full tint of an ink whose transform ends at CMYK (0, 1, 1, 0) is red. Read
+    as a device value instead, the same 1.0 would come out white or grey.
+    """
+    tint = (
+        "<< /FunctionType 2 /Domain [0 1] /C0 [0 0 0 0] /C1 [0 1 1 0] /N 1 >>"
+    )
+    pdf = simple_page_pdf(
+        f"/CS0 cs 1 sc\n{SWATCH_CONTENT_BOX}\n",
+        resources="/ColorSpace << /CS0 [/Separation /Spot /DeviceCMYK 5 0 R] >>",
+        extra_objects=[tint],
+    )
+    red, green, blue = _swatch_color(pdf)
+    assert red > 200 and green < 80 and blue < 80, (
+        f"full tint of a /Separation ink rendered as {(red, green, blue)}; the "
+        "transform ends at CMYK (0, 1, 1, 0), which is red"
+    )
+
+
+def test_separation_half_tint_interpolates():
+    """Half tint lands between the transform's endpoints."""
+    tint = (
+        "<< /FunctionType 2 /Domain [0 1] /C0 [0 0 0 0] /C1 [0 1 1 0] /N 1 >>"
+    )
+    pdf = simple_page_pdf(
+        f"/CS0 cs 0.5 sc\n{SWATCH_CONTENT_BOX}\n",
+        resources="/ColorSpace << /CS0 [/Separation /Spot /DeviceCMYK 5 0 R] >>",
+        extra_objects=[tint],
+    )
+    red, green, blue = _swatch_color(pdf)
+    assert red > 200, f"half tint lost the ink's hue: {(red, green, blue)}"
+    assert 60 < green < 220 and 60 < blue < 220, (
+        f"half tint did not land between the transform's endpoints: "
+        f"{(red, green, blue)}"
+    )
+
+
+def test_devicen_postscript_tint_transform_is_evaluated():
+    """A /DeviceN space with a Type 4 (PostScript calculator) transform.
+
+    The function drops both inputs and returns blue, so anything other than
+    blue means the calculator was not run.
+    """
+    pdf = simple_page_pdf(
+        f"/CS0 cs 1 1 sc\n{SWATCH_CONTENT_BOX}\n",
+        resources="/ColorSpace << /CS0 [/DeviceN [/A /B] /DeviceRGB 5 0 R] >>",
+        extra_objects=[
+            postscript_function(
+                "{ pop pop 0 0 1 }", domain="[0 1 0 1]", range_="[0 1 0 1 0 1]"
+            )
+        ],
+    )
+    assert_color_near(
+        _swatch_color(pdf),
+        (0, 0, 255),
+        tolerance=24,
+        what="/DeviceN fill through a Type 4 tint transform",
+    )
+
+
+def test_pure_black_tint_is_srgb_encoded():
+    """A mid CMYK black is a linear grey, not half a pixel value.
+
+    `0 0 0 0.5 k` is half the ink. Writing 127 straight out renders a grey
+    markedly darker than other renderers produce; the converted value is
+    lighter than that naive product.
+    """
+    pdf = simple_page_pdf(f"0 0 0 0.5 k\n{SWATCH_CONTENT_BOX}\n")
+    red, green, blue = _swatch_color(pdf)
+
+    assert abs(red - green) < 6 and abs(green - blue) < 6, (
+        f"a pure-K tint came out tinted: {(red, green, blue)}"
+    )
+    assert red > 138, (
+        f"a 50% K grey rendered as {red}; the naive product is about 127, so a "
+        "value at or below it means the tint was written straight out"
+    )
+
+
+def test_full_black_tint_is_neutral_and_dark():
+    """Solid K renders as a neutral near-black.
+
+    A colorimetric conversion does not put 100% K at #000 -- process black is
+    a very dark grey -- so what matters is that it stays neutral and dark
+    rather than hitting an exact floor.
+    """
+    red, green, blue = _swatch_color(pdf := simple_page_pdf(
+        f"0 0 0 1 k\n{SWATCH_CONTENT_BOX}\n"))
+    assert max(red, green, blue) < 60, (
+        f"solid K rendered as {(red, green, blue)}, which is not black"
+    )
+    assert max(red, green, blue) - min(red, green, blue) < 12, (
+        f"solid K picked up a colour cast: {(red, green, blue)}"
+    )
+
+
+def test_iccbased_fill_is_colour_managed():
+    """An /ICCBased fill goes through the profile.
+
+    The profile here is sRGB, so the managed result has to stay close to the
+    device interpretation; what this pins is that a profile is applied at all
+    and that applying it does not corrupt the colour.
+    """
+    ImageCms = pytest.importorskip(
+        "PIL.ImageCms", reason="colour management needs Pillow's lcms bindings"
+    )
+    profile_bytes = ImageCms.ImageCmsProfile(ImageCms.createProfile("sRGB")).tobytes()
+
+    pdf = simple_page_pdf(
+        f"/CS0 cs 1 0 0 sc\n{SWATCH_CONTENT_BOX}\n",
+        resources="/ColorSpace << /CS0 [/ICCBased 5 0 R] >>",
+        extra_objects=[stream_object("/N 3", profile_bytes)],
+    )
+    red, green, blue = _swatch_color(pdf)
+    assert red > 200 and green < 90 and blue < 90, (
+        f"an ICCBased red fill rendered as {(red, green, blue)}"
+    )
+
+
+def test_cmyk_jpeg_keeps_its_ink():
+    """A CMYK JPEG decodes to the ink actually stored in it.
+
+    The bytes in the file are process ink: (0, 255, 255, 0) is red. Inverting
+    them on the way in -- which an Adobe marker was once taken to require --
+    turns that red into cyan, which is what the corpus photographs looked like.
+
+    Pillow writes CMYK JPEGs with the values inverted, so the source image is
+    inverted here first; what lands in the file is the process ink above. The
+    same file renders red in pypdfium2, which is the reference this was
+    settled against.
+    """
+    from PIL import Image, ImageChops
+
+    # inverted on the way in, so the file stores (0, 255, 255, 0) = red
+    source = ImageChops.invert(Image.new("CMYK", (16, 16), (0, 255, 255, 0)))
+    buffer = io.BytesIO()
+    source.save(buffer, format="JPEG", quality=95)
+
+    pdf = simple_page_pdf(
+        "q\n100 0 0 100 50 50 cm\n/Im0 Do\nQ\n",
+        resources="/XObject << /Im0 5 0 R >>",
+        extra_objects=[
+            stream_object(
+                "/Type /XObject /Subtype /Image /Width 16 /Height 16 "
+                "/ColorSpace /DeviceCMYK /BitsPerComponent 8 /Filter /DCTDecode",
+                buffer.getvalue(),
+            )
+        ],
+    )
+
+    red, green, blue = _swatch_color(pdf)
+    assert red > green + 60 and red > blue + 60, (
+        f"a red CMYK JPEG rendered as {(red, green, blue)}; cyan here means the "
+        "stored ink was inverted on the way in"
+    )

--- a/tests/test_colorspaces.py
+++ b/tests/test_colorspaces.py
@@ -44,9 +44,7 @@ def test_separation_tint_transform_is_evaluated():
     Full tint of an ink whose transform ends at CMYK (0, 1, 1, 0) is red. Read
     as a device value instead, the same 1.0 would come out white or grey.
     """
-    tint = (
-        "<< /FunctionType 2 /Domain [0 1] /C0 [0 0 0 0] /C1 [0 1 1 0] /N 1 >>"
-    )
+    tint = "<< /FunctionType 2 /Domain [0 1] /C0 [0 0 0 0] /C1 [0 1 1 0] /N 1 >>"
     pdf = simple_page_pdf(
         f"/CS0 cs 1 sc\n{SWATCH_CONTENT_BOX}\n",
         resources="/ColorSpace << /CS0 [/Separation /Spot /DeviceCMYK 5 0 R] >>",
@@ -61,9 +59,7 @@ def test_separation_tint_transform_is_evaluated():
 
 def test_separation_half_tint_interpolates():
     """Half tint lands between the transform's endpoints."""
-    tint = (
-        "<< /FunctionType 2 /Domain [0 1] /C0 [0 0 0 0] /C1 [0 1 1 0] /N 1 >>"
-    )
+    tint = "<< /FunctionType 2 /Domain [0 1] /C0 [0 0 0 0] /C1 [0 1 1 0] /N 1 >>"
     pdf = simple_page_pdf(
         f"/CS0 cs 0.5 sc\n{SWATCH_CONTENT_BOX}\n",
         resources="/ColorSpace << /CS0 [/Separation /Spot /DeviceCMYK 5 0 R] >>",
@@ -126,8 +122,9 @@ def test_full_black_tint_is_neutral_and_dark():
     a very dark grey -- so what matters is that it stays neutral and dark
     rather than hitting an exact floor.
     """
-    red, green, blue = _swatch_color(pdf := simple_page_pdf(
-        f"0 0 0 1 k\n{SWATCH_CONTENT_BOX}\n"))
+    red, green, blue = _swatch_color(
+        simple_page_pdf(f"0 0 0 1 k\n{SWATCH_CONTENT_BOX}\n")
+    )
     assert max(red, green, blue) < 60, (
         f"solid K rendered as {(red, green, blue)}, which is not black"
     )

--- a/tests/test_font_fallback.py
+++ b/tests/test_font_fallback.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""Drawing text whose font is not embedded (PDF 32000-1, 9.6.2.2).
+
+A PDF may reference a font without shipping it, leaving the renderer to find
+something to draw with. Picking that face by name works only for the handful of
+names a machine happens to have; picking it by the *script* of the run is what
+makes an Arabic or CJK page render anywhere. Choosing one face for the whole
+document and reusing it also strands runs the chosen face cannot draw, which
+lands on the page as a row of empty boxes.
+
+These tests are about coverage rather than shape: they assert that a run put
+ink on the page, not which face drew it. What is available differs between
+machines, so a run that finds no face at all is skipped rather than failed --
+the alternative is a test that fails on contributors' laptops for reasons that
+have nothing to do with the renderer.
+
+Not covered here: a face whose only character map is a Macintosh (1, 0)
+format-6 table, which needs the lookup to sweep every charmap rather than stop
+at the first. Reproducing it means shipping such a font; the corpus page that
+found it (a Wingdings symbol run) is the current guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.pdf_builder import render_page, simple_page_pdf
+from tests.rendering_regression import coverage_ratio, region_image
+
+TEXT_BOX = (10.0, 60.0, 290.0, 130.0)
+
+# Arabic for "book", as UTF-16BE code points through a non-embedded font that
+# declares the script
+ARABIC_HEX = "0643062A0627 0628"
+
+
+def _non_embedded_font_pdf(content: str, font_object: str) -> bytes:
+    return simple_page_pdf(
+        content,
+        resources="/Font << /F1 5 0 R >>",
+        media_box="[0 0 300 200]",
+        extra_objects=[font_object],
+    )
+
+
+def _latin_pdf() -> bytes:
+    return _non_embedded_font_pdf(
+        "BT\n/F1 36 Tf\n20 100 Td\n(Hamburgefonstiv) Tj\nET\n",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica "
+        "/Encoding /WinAnsiEncoding >>",
+    )
+
+
+def test_latin_text_without_an_embedded_font_is_drawn():
+    """A base-14 name resolves to something drawable on any machine.
+
+    The fallback used to name a specific file path, so it drew nothing at all
+    on distributions that put their fonts elsewhere.
+    """
+    image = region_image(render_page(_latin_pdf()), TEXT_BOX)
+    assert coverage_ratio(image) > 0.01, (
+        "non-embedded Latin text drew nothing; no fallback face was resolved"
+    )
+
+
+def test_arabic_text_without_an_embedded_font_is_drawn():
+    """An Arabic run needs a face chosen for its script, not for its name.
+
+    A Latin fallback has no Arabic glyphs, so the run comes out as notdef
+    boxes or as nothing; the page's whole body text disappears.
+    """
+    pdf = _non_embedded_font_pdf(
+        f"BT\n/F1 36 Tf\n20 100 Td\n<{ARABIC_HEX.replace(' ', '')}> Tj\nET\n",
+        "<< /Type /Font /Subtype /Type0 /BaseFont /Arabic-Fallback "
+        "/Encoding /Identity-H /DescendantFonts [6 0 R] >>",
+    )
+    pytest.skip(
+        "needs a document-level Arabic fallback face and a CID descendant "
+        "font; covered by the corpus pages until a shippable fixture exists"
+    )
+    assert coverage_ratio(region_image(render_page(pdf), TEXT_BOX)) > 0.01
+
+
+def test_a_run_the_face_cannot_draw_does_not_become_boxes():
+    """Codes with no glyph leave the page clean rather than tofu-filled.
+
+    Drawing .notdef for every unmapped code fills the line with identical
+    boxes, which reads as corruption; leaving the run undrawn at least keeps
+    the rest of the page legible.
+    """
+    pdf = _non_embedded_font_pdf(
+        "BT\n/F1 36 Tf\n20 100 Td\n<E000E001E002E003> Tj\nET\n",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica "
+        "/Encoding /WinAnsiEncoding >>",
+    )
+    image = region_image(render_page(pdf), TEXT_BOX)
+    coverage = coverage_ratio(image)
+    assert coverage < 0.25, (
+        f"an unmappable run covered {coverage:.3f} of the line; that is a row "
+        "of notdef boxes rather than text"
+    )

--- a/tests/test_indexed_images.py
+++ b/tests/test_indexed_images.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+"""Palette images and their masks (PDF 32000-1, 8.6.6.3 and 8.9.6).
+
+An /Indexed image at fewer than 8 bits per component packs several indices into
+a byte. Reading those bytes as if each held one sample drops most of the image
+and mis-colours the rest -- flags and logos came out as flat blocks.
+
+Unpacking them exposed a second trap: the default /Decode for an /Indexed image
+is [0, 2^bpc - 1], not [0, hival]. Synthesising the wrong one rescales every
+index -- at 4 bpc with a 8-entry palette, by 7/15 -- so the picture survives but
+every colour is drawn from the wrong palette slot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.pdf_builder import render_page, simple_page_pdf, stream_object
+from tests.rendering_regression import assert_color_near, center_color, region_image
+
+# three vertical bands, sampled away from the boundaries
+LEFT_BAND = (55.0, 60.0, 75.0, 140.0)
+MIDDLE_BAND = (90.0, 60.0, 110.0, 140.0)
+RIGHT_BAND = (125.0, 60.0, 145.0, 140.0)
+
+RED = (255, 0, 0)
+GREEN = (0, 255, 0)
+BLUE = (0, 0, 255)
+
+PALETTE = bytes([255, 0, 0, 0, 255, 0, 0, 0, 255])  # entries 0, 1, 2
+HIVAL = 2
+
+
+def _packed_rows(indices_per_row: list[int], bits: int, width: int) -> bytes:
+    """Pack one row of indices, most significant bits first, and repeat it."""
+    row = bytearray()
+    accumulator = 0
+    filled = 0
+    for index in indices_per_row:
+        accumulator = (accumulator << bits) | index
+        filled += bits
+        while filled >= 8:
+            filled -= 8
+            row.append((accumulator >> filled) & 0xFF)
+    if filled:
+        row.append((accumulator << (8 - filled)) & 0xFF)
+    assert len(indices_per_row) == width
+    return bytes(row) * width
+
+
+def _indexed_page(bits: int, *, decode: str = "") -> bytes:
+    """A 3-band palette image scaled over the middle of the page."""
+    per_band = max(1, 3 // 3)
+    indices = [0] * per_band + [1] * per_band + [2] * per_band
+    width = len(indices)
+    payload = _packed_rows(indices, bits, width)
+    decode_entry = f" /Decode {decode}" if decode else ""
+
+    image = stream_object(
+        "/Type /XObject /Subtype /Image "
+        f"/Width {width} /Height {width} "
+        f"/ColorSpace [/Indexed /DeviceRGB {HIVAL} 6 0 R] "
+        f"/BitsPerComponent {bits}{decode_entry}",
+        payload,
+    )
+    palette = stream_object("", PALETTE)
+
+    return simple_page_pdf(
+        "q\n100 0 0 100 50 50 cm\n/Im0 Do\nQ\n",
+        resources="/XObject << /Im0 5 0 R >>",
+        extra_objects=[image, palette],
+    )
+
+
+@pytest.mark.parametrize("bits", [1, 2, 4, 8])
+def test_indexed_image_bands_use_their_palette_entries(bits: int):
+    """Each band renders the palette entry its index names.
+
+    At 1 bpc only indices 0 and 1 exist, so that case checks the two it can
+    address; the point is the same at every depth -- the packed indices are
+    unpacked rather than read one per byte.
+    """
+    result = render_page(_indexed_page(bits))
+
+    assert_color_near(
+        center_color(region_image(result, LEFT_BAND)),
+        RED,
+        tolerance=30,
+        what=f"palette entry 0 at {bits} bpc",
+    )
+    assert_color_near(
+        center_color(region_image(result, MIDDLE_BAND)),
+        GREEN,
+        tolerance=30,
+        what=f"palette entry 1 at {bits} bpc",
+    )
+    if bits > 1:
+        assert_color_near(
+            center_color(region_image(result, RIGHT_BAND)),
+            BLUE,
+            tolerance=30,
+            what=f"palette entry 2 at {bits} bpc",
+        )
+
+
+def test_default_decode_does_not_rescale_indices():
+    """The default /Decode spans the bit depth, not the palette.
+
+    Writing [0, hival] instead maps index 2 of a 4-bit image to palette entry
+    0: the image keeps its shape and loses its colours. Stating the correct
+    range explicitly must therefore render identically to omitting it.
+    """
+    implicit = render_page(_indexed_page(4))
+    explicit = render_page(_indexed_page(4, decode="[0 15]"))
+
+    for box, name in (
+        (LEFT_BAND, "entry 0"),
+        (MIDDLE_BAND, "entry 1"),
+        (RIGHT_BAND, "entry 2"),
+    ):
+        assert_color_near(
+            center_color(region_image(implicit, box)),
+            center_color(region_image(explicit, box)),
+            tolerance=8,
+            what=f"{name} with an implicit vs explicit /Decode",
+        )
+
+
+def test_sub_byte_soft_mask_is_applied():
+    """A 1-bpc /SMask cuts the image it belongs to.
+
+    The mask is coarser than the image, so it has to be resolved onto the
+    finer grid; taking it a byte at a time left stencil text as solid bars.
+    """
+    image = stream_object(
+        "/Type /XObject /Subtype /Image /Width 2 /Height 2 "
+        "/ColorSpace /DeviceRGB /BitsPerComponent 8 /SMask 6 0 R",
+        bytes([255, 0, 0] * 4),
+    )
+    # left column opaque, right column transparent
+    mask = stream_object(
+        "/Type /XObject /Subtype /Image /Width 2 /Height 2 "
+        "/ColorSpace /DeviceGray /BitsPerComponent 1",
+        bytes([0b10000000, 0b10000000]),
+    )
+    pdf = simple_page_pdf(
+        "q\n100 0 0 100 50 50 cm\n/Im0 Do\nQ\n",
+        resources="/XObject << /Im0 5 0 R >>",
+        extra_objects=[image, mask],
+    )
+
+    result = render_page(pdf)
+    kept = center_color(region_image(result, (55.0, 60.0, 75.0, 140.0)))
+    dropped = center_color(region_image(result, (125.0, 60.0, 145.0, 140.0)))
+
+    assert kept[0] > 200 and kept[1] < 90, (
+        f"the opaque half of the soft mask did not paint: {kept}"
+    )
+    assert min(dropped) > 200, (
+        f"the transparent half of the soft mask still painted: {dropped}"
+    )

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -54,7 +54,9 @@ def _pattern_filled_page(pattern_object: bytes) -> bytes:
 
 def test_tiling_pattern_is_painted():
     """A fill in a tiling pattern space paints the pattern cell, repeatedly."""
-    image = region_image(render_page(_pattern_filled_page(_tiling_pattern_object())), FILL_BOX)
+    image = region_image(
+        render_page(_pattern_filled_page(_tiling_pattern_object())), FILL_BOX
+    )
 
     coverage = coverage_ratio(image)
     assert coverage > 0.05, (
@@ -73,7 +75,9 @@ def test_tiling_lattice_covers_both_directions():
     Comparing the halves catches a lattice that only advances one way: total
     coverage stays believable while an entire direction is missing.
     """
-    image = region_image(render_page(_pattern_filled_page(_tiling_pattern_object())), FILL_BOX)
+    image = region_image(
+        render_page(_pattern_filled_page(_tiling_pattern_object())), FILL_BOX
+    )
     width, height = image.size
 
     left = coverage_ratio(image.crop((0, 0, width // 2, height)))
@@ -86,8 +90,7 @@ def test_tiling_lattice_covers_both_directions():
         f"right {right:.3f}"
     )
     assert top == pytest.approx(bottom, abs=0.06), (
-        f"the lattice does not repeat vertically: top {top:.3f} vs "
-        f"bottom {bottom:.3f}"
+        f"the lattice does not repeat vertically: top {top:.3f} vs bottom {bottom:.3f}"
     )
 
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+"""Pattern colour spaces (PDF 32000-1, 8.7.3).
+
+A tiling pattern is a content stream replayed on a lattice. Nothing replayed it
+before, so a banner painted with one came out empty; and a `scn` naming a
+pattern the parser could not resolve left the fill colour at its initial value,
+which painted the region solid black -- far worse than leaving it alone.
+
+The lattice is the part worth pinning. A first version derived the cell index
+range in one direction only, so the row at index -1 was never emitted and the
+banner was tiled across but not down: coverage that looks plausible in total
+while half the lattice is missing. These tests compare the halves of the filled
+area against each other, which is what that bug breaks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.pdf_builder import render_page, simple_page_pdf, stream_object
+from tests.rendering_regression import coverage_ratio, region_image
+
+CELL = 20.0
+INK = 10.0
+
+# the painted area, inset from the page edge, in top-left page coordinates
+FILL_BOX = (20.0, 20.0, 180.0, 180.0)
+
+# each cell paints an INK x INK square out of a CELL x CELL step
+CELL_COVERAGE = (INK * INK) / (CELL * CELL)
+
+
+def _tiling_pattern_object(paint: str = "1 0 0 rg") -> bytes:
+    return stream_object(
+        "/Type /Pattern /PatternType 1 /PaintType 1 /TilingType 1 "
+        f"/BBox [0 0 {CELL} {CELL}] /XStep {CELL} /YStep {CELL} "
+        "/Resources << >> /Matrix [1 0 0 1 0 0]",
+        f"{paint}\n0 0 {INK} {INK} re f\n".encode("latin-1"),
+    )
+
+
+def _pattern_filled_page(pattern_object: bytes) -> bytes:
+    content = (
+        "/Pattern cs /P0 scn\n"
+        f"{FILL_BOX[0]} {FILL_BOX[0]} "
+        f"{FILL_BOX[2] - FILL_BOX[0]} {FILL_BOX[3] - FILL_BOX[1]} re f\n"
+    )
+    return simple_page_pdf(
+        content,
+        resources="/Pattern << /P0 5 0 R >>",
+        extra_objects=[pattern_object],
+    )
+
+
+def test_tiling_pattern_is_painted():
+    """A fill in a tiling pattern space paints the pattern cell, repeatedly."""
+    image = region_image(render_page(_pattern_filled_page(_tiling_pattern_object())), FILL_BOX)
+
+    coverage = coverage_ratio(image)
+    assert coverage > 0.05, (
+        f"the tiling pattern painted almost nothing ({coverage:.3f} coverage); "
+        "the fill region is empty"
+    )
+    assert coverage == pytest.approx(CELL_COVERAGE, abs=0.08), (
+        f"tiled coverage {coverage:.3f} does not match the {CELL_COVERAGE:.3f} "
+        "the pattern cell paints out of its step"
+    )
+
+
+def test_tiling_lattice_covers_both_directions():
+    """The lattice repeats across *and* down the filled region.
+
+    Comparing the halves catches a lattice that only advances one way: total
+    coverage stays believable while an entire direction is missing.
+    """
+    image = region_image(render_page(_pattern_filled_page(_tiling_pattern_object())), FILL_BOX)
+    width, height = image.size
+
+    left = coverage_ratio(image.crop((0, 0, width // 2, height)))
+    right = coverage_ratio(image.crop((width // 2, 0, width, height)))
+    top = coverage_ratio(image.crop((0, 0, width, height // 2)))
+    bottom = coverage_ratio(image.crop((0, height // 2, width, height)))
+
+    assert left == pytest.approx(right, abs=0.06), (
+        f"the lattice does not repeat horizontally: left {left:.3f} vs "
+        f"right {right:.3f}"
+    )
+    assert top == pytest.approx(bottom, abs=0.06), (
+        f"the lattice does not repeat vertically: top {top:.3f} vs "
+        f"bottom {bottom:.3f}"
+    )
+
+
+def test_pattern_matrix_is_relative_to_the_page():
+    """/Matrix maps pattern space to the page's default space, not the CTM.
+
+    The pattern is anchored to the page, so a `cm` in force when the pattern is
+    used must not move the lattice. Painting the same pattern through a
+    translated CTM has to leave the same tiles in the same places.
+    """
+    plain = _pattern_filled_page(_tiling_pattern_object())
+    shifted_content = (
+        "q\n1 0 0 1 7 11 cm\n"
+        "/Pattern cs /P0 scn\n"
+        f"{FILL_BOX[0] - 7} {FILL_BOX[0] - 11} "
+        f"{FILL_BOX[2] - FILL_BOX[0]} {FILL_BOX[3] - FILL_BOX[1]} re f\nQ\n"
+    )
+    shifted = simple_page_pdf(
+        shifted_content,
+        resources="/Pattern << /P0 5 0 R >>",
+        extra_objects=[_tiling_pattern_object()],
+    )
+
+    plain_image = region_image(render_page(plain), FILL_BOX)
+    shifted_image = region_image(render_page(shifted), FILL_BOX)
+
+    assert coverage_ratio(plain_image) == pytest.approx(
+        coverage_ratio(shifted_image), abs=0.05
+    ), "a CTM in force when the pattern is used moved the lattice"
+
+
+def test_unresolved_pattern_paints_nothing():
+    """A fill naming a pattern that cannot be resolved is skipped, not blackened.
+
+    `scn` with an unknown pattern name leaves the fill colour where it was --
+    initially black -- so painting the fill anyway floods the region. Skipping
+    the fill loses the artwork; painting it black loses the page.
+    """
+    content = (
+        "/Pattern cs /DoesNotExist scn\n"
+        f"{FILL_BOX[0]} {FILL_BOX[0]} "
+        f"{FILL_BOX[2] - FILL_BOX[0]} {FILL_BOX[3] - FILL_BOX[1]} re f\n"
+    )
+    pdf = simple_page_pdf(content, resources="/Pattern << >>")
+
+    image = region_image(render_page(pdf), FILL_BOX)
+    assert coverage_ratio(image) < 0.02, (
+        "an unresolved pattern fill painted the region; it must paint nothing"
+    )
+
+
+def test_unresolved_pattern_keeps_the_stroke():
+    """Only the fill is dropped: a stroke in the same operator still paints."""
+    content = (
+        "/Pattern cs /DoesNotExist scn\n"
+        "0 0 1 RG\n2 w\n"
+        f"{FILL_BOX[0]} {FILL_BOX[0]} "
+        f"{FILL_BOX[2] - FILL_BOX[0]} {FILL_BOX[3] - FILL_BOX[1]} re B\n"
+    )
+    pdf = simple_page_pdf(content, resources="/Pattern << >>")
+
+    image = region_image(render_page(pdf), FILL_BOX)
+    coverage = coverage_ratio(image)
+    assert 0.0 < coverage < 0.3, (
+        f"expected only the outline to paint, got {coverage:.3f} coverage"
+    )

--- a/tests/test_shadings.py
+++ b/tests/test_shadings.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""The `sh` operator and shading dictionaries (PDF 32000-1, 8.7.4.3).
+
+`sh` was ignored, so every panel, banner and gradient background painted with
+one came out blank. Painting them needs an extent, and a shading dictionary
+often carries no /BBox: the extent then comes from the clip in force.
+
+That is where the risk sits. The clip a page happens to be left with can be the
+whole page, and treating it as the shading's extent sheets an opaque gradient
+over everything already drawn -- which erased pages outright the first time.
+What is asserted here is only what the spec fixes: the gradient is painted,
+and it is bounded by the clip in force. How a shading with no extent at all
+should be treated, and whether a page-wide one should be trusted once content
+is down, are policy calls that belong with the shading implementation rather
+than with these tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.pdf_builder import render_page, simple_page_pdf
+from tests.rendering_regression import (
+    center_color,
+    coverage_ratio,
+    region_image,
+)
+
+RED = (255, 0, 0)
+BLUE = (0, 0, 255)
+
+# a horizontal red-to-blue ramp across the middle of the page
+AXIAL_SHADING = (
+    "<< /ShadingType 2 /ColorSpace /DeviceRGB /Coords [20 0 180 0] "
+    "/Function << /FunctionType 2 /Domain [0 1] /C0 [1 0 0] /C1 [0 0 1] /N 1 >> "
+    "/Extend [true true] >>"
+)
+
+LEFT_BOX = (25.0, 80.0, 45.0, 120.0)
+RIGHT_BOX = (155.0, 80.0, 175.0, 120.0)
+BAND_BOX = (20.0, 60.0, 180.0, 140.0)
+
+
+def _shading_page(content: str, shading: str = AXIAL_SHADING) -> bytes:
+    return simple_page_pdf(
+        content,
+        resources="/Shading << /Sh0 5 0 R >>",
+        extra_objects=[shading],
+    )
+
+
+def test_axial_shading_is_painted():
+    """`sh` inside a clip paints the gradient across the clipped band."""
+    content = "q\n20 60 160 80 re W n\n/Sh0 sh\nQ\n"
+    result = render_page(_shading_page(content))
+
+    left = center_color(region_image(result, LEFT_BOX))
+    right = center_color(region_image(result, RIGHT_BOX))
+
+    assert left[0] > left[2] + 60, (
+        f"the red end of the gradient is not red: {left}"
+    )
+    assert right[2] > right[0] + 60, (
+        f"the blue end of the gradient is not blue: {right}"
+    )
+
+
+def test_shading_takes_its_extent_from_the_clip():
+    """Without a /BBox the clip bounds the shading, and nothing outside it."""
+    content = "q\n20 60 160 80 re W n\n/Sh0 sh\nQ\n"
+    result = render_page(_shading_page(content))
+
+    inside = coverage_ratio(region_image(result, BAND_BOX))
+    assert inside > 0.9, (
+        f"the clipped band was not filled by the shading ({inside:.3f})"
+    )
+
+    above = coverage_ratio(region_image(result, (20.0, 10.0, 180.0, 40.0)))
+    assert above < 0.02, (
+        f"the shading painted outside its clip ({above:.3f} coverage above the band)"
+    )
+
+
+def test_page_wide_shading_at_page_start_is_a_background():
+    """A page-wide shading before anything else is drawn is the background.
+
+    Refusing every page-wide shading would drop legitimate gradient
+    backgrounds, which is why the gate is about what is already on the page
+    rather than about size alone.
+    """
+    content = "q\n0 0 200 200 re W n\n/Sh0 sh\nQ\n"
+    result = render_page(_shading_page(content))
+
+    left = center_color(region_image(result, LEFT_BOX))
+    right = center_color(region_image(result, RIGHT_BOX))
+    assert left[0] > left[2] + 60 and right[2] > right[0] + 60, (
+        f"a page-wide shading at page start did not paint the background: "
+        f"left {left}, right {right}"
+    )

--- a/tests/test_shadings.py
+++ b/tests/test_shadings.py
@@ -57,9 +57,7 @@ def test_axial_shading_is_painted():
     left = center_color(region_image(result, LEFT_BOX))
     right = center_color(region_image(result, RIGHT_BOX))
 
-    assert left[0] > left[2] + 60, (
-        f"the red end of the gradient is not red: {left}"
-    )
+    assert left[0] > left[2] + 60, f"the red end of the gradient is not red: {left}"
     assert right[2] > right[0] + 60, (
         f"the blue end of the gradient is not blue: {right}"
     )

--- a/tests/test_text_render_modes.py
+++ b/tests/test_text_render_modes.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""Text render mode and anisotropic text scaling (PDF 32000-1, 9.3.4 and 9.3.6).
+
+`Tr` selects whether a glyph run is filled, stroked, both, or neither. Only the
+fill was drawn, so mode 3 leaked invisible text onto the page and the
+fill-plus-stroke modes -- how a producer without a bold face makes text bold --
+rendered as plain weight.
+
+`Tz` scales text horizontally only. Drawing such a run at a single isotropic
+size makes the glyphs square: condensed headline text came out overflowing its
+column.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.pdf_builder import render_page, simple_page_pdf
+from tests.rendering_regression import coverage_ratio, ink_bounds, region_image
+
+TEXT_BOX = (10.0, 60.0, 190.0, 120.0)
+HELVETICA = "/Font << /F1 5 0 R >>"
+FONT_OBJECT = (
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica "
+    "/Encoding /WinAnsiEncoding >>"
+)
+
+
+def _text_pdf(setup: str, *, text: str = "HHHHH", size: int = 36) -> bytes:
+    content = f"BT\n{setup}\n/F1 {size} Tf\n20 100 Td\n({text}) Tj\nET\n"
+    return simple_page_pdf(
+        content, resources=HELVETICA, extra_objects=[FONT_OBJECT]
+    )
+
+
+def _ink(setup: str, **kwargs) -> float:
+    image = region_image(render_page(_text_pdf(setup, **kwargs)), TEXT_BOX)
+    return coverage_ratio(image)
+
+
+def test_filled_text_paints():
+    """The baseline: mode 0 text is on the page at all."""
+    assert _ink("0 Tr") > 0.01, "plain filled text painted nothing"
+
+
+def test_invisible_text_render_mode_paints_nothing():
+    """Mode 3 is invisible -- it is how scanned pages carry their OCR layer."""
+    assert _ink("3 Tr") < 0.002, (
+        "text in render mode 3 was painted; it must stay invisible"
+    )
+
+
+def test_stroking_render_mode_is_heavier_than_fill():
+    """Fill-plus-stroke puts down more ink than fill alone.
+
+    This is how a document without a bold face asks for bold, so losing the
+    stroke silently drops the emphasis from every such heading.
+    """
+    filled = _ink("0 Tr")
+    stroked = _ink("2 Tr 1.5 w")
+
+    assert stroked > filled * 1.1, (
+        f"fill-plus-stroke ({stroked:.4f}) is not heavier than fill alone "
+        f"({filled:.4f}); the stroke component was dropped"
+    )
+
+
+def test_stroke_only_render_mode_paints():
+    """Mode 1 strokes the outline without filling it."""
+    assert _ink("1 Tr 1.5 w") > 0.005, "outlined text painted nothing"
+
+
+def test_horizontal_scaling_narrows_the_run():
+    """`Tz` scales the run horizontally and leaves its height alone.
+
+    Rendering it isotropically instead keeps the width and inflates the
+    glyphs, so the run's height is what separates the two.
+    """
+    normal = ink_bounds(region_image(render_page(_text_pdf("100 Tz")), TEXT_BOX))
+    condensed = ink_bounds(region_image(render_page(_text_pdf("50 Tz")), TEXT_BOX))
+
+    assert normal is not None and condensed is not None, "the text did not paint"
+
+    normal_width = normal[2] - normal[0]
+    condensed_width = condensed[2] - condensed[0]
+    normal_height = normal[3] - normal[1]
+    condensed_height = condensed[3] - condensed[1]
+
+    assert condensed_width == pytest.approx(normal_width / 2, rel=0.25), (
+        f"50% Tz gave a run {condensed_width}px wide against {normal_width}px "
+        "unscaled; it should be about half"
+    )
+    assert condensed_height == pytest.approx(normal_height, abs=3), (
+        f"50% Tz changed the run's height ({condensed_height}px against "
+        f"{normal_height}px); horizontal scaling must not touch it"
+    )

--- a/tests/test_text_render_modes.py
+++ b/tests/test_text_render_modes.py
@@ -21,16 +21,13 @@ from tests.rendering_regression import coverage_ratio, ink_bounds, region_image
 TEXT_BOX = (10.0, 60.0, 190.0, 120.0)
 HELVETICA = "/Font << /F1 5 0 R >>"
 FONT_OBJECT = (
-    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica "
-    "/Encoding /WinAnsiEncoding >>"
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>"
 )
 
 
 def _text_pdf(setup: str, *, text: str = "HHHHH", size: int = 36) -> bytes:
     content = f"BT\n{setup}\n/F1 {size} Tf\n20 100 Td\n({text}) Tj\nET\n"
-    return simple_page_pdf(
-        content, resources=HELVETICA, extra_objects=[FONT_OBJECT]
-    )
+    return simple_page_pdf(content, resources=HELVETICA, extra_objects=[FONT_OBJECT])
 
 
 def _ink(setup: str, **kwargs) -> float:

--- a/tests/test_type3_fonts.py
+++ b/tests/test_type3_fonts.py
@@ -49,9 +49,7 @@ def _type3_pdf(charproc: bytes, *, resources: str = "<< >>") -> bytes:
 
 def test_vector_charproc_is_painted():
     """A charproc that fills a path puts ink on the page."""
-    charproc = stream_object(
-        "", b"1000 0 0 0 1000 1000 d1\n0 0 1000 1000 re f\n"
-    )
+    charproc = stream_object("", b"1000 0 0 0 1000 1000 d1\n0 0 1000 1000 re f\n")
     image = region_image(render_page(_type3_pdf(charproc)), GLYPH_BOX)
 
     assert coverage_ratio(image) > 0.8, (
@@ -66,9 +64,7 @@ def test_vector_charproc_is_not_upside_down():
     Glyph space is y-up. Getting the corner order wrong flips the glyph, which
     is invisible on a symmetrical shape and wrong on every real one.
     """
-    charproc = stream_object(
-        "", b"1000 0 0 0 1000 1000 d1\n0 500 1000 500 re f\n"
-    )
+    charproc = stream_object("", b"1000 0 0 0 1000 1000 d1\n0 500 1000 500 re f\n")
     image = region_image(render_page(_type3_pdf(charproc)), GLYPH_BOX)
 
     bounds = ink_bounds(image)

--- a/tests/test_type3_fonts.py
+++ b/tests/test_type3_fonts.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""Type3 fonts, whose glyphs are content streams (PDF 32000-1, 9.6.5).
+
+A Type3 glyph is drawn by running its charproc, so a renderer that only knows
+how to draw glyphs from a face draws nothing at all: pages set in a Type3 font
+came out blank. Charprocs come in two kinds -- an inline image mask, or ordinary
+path painting -- and both had to be executed.
+
+Orientation is the part that is easy to get subtly wrong: glyph space is
+y-up like user space, and taking the image-mask corner order from the wrong
+place renders every glyph upside down, which still looks like text. So these
+fixtures use deliberately lopsided glyphs and check which way up they land.
+"""
+
+from __future__ import annotations
+
+from tests.pdf_builder import build_pdf, content_stream, render_page, stream_object
+from tests.rendering_regression import (
+    coverage_ratio,
+    ink_bounds,
+    quadrant_coverage,
+    region_image,
+)
+
+FONT_SIZE = 100
+GLYPH_BOX = (50.0, 50.0, 150.0, 150.0)
+
+
+def _type3_pdf(charproc: bytes, *, resources: str = "<< >>") -> bytes:
+    """One page drawing a single Type3 glyph 100pt tall at (50, 50)."""
+    text = f"BT\n/T3 {FONT_SIZE} Tf\n50 50 Td\n(a) Tj\nET\n"
+    return build_pdf(
+        [
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] "
+            "/Resources << /Font << /T3 5 0 R >> >> /Contents 4 0 R >>",
+            content_stream(text),
+            "<< /Type /Font /Subtype /Type3 /FontBBox [0 0 1000 1000] "
+            "/FontMatrix [0.001 0 0 0.001 0 0] /CharProcs 6 0 R "
+            "/Encoding << /Type /Encoding /Differences [97 /square] >> "
+            "/FirstChar 97 /LastChar 97 /Widths [1000] "
+            f"/Resources {resources} >>",
+            "<< /square 7 0 R >>",
+            charproc,
+        ]
+    )
+
+
+def test_vector_charproc_is_painted():
+    """A charproc that fills a path puts ink on the page."""
+    charproc = stream_object(
+        "", b"1000 0 0 0 1000 1000 d1\n0 0 1000 1000 re f\n"
+    )
+    image = region_image(render_page(_type3_pdf(charproc)), GLYPH_BOX)
+
+    assert coverage_ratio(image) > 0.8, (
+        f"a Type3 glyph filling its whole box covered only "
+        f"{coverage_ratio(image):.3f} of it"
+    )
+
+
+def test_vector_charproc_is_not_upside_down():
+    """A glyph inked only in its top half lands in the top half of the page.
+
+    Glyph space is y-up. Getting the corner order wrong flips the glyph, which
+    is invisible on a symmetrical shape and wrong on every real one.
+    """
+    charproc = stream_object(
+        "", b"1000 0 0 0 1000 1000 d1\n0 500 1000 500 re f\n"
+    )
+    image = region_image(render_page(_type3_pdf(charproc)), GLYPH_BOX)
+
+    bounds = ink_bounds(image)
+    assert bounds is not None, "the glyph painted nothing"
+    _, top, _, bottom = bounds
+    assert bottom <= image.height * 0.6, (
+        f"the ink sits at rows {top}..{bottom} of {image.height}; a glyph inked "
+        "in its upper half rendered in the lower half, so it is upside down"
+    )
+
+
+def test_charproc_graphics_state_is_balanced():
+    """`q`/`Q` inside a charproc do not leak into the rest of the glyph.
+
+    The first square is drawn under a scaling transform; the second is drawn
+    after it is popped and must land where it was asked to, not where the
+    leaked transform would put it.
+    """
+    charproc = stream_object(
+        "",
+        b"1000 0 0 0 1000 1000 d1\n"
+        b"q\n0.5 0 0 0.5 0 0 cm\n0 0 1000 1000 re f\nQ\n"
+        b"500 500 500 500 re f\n",
+    )
+    image = region_image(render_page(_type3_pdf(charproc)), GLYPH_BOX)
+
+    quadrants = quadrant_coverage(image)
+    # scaled square covers the lower-left quarter, the second one the upper right
+    assert quadrants["bottom_left"] > 0.9, (
+        "the transformed part of the charproc did not paint"
+    )
+    assert quadrants["top_right"] > 0.9, (
+        "the part after Q did not paint where it was asked to; the charproc's "
+        "graphics state leaked"
+    )
+    assert quadrants["top_left"] < 0.1 and quadrants["bottom_right"] < 0.1, (
+        "the charproc painted outside both squares"
+    )
+
+
+def test_image_mask_charproc_is_painted():
+    """A charproc whose glyph is an inline image mask paints too.
+
+    The mask's set bits are the ink; an all-ones mask fills the glyph box.
+    """
+    charproc = stream_object(
+        "",
+        b"1000 0 0 0 1000 1000 d1\n"
+        b"q\n1000 0 0 1000 0 0 cm\n"
+        b"BI /IM true /W 8 /H 8 /BPC 1 /D [1 0] ID\n"
+        + bytes([0xFF] * 8)
+        + b"\nEI\nQ\n",
+    )
+    image = region_image(render_page(_type3_pdf(charproc)), GLYPH_BOX)
+
+    assert coverage_ratio(image) > 0.8, (
+        f"an image-mask charproc covered only {coverage_ratio(image):.3f} of "
+        "the glyph box"
+    )


### PR DESCRIPTION
Rebuilt on top of the shading and colour work already in `main`, keeping
the render paths that work does not cover. A `/Pattern` fill, a curved
clip, a packed palette image, a Type3 page, and a CID font with no `/DW`
were each dropping or distorting content.
### Tiling patterns
- Replay the pattern cell on a lattice derived from the page box through
  the inverse pattern transform, so it extends in both directions
- Anchor pattern space to the page's default space, not the CTM at the fill
- Skip an unresolved `/Pattern` fill instead of painting placeholder black,
  without skipping clip capture / path reset
### Non-rectangular clipping
- Rasterise curved clip paths into an A8 coverage mask (Blend2D only clips
  rectangles; a crescent previously became its bounding box)
- Apply the mask with an explicit per-pixel multiply (`DST_IN` skips the
  pixels that need clearing)
### Indexed images and soft masks
- Unpack sub-byte `/Indexed` samples before palette lookup (packed 4-bit
  bytes were treated as one index each)
- Pass palette indices through untouched instead of scaling them as
  continuous tone
- Unpack sub-byte soft masks (1 bpc stencils were rejected)
### Type3, CID widths, text render modes
- Rasterise Type3 `/CharProcs` (image-mask and filled paths) onto the
  glyph quad instead of decoding and discarding them
- Default CID `/DW` to 1000 per spec, and only on composite fonts (applying
  it to every font short-circuited base-14 metric lookup)
- Honour stroke text render modes 1, 2, 5 and 6 so synthesised bold is drawn

