### PR TITLE
feat(render): clip paths, masks, CMYK/Indexed images, font fallback, Symbol brackets

### DIFF
--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -138,6 +138,7 @@ namespace
       pybind11::dict row;
       row["type"] = instruction_name(pdflib::BITMAP_RENDER_INSTRUCTION);
       row["xobject_key"] = instr.get_key();
+      row["source"] = pdflib::to_string(instr.get_source());
       row["shape"] = instr.get_shape();
       row["pixel_format"] = pixel_format_name(instr.get_pixel_format());
       row["image_mask"] = instr.is_image_mask();
@@ -239,6 +240,7 @@ namespace
       pybind11::dict row;
       row["index"] = bitmap_index;
       row["xobject_key"] = instr.get_key();
+      row["source"] = pdflib::to_string(instr.get_source());
       row["shape"] = instr.get_shape();
       row["pixel_format"] = pixel_format_name(instr.get_pixel_format());
       row["image_mask"] = instr.is_image_mask();

--- a/src/parse/enums.h
+++ b/src/parse/enums.h
@@ -297,6 +297,29 @@ namespace pdflib
     BLEND_MODE_LUMINOSITY,
   };
 
+  // What a bitmap instruction is a picture OF. A Type3 glyph procedure is
+  // rasterised into an image mask and painted through the very same bitmap
+  // path as page artwork (see pdf_state<TEXT>), so without this the two are
+  // indistinguishable downstream: one page of Type3 text yields a bitmap per
+  // painted character, drowning the handful of real images among them.
+  enum bitmap_source {
+    BITMAP_SOURCE_XOBJECT,      // an image XObject painted by `Do`
+    BITMAP_SOURCE_INLINE,       // an inline image (BI ... ID ... EI)
+    BITMAP_SOURCE_TYPE3_GLYPH,  // the mask of one Type3 glyph procedure
+  };
+
+  inline std::string to_string(bitmap_source source)
+  {
+    switch(source)
+      {
+      case BITMAP_SOURCE_XOBJECT:     return "xobject";
+      case BITMAP_SOURCE_INLINE:      return "inline";
+      case BITMAP_SOURCE_TYPE3_GLYPH: return "type3_glyph";
+      }
+
+    return "unknown";
+  }
+
   // State of an ExtGState /SMask entry. A present soft mask is the one
   // transparency parameter whose omission makes the output wrong rather than
   // merely approximate, so absent and /None are kept apart.

--- a/src/parse/page_items/page_image.h
+++ b/src/parse/page_items/page_image.h
@@ -77,6 +77,8 @@ namespace pdflib
     std::shared_ptr<Buffer>  raw_stream_data;
     std::shared_ptr<Buffer>  decoded_stream_data;
     std::shared_ptr<std::vector<uint8_t>> soft_mask_data;
+    int soft_mask_width = 0;
+    int soft_mask_height = 0;
 
     // PDF image semantics copied from XObject
     bool decode_present = false;

--- a/src/parse/page_items/render_instructions.h
+++ b/src/parse/page_items/render_instructions.h
@@ -491,6 +491,7 @@ namespace pdflib
                        double r_x1, double r_y1,
                        double r_x2, double r_y2,
                        double r_x3, double r_y3,
+                       bitmap_source source = BITMAP_SOURCE_XOBJECT,
                        clip_state_instruction clip_state = clip_state_instruction()):
       xobject_key(xobject_key),
       data(std::move(data)),
@@ -505,9 +506,16 @@ namespace pdflib
       r_x1(r_x1), r_y1(r_y1),
       r_x2(r_x2), r_y2(r_y2),
       r_x3(r_x3), r_y3(r_y3),
+      source(source),
       clip_state(std::move(clip_state)) {}
 
     const std::string& get_key() const { return xobject_key; }
+
+    // Whether this bitmap is page artwork or a rasterised Type3 glyph. The
+    // key spells it out too (`type3:...`, `__inline_image_...`), but that is
+    // a naming convention; this is the fact itself.
+    bitmap_source get_source() const { return source; }
+    bool is_glyph() const { return source == BITMAP_SOURCE_TYPE3_GLYPH; }
 
     const std::shared_ptr<std::vector<uint8_t> >& get_data() const { return data; }
     const std::shared_ptr<std::vector<uint8_t> >& get_alpha_data() const { return alpha_data; }
@@ -567,6 +575,7 @@ namespace pdflib
     const double r_x3;
     const double r_y3;
 
+    const bitmap_source source;
     const clip_state_instruction clip_state;
   };
 

--- a/src/parse/page_items/render_instructions.h
+++ b/src/parse/page_items/render_instructions.h
@@ -42,7 +42,16 @@ namespace pdflib
     clip_path_instruction(std::vector<double> x,
                           std::vector<double> y,
                           page_shape_closing_type closing_type,
-                          page_shape_type shape_type);
+                          page_shape_type shape_type,
+                          int clip_group = 0);
+
+    // Subpaths captured by ONE W/W* operation share a group: together they
+    // form a single clip path under the clip's fill rule. Only paths of
+    // DIFFERENT groups intersect. Treating each subpath as its own clip and
+    // intersecting turned any multi-subpath clip (an outline-art stencil, a
+    // text-shaped clip) into an empty region, and the fill through it
+    // disappeared.
+    int get_clip_group() const { return clip_group; }
 
     const std::vector<double>& get_x() const { return x; }
     const std::vector<double>& get_y() const { return y; }
@@ -60,7 +69,7 @@ namespace pdflib
       for(auto& v : x_) { v += dx; }
       for(auto& v : y_) { v += dy; }
       return clip_path_instruction(std::move(x_), std::move(y_),
-                                   closing_type, shape_type);
+                                   closing_type, shape_type, clip_group);
     }
 
   private:
@@ -68,6 +77,7 @@ namespace pdflib
     std::vector<double> y;
     page_shape_closing_type closing_type;
     page_shape_type shape_type;
+    int clip_group = 0;
   };
 
   inline clip_path_instruction::clip_path_instruction():
@@ -80,11 +90,13 @@ namespace pdflib
   inline clip_path_instruction::clip_path_instruction(std::vector<double> x_,
                                                       std::vector<double> y_,
                                                       page_shape_closing_type closing_type_,
-                                                      page_shape_type shape_type_):
+                                                      page_shape_type shape_type_,
+                                                      int clip_group_):
     x(std::move(x_)),
     y(std::move(y_)),
     closing_type(closing_type_),
-    shape_type(shape_type_)
+    shape_type(shape_type_),
+    clip_group(clip_group_)
   {}
 
   class clip_state_instruction

--- a/src/parse/pdf_decoders/page.h
+++ b/src/parse/pdf_decoders/page.h
@@ -1802,8 +1802,64 @@ namespace pdflib
         page_shapes.push_back(shape);
       }
 
+    // The frame a field draws around itself is form chrome rather than page
+    // content, and painting it is what puts empty squares on a page: a
+    // producer that cannot embed a glyph is free to leave a bordered
+    // placeholder button in its place, and every one of those came out as a
+    // box no other renderer draws -- pdfium paints none of this even with the
+    // form environment initialised and form drawing asked for.
+    //
+    // What a field draws *inside* itself is content and is kept, a checkbox
+    // tick being the case that matters. The two are told apart by geometry:
+    // in appearance-stream coordinates the widget occupies (0, 0)-(w, h), so
+    // a subpath whose extent is that rectangle is the frame. The tolerance is
+    // the line width because a stroked border is inset by half of it, and it
+    // never reaches half the field, so a tick cannot be mistaken for a frame.
+    //
+    // Only the painting is dropped. The shape stays in the parsed output
+    // above, where it describes the field for anything reading geometry.
+    const double widget_w = bbox[2] - bbox[0];
+    const double widget_h = bbox[3] - bbox[1];
+
+    auto traces_the_widget_rect = [&](const shape_instruction& shape_instr)
+    {
+      if(widget_w <= 0.0 or widget_h <= 0.0) { return false; }
+
+      bool seen = false;
+      double x0 = 0.0, y0 = 0.0, x1 = 0.0, y1 = 0.0;
+
+      for(const auto& subpath : shape_instr.get_subpaths())
+        {
+          std::vector<double> xs = subpath.get_px();
+          std::vector<double> ys = subpath.get_py();
+          xs.push_back(subpath.get_x0());
+          ys.push_back(subpath.get_y0());
+
+          for(std::size_t l = 0; l < xs.size(); l++)
+            {
+              if(not seen) { x0 = x1 = xs[l]; y0 = y1 = ys[l]; seen = true; }
+              x0 = std::min(x0, xs[l]); x1 = std::max(x1, xs[l]);
+              y0 = std::min(y0, ys[l]); y1 = std::max(y1, ys[l]);
+            }
+        }
+
+      if(not seen) { return false; }
+
+      const double tol = std::max(1.0, shape_instr.get_line_width());
+      return (std::abs(x0 - 0.0)      <= tol and
+              std::abs(y0 - 0.0)      <= tol and
+              std::abs(x1 - widget_w) <= tol and
+              std::abs(y1 - widget_h) <= tol);
+    };
+
     for(const auto& shape_instr : ap_instructions.get_shape_instructions())
       {
+        if(traces_the_widget_rect(shape_instr))
+          {
+            LOG_S(INFO) << "skipping the frame of a widget appearance stream";
+            continue;
+          }
+
         instructions.add_shape_instruction(shape_instr.translated(ox, oy));
       }
 

--- a/src/parse/pdf_decoders/stream.h
+++ b/src/parse/pdf_decoders/stream.h
@@ -84,8 +84,9 @@ namespace pdflib
     void do_shading(const std::string& sh_name);
 
     // `scn` naming a tiling pattern: replay the pattern cell across the page
-    // box. Returns false when the pattern cannot be resolved or painted.
-    bool do_pattern_fill(const std::string& pattern_name);
+    // box, clipped to the path being filled. `even_odd` is that path's fill
+    // rule. Returns false when the pattern cannot be resolved or painted.
+    bool do_pattern_fill(const std::string& pattern_name, bool even_odd);
 
     // marked-content (BMC/BDC ... EMC) tracking, used to honor /ActualText
     // replacement text (PDF 32000-1, section 14.9.4)
@@ -645,7 +646,8 @@ namespace pdflib
   // 8.7.4.5: `sh` paints the named shading over the whole current clip
   // region, taking its colours from the shading's own colour space and
   // function rather than from the current fill colour.
-  bool pdf_decoder<STREAM>::do_pattern_fill(const std::string& pattern_name)
+  bool pdf_decoder<STREAM>::do_pattern_fill(const std::string& pattern_name,
+                                            bool even_odd)
   {
     if(not page_patterns or page_patterns->count(pattern_name) == 0)
       {
@@ -780,6 +782,23 @@ namespace pdflib
         if(res.hasKey("/XObject"))   { QPDFObjectHandle o = res.getKey("/XObject");   page_xobjects_->set(o, timings); }
       }
 
+    // The path being filled bounds the pattern (PDF 32000-1, 8.7.3.1): the
+    // cells paint only inside it. Without this the lattice covered the whole
+    // page box, so a page whose pattern fill was one small shape came out with
+    // a block of cells in the corner that no other renderer draws.
+    //
+    // The capture has to happen before the cell placement matrix goes on:
+    // clips are transformed by the matrix current when they are captured, and
+    // after the `cm` below that is pattern space, not the space the path was
+    // built in.
+    this->q();
+    {
+      std::vector<qpdf_stream_instruction> no_parameters;
+      if(even_odd) { current_shape_state().WStar(no_parameters); }
+      else         { current_shape_state().W(no_parameters);     }
+      current_shape_state().n(no_parameters);
+    }
+
     bool painted = false;
 
     for(int iy = iy0; iy <= iy1; iy++)
@@ -830,6 +849,8 @@ namespace pdflib
             painted = true;
           }
       }
+
+    this->Q();
 
     return painted;
   }
@@ -1747,7 +1768,7 @@ namespace pdflib
           if(current_graphic_state().get_fill_is_unresolved_pattern() and
              not current_graphic_state().get_fill_pattern_name().empty())
             {
-              do_pattern_fill(current_graphic_state().get_fill_pattern_name());
+              do_pattern_fill(current_graphic_state().get_fill_pattern_name(), false);
             }
           current_shape_state().f(parameters);
         }
@@ -1766,7 +1787,7 @@ namespace pdflib
           if(current_graphic_state().get_fill_is_unresolved_pattern() and
              not current_graphic_state().get_fill_pattern_name().empty())
             {
-              do_pattern_fill(current_graphic_state().get_fill_pattern_name());
+              do_pattern_fill(current_graphic_state().get_fill_pattern_name(), true);
             }
           current_shape_state().fStar(parameters);
         }

--- a/src/parse/pdf_resources/page_colorspace.h
+++ b/src/parse/pdf_resources/page_colorspace.h
@@ -30,6 +30,13 @@ namespace pdflib
     // images use it to decide whether going through the transform is worth it.
     bool has_tint_transform() const;
 
+    // Number of tint components a Separation/DeviceN colour takes: one per
+    // colorant.
+    int tint_component_count() const
+    {
+      return static_cast<int>(colorant_names_.size());
+    }
+
     // Maps the numeric SC/SCN/sc/scn operands to RGB; returns false when
     // the space cannot interpret them (pattern, unknown family, wrong
     // operand count), in which case the caller keeps its own fallback.

--- a/src/parse/pdf_resources/page_font/glyphs.h
+++ b/src/parse/pdf_resources/page_font/glyphs.h
@@ -8,6 +8,8 @@
 #include <unordered_set>
 #include <unordered_map>
 
+#include <map>
+
 namespace pdflib
 {
 
@@ -187,6 +189,32 @@ namespace pdflib
             name_to_code[key] = val;
 
             std::string val_ = preprocess(val);
+
+            // The Adobe Glyph List places the Symbol font's bracket, brace and
+            // parenthesis PIECES -- the parts a typesetter stacks to build a
+            // tall delimiter around a matrix -- in the private-use area, where
+            // they were assigned before Unicode had them. Nothing but the
+            // original Symbol font maps that range, so a fallback face draws
+            // .notdef boxes down the sides of every matrix. Unicode has had
+            // these since 3.2 (Miscellaneous Technical, U+239B..U+23AD), and
+            // ordinary text faces carry them; rewrite the legacy codes to the
+            // real ones, which fixes both the render and the extracted text.
+            {
+              static const std::map<std::string, std::string> legacy_pua = {
+                {"F8EB", "239B"}, {"F8EC", "239C"}, {"F8ED", "239D"},  // ( pieces
+                {"F8F6", "239E"}, {"F8F7", "239F"}, {"F8F8", "23A0"},  // ) pieces
+                {"F8EE", "23A1"}, {"F8EF", "23A2"}, {"F8F0", "23A3"},  // [ pieces
+                {"F8F9", "23A4"}, {"F8FA", "23A5"}, {"F8FB", "23A6"},  // ] pieces
+                {"F8F1", "23A7"}, {"F8F2", "23A8"}, {"F8F3", "23A9"},  // { pieces
+                {"F8F4", "23AA"},                                       // brace ext
+                {"F8FC", "23AB"}, {"F8FD", "23AC"}, {"F8FE", "23AD"},  // } pieces
+                {"F8F5", "23AE"},                                       // integral ext
+                {"F8E7", "23AF"},                                       // horizontal ext
+                {"F8E6", "23D0"},                                       // vertical ext
+              };
+              auto it = legacy_pua.find(val_);
+              if(it != legacy_pua.end()) { val_ = it->second; }
+            }
 
             if(val_.size()%4==0 and name_to_utf8.count(key)==0)
               {

--- a/src/parse/pdf_resources/page_pattern.h
+++ b/src/parse/pdf_resources/page_pattern.h
@@ -38,7 +38,15 @@ namespace pdflib
 
     // Tiling only: the pattern cell's own resources and content stream.
     QPDFObjectHandle get_resources() const { return resources_; }
-    bool has_resources() const { return resources_.isDictionary(); }
+    // QPDFObjectHandle's accessors are non-const in the qpdf releases we
+    // build against, so go through a copy (the handle is a shared reference,
+    // copying it costs nothing) -- the same way page_xobject_form does.
+    bool has_resources() const
+    {
+      QPDFObjectHandle resources = resources_;
+      return resources.isDictionary();
+    }
+
     std::vector<qpdf_stream_instruction> parse_stream() const;
 
     // Shading pattern only.
@@ -136,14 +144,15 @@ namespace pdflib
   std::vector<qpdf_stream_instruction> pdf_resource<PAGE_PATTERN>::parse_stream() const
   {
     std::vector<qpdf_stream_instruction> insts;
-    if(not qpdf_pattern_.isStream())
+
+    QPDFObjectHandle stream = qpdf_pattern_;
+    if(not stream.isStream())
       {
         return insts;
       }
 
     try
       {
-        QPDFObjectHandle stream = qpdf_pattern_;
         qpdf_stream_decoder decoder(insts);
         decoder.decode(stream);
       }

--- a/src/parse/pdf_resources/page_xobject_image.h
+++ b/src/parse/pdf_resources/page_xobject_image.h
@@ -186,6 +186,8 @@ namespace pdflib
     std::shared_ptr<Buffer>  get_decoded_stream_data() const;
     bool                     has_soft_mask_data() const;
     std::shared_ptr<std::vector<uint8_t>> get_soft_mask_data() const;
+    int get_soft_mask_width() const { return soft_mask_width; }
+    int get_soft_mask_height() const { return soft_mask_height; }
 
     // Determine file extension from filters (e.g. ".jpg", ".jp2", ".jb2", ".bin")
     std::string pick_extension() const;
@@ -248,6 +250,8 @@ namespace pdflib
     std::shared_ptr<Buffer> raw_stream_data;
     std::shared_ptr<Buffer> decoded_stream_data;
     std::shared_ptr<std::vector<uint8_t>> soft_mask_data;
+    int soft_mask_width = 0;
+    int soft_mask_height = 0;
 
     // PDF image semantics
     std::vector<double> decode_array; // length 2*ncomp when present
@@ -1119,10 +1123,16 @@ namespace pdflib
         return;
       }
 
-    const size_t expected = static_cast<size_t>(image_width) * image_height;
+    // Resolve onto the finer of the two grids. Downsampling a mask that is
+    // higher-resolution than its base image would throw away exactly the
+    // detail it exists to carry -- a 2x2 colour swatch stencilled by a 141x100
+    // glyph mask is a common way to draw text, and collapsing it to 2x2 turns
+    // the text into a gradient smear across the whole line.
+    const int dst_w = std::max(image_width, sm_w);
+    const int dst_h = std::max(image_height, sm_h);
 
     auto out = std::make_shared<std::vector<uint8_t>>();
-    out->resize(expected);
+    out->resize(static_cast<size_t>(dst_w) * dst_h);
 
     auto const* src = smask_unpacked.empty()
       ? reinterpret_cast<uint8_t const*>(smask_buf->getBuffer())
@@ -1130,25 +1140,27 @@ namespace pdflib
     auto const decode = smask.get_decode_array();
     const bool has_decode = smask.has_decode_array() and decode.size() >= 2;
 
-    // nearest-neighbor sampling from the mask grid onto the image grid
+    // nearest-neighbor sampling from the mask grid onto the target grid
     // (identity when the dimensions already match)
-    for(int row = 0; row < image_height; ++row)
+    for(int row = 0; row < dst_h; ++row)
       {
-        const size_t src_row = (static_cast<size_t>(row) * sm_h) / image_height;
-        for(int col = 0; col < image_width; ++col)
+        const size_t src_row = (static_cast<size_t>(row) * sm_h) / dst_h;
+        for(int col = 0; col < dst_w; ++col)
           {
-            const size_t src_col = (static_cast<size_t>(col) * sm_w) / image_width;
+            const size_t src_col = (static_cast<size_t>(col) * sm_w) / dst_w;
 
             uint8_t alpha = src[src_row * sm_w + src_col];
             if(has_decode)
               {
                 alpha = jpeg::apply_decode_component(alpha, decode[0], decode[1]);
               }
-            (*out)[static_cast<size_t>(row) * image_width + col] = alpha;
+            (*out)[static_cast<size_t>(row) * dst_w + col] = alpha;
           }
       }
 
-    soft_mask_data = std::move(out);
+    soft_mask_data   = std::move(out);
+    soft_mask_width  = dst_w;
+    soft_mask_height = dst_h;
 
     LOG_S(INFO) << "decoded SMask for xobject_key=" << xobject_key
                 << " alpha_size=" << soft_mask_data->size();

--- a/src/parse/pdf_resources/page_xobject_image.h
+++ b/src/parse/pdf_resources/page_xobject_image.h
@@ -3,6 +3,8 @@
 #ifndef PDF_PAGE_XOBJECT_IMAGE_RESOURCE_H
 #define PDF_PAGE_XOBJECT_IMAGE_RESOURCE_H
 
+#include <parse/utils/ccitt/ccitt_utils.h>
+
 #include <cstdint>
 #include <cstring>
 
@@ -1004,12 +1006,29 @@ namespace pdflib
   {
     soft_mask_data.reset();
 
-    if(not qpdf_xobject_dict.hasKey("/SMask"))
+    // /SMask carries alpha directly. /Mask (as a stream) is a stencil: a
+    // 1-bit image mask whose 1-samples knock the corresponding image pixels
+    // OUT (ISO 32000-1, 8.9.6.4). Ignoring it painted the image's own
+    // background pixels over whatever the mask was meant to reveal -- a logo
+    // shipped as an opaque rectangle plus a stencil rendered as the
+    // rectangle.
+    bool stencil = false;
+    QPDFObjectHandle qpdf_smask;
+    if(qpdf_xobject_dict.hasKey("/SMask"))
+      {
+        qpdf_smask = qpdf_xobject_dict.getKey("/SMask");
+      }
+    else if(qpdf_xobject_dict.hasKey("/Mask") and
+            qpdf_xobject_dict.getKey("/Mask").isStream())
+      {
+        qpdf_smask = qpdf_xobject_dict.getKey("/Mask");
+        stencil = true;
+      }
+    else
       {
         return;
       }
 
-    auto qpdf_smask = qpdf_xobject_dict.getKey("/SMask");
     if(not qpdf_smask.isStream())
       {
         LOG_S(WARNING) << "SMask present but is not a stream for xobject_key=" << xobject_key;
@@ -1045,7 +1064,7 @@ namespace pdflib
       smask.get_color_space() == "/DeviceGray"
       or (smask.get_color_space().find("/ICCBased") != std::string::npos
           and smask.get_icc_components() == 1);
-    if(not gray_mask)
+    if(not gray_mask and not stencil)
       {
         LOG_S(WARNING) << "SMask color space unsupported for xobject_key=" << xobject_key
                        << " smask_cs=" << smask.get_color_space()
@@ -1053,7 +1072,8 @@ namespace pdflib
         return;
       }
 
-    const int smask_bpc = smask.get_bits_per_component();
+    int smask_bpc = smask.get_bits_per_component();
+    if(stencil and smask_bpc <= 0) { smask_bpc = 1; }
     if(smask_bpc != 8 and smask_bpc != 1 and smask_bpc != 2 and smask_bpc != 4)
       {
         LOG_S(WARNING) << "SMask bits/component unsupported for xobject_key=" << xobject_key
@@ -1061,13 +1081,51 @@ namespace pdflib
         return;
       }
 
+    // A stencil mask is very often CCITTFax-compressed, which qpdf cannot
+    // defilter; decode it here. `ccitt::decode` yields one byte per pixel
+    // with 0 = dark.
+    std::vector<uint8_t> ccitt_samples;
     if(not smask.has_decoded_stream_data())
       {
-        LOG_S(WARNING) << "SMask has no decoded stream data for xobject_key=" << xobject_key;
-        return;
+        QPDFObjectHandle mdict = qpdf_smask.getDict();
+        const std::string filter =
+          mdict.hasKey("/Filter") ? mdict.getKey("/Filter").unparse() : "";
+        if(filter.find("CCITTFaxDecode") != std::string::npos and
+           smask.has_raw_stream_data())
+          {
+            int K = 0;
+            bool black_is_1 = false;
+            QPDFObjectHandle dp = mdict.getKey("/DecodeParms");
+            if(dp.isArray() and dp.getArrayNItems() > 0) { dp = dp.getArrayItem(0); }
+            if(dp.isDictionary())
+              {
+                if(dp.hasKey("/K") and dp.getKey("/K").isInteger())
+                  { K = static_cast<int>(dp.getKey("/K").getIntValue()); }
+                if(dp.hasKey("/BlackIs1") and dp.getKey("/BlackIs1").isBool())
+                  { black_is_1 = dp.getKey("/BlackIs1").getBoolValue(); }
+              }
+
+            auto raw = smask.get_raw_stream_data();
+            ccitt_samples = ccitt::decode(
+              reinterpret_cast<const uint8_t*>(raw->getBuffer()),
+              raw->getSize(), sm_w, sm_h, K, black_is_1);
+            if(ccitt_samples.size() < static_cast<size_t>(sm_w) * sm_h)
+              {
+                LOG_S(WARNING) << "mask CCITT decode too small for xobject_key="
+                               << xobject_key;
+                return;
+              }
+            smask_bpc = 8;
+          }
+        else
+          {
+            LOG_S(WARNING) << "SMask has no decoded stream data for xobject_key=" << xobject_key;
+            return;
+          }
       }
 
-    auto smask_buf = smask.get_decoded_stream_data();
+    auto smask_buf = smask.has_decoded_stream_data()
+      ? smask.get_decoded_stream_data() : nullptr;
 
     // A stencil-shaped mask is usually written at 1 bit per pixel, packed
     // several samples to a byte and padded to a byte at the end of each row.
@@ -1075,7 +1133,7 @@ namespace pdflib
     // eight columns to be the whole row, so the transparent part of the image
     // keeps painting. Expand to one byte per sample first.
     std::vector<uint8_t> smask_unpacked;
-    if(smask_bpc != 8)
+    if(smask_bpc != 8 and ccitt_samples.empty())
       {
         const size_t row_bits = static_cast<size_t>(sm_w) * static_cast<size_t>(smask_bpc);
         const size_t row_bytes = (row_bits + 7u) / 8u;
@@ -1115,7 +1173,8 @@ namespace pdflib
       }
 
     const size_t smask_expected = static_cast<size_t>(sm_w) * sm_h;
-    if(smask_unpacked.empty() and smask_buf->getSize() < smask_expected)
+    if(smask_unpacked.empty() and ccitt_samples.empty()
+       and smask_buf->getSize() < smask_expected)
       {
         LOG_S(WARNING) << "SMask decoded stream too small for xobject_key=" << xobject_key
                        << " size=" << smask_buf->getSize()
@@ -1134,9 +1193,10 @@ namespace pdflib
     auto out = std::make_shared<std::vector<uint8_t>>();
     out->resize(static_cast<size_t>(dst_w) * dst_h);
 
-    auto const* src = smask_unpacked.empty()
-      ? reinterpret_cast<uint8_t const*>(smask_buf->getBuffer())
-      : smask_unpacked.data();
+    auto const* src =
+      not ccitt_samples.empty() ? ccitt_samples.data()
+      : not smask_unpacked.empty() ? smask_unpacked.data()
+      : reinterpret_cast<uint8_t const*>(smask_buf->getBuffer());
     auto const decode = smask.get_decode_array();
     const bool has_decode = smask.has_decode_array() and decode.size() >= 2;
 
@@ -1154,7 +1214,11 @@ namespace pdflib
               {
                 alpha = jpeg::apply_decode_component(alpha, decode[0], decode[1]);
               }
-            (*out)[static_cast<size_t>(row) * dst_w + col] = alpha;
+            // Stencil (/Mask): a 1-sample masks the pixel OUT, the inverse
+            // of /SMask's alpha reading. ccitt::decode returns 0 = dark =
+            // sample 0 = painted, so the same inversion applies there.
+            (*out)[static_cast<size_t>(row) * dst_w + col] =
+              stencil ? static_cast<uint8_t>(255 - alpha) : alpha;
           }
       }
 

--- a/src/parse/pdf_resources/page_xobject_image.h
+++ b/src/parse/pdf_resources/page_xobject_image.h
@@ -241,6 +241,7 @@ namespace pdflib
     int              indexed_hival  = -1; // hival from /Indexed color space; -1 if not Indexed
     std::string      indexed_base_cs;    // base color space name for /Indexed (e.g. "/DeviceRGB")
     std::shared_ptr<std::vector<uint8_t>> indexed_palette; // raw palette bytes: (hival+1)*ncomps bytes
+    std::shared_ptr<pdf_resource<PAGE_COLORSPACE> > indexed_tint_space;
     std::shared_ptr<std::vector<uint8_t>> indexed_base_icc_profile;
     int              indexed_base_icc_components = 0;
     std::vector<std::string> indexed_base_device_n_names;
@@ -574,6 +575,29 @@ namespace pdflib
                             indexed_base_cs = base_name.getName();
                             LOG_S(INFO) << "Indexed array base color space: " << indexed_base_cs;
                           }
+
+                        // A /Separation (or unhandled /DeviceN) base: the
+                        // palette entries are TINT values, one sample per
+                        // colorant, meaningless until run through the tint
+                        // transform. Parse the space now; the palette is
+                        // converted to RGB right after it is loaded.
+                        if(base_name.isName() and
+                           (base_name.getName() == "/Separation" or
+                            (base_name.getName() == "/DeviceN" and
+                             indexed_base_cs != "/DeviceCMYK" and
+                             indexed_base_cs != "/DeviceGray")))
+                          {
+                            indexed_tint_space =
+                              std::make_shared<pdf_resource<PAGE_COLORSPACE> >();
+                            indexed_tint_space->set(xobject_key + "/IndexedBase",
+                                                    base_obj);
+                            if(not indexed_tint_space->has_tint_transform())
+                              {
+                                LOG_S(WARNING) << "Indexed tint base did not resolve "
+                                               << "for xobject_key=" << xobject_key;
+                                indexed_tint_space.reset();
+                              }
+                          }
                       }
                     else
                       {
@@ -621,6 +645,48 @@ namespace pdflib
                         else
                           {
                             LOG_S(WARNING) << "Indexed color space: unrecognized lookup table type";
+                          }
+
+                        // Tint-space base: run every palette entry through
+                        // the tint transform and keep an RGB palette. Without
+                        // this the image has no usable base space at all and
+                        // is dropped for a placeholder.
+                        if(indexed_tint_space and indexed_palette
+                           and not indexed_palette->empty())
+                          {
+                            const int ncomp = std::max<int>(
+                              1, indexed_tint_space->tint_component_count());
+                            const size_t entries = indexed_palette->size() / ncomp;
+                            auto rgb_pal = std::make_shared<std::vector<uint8_t>>();
+                            rgb_pal->reserve(entries * 3);
+                            std::vector<double> comps(ncomp, 0.0);
+                            bool ok = entries > 0;
+                            for(size_t e = 0; ok and e < entries; ++e)
+                              {
+                                for(int c = 0; c < ncomp; ++c)
+                                  {
+                                    comps[c] = (*indexed_palette)[e * ncomp + c] / 255.0;
+                                  }
+                                std::array<int, 3> rgb = {0, 0, 0};
+                                if(indexed_tint_space->map_to_rgb(comps, rgb))
+                                  {
+                                    rgb_pal->push_back(static_cast<uint8_t>(rgb[0]));
+                                    rgb_pal->push_back(static_cast<uint8_t>(rgb[1]));
+                                    rgb_pal->push_back(static_cast<uint8_t>(rgb[2]));
+                                  }
+                                else { ok = false; }
+                              }
+                            if(ok)
+                              {
+                                indexed_palette = std::move(rgb_pal);
+                                indexed_base_cs = "/DeviceRGB";
+                                LOG_S(INFO) << "Indexed tint-base palette converted to RGB: "
+                                            << indexed_palette->size() << " bytes";
+                              }
+                            else
+                              {
+                                LOG_S(WARNING) << "Indexed tint-base palette conversion failed";
+                              }
                           }
 
                         if(indexed_base_cs == "/DeviceCMYK"

--- a/src/parse/pdf_resources/page_xobject_image.h
+++ b/src/parse/pdf_resources/page_xobject_image.h
@@ -809,10 +809,15 @@ namespace pdflib
 	  }
 	else if(color_space=="/DeviceCMYK")
 	  {
+	    // ISO 32000-1 table 89: the default is the identity, [0 1] per
+	    // component. Synthesising the inverted array here flipped every CMYK
+	    // sample once; paths whose convention flag inverted a second time
+	    // cancelled it by accident, and the one that did not (JPX) rendered
+	    // photographic negatives.
 	    LOG_S(WARNING) << "no `/Decode` found: falling back on default for " << color_space;
 	    decode_array = {
-	      1, 0, 1, 0,
-	      1, 0, 1, 0
+	      0, 1, 0, 1,
+	      0, 1, 0, 1
 	    };
 	    decode_present = !decode_array.empty();
 	  }

--- a/src/parse/pdf_states/bitmap.h
+++ b/src/parse/pdf_states/bitmap.h
@@ -56,7 +56,8 @@ namespace pdflib
     };
 
     void add_bitmap_instruction(const page_item<PAGE_IMAGE>& image,
-                                clip_state_instruction clip_state);
+                                clip_state_instruction clip_state,
+                                bitmap_source source);
 
     void populate_geometry(page_item<PAGE_IMAGE>& image,
                            const clip_state_instruction& clip_state) const;
@@ -268,7 +269,7 @@ namespace pdflib
 
     page_images.push_back(image);
 
-    add_bitmap_instruction(image, std::move(clip_state));
+    add_bitmap_instruction(image, std::move(clip_state), BITMAP_SOURCE_XOBJECT);
   }
 
   void pdf_state<BITMAP>::Do_inline_image(
@@ -320,7 +321,7 @@ namespace pdflib
     image.rgb_filling_ops    = grph_state.get_rgb_filling_ops();
 
     page_images.push_back(image);
-    add_bitmap_instruction(image, std::move(clip_state));
+    add_bitmap_instruction(image, std::move(clip_state), BITMAP_SOURCE_INLINE);
   }
 
   void pdf_state<BITMAP>::populate_geometry(
@@ -384,7 +385,8 @@ namespace pdflib
   }
 
   void pdf_state<BITMAP>::add_bitmap_instruction(const page_item<PAGE_IMAGE>& image,
-                                                 clip_state_instruction clip_state)
+                                                 clip_state_instruction clip_state,
+                                                 bitmap_source source)
   {
     std::shared_ptr<std::vector<uint8_t>> pixel_data;
     std::array<int, 3> pixel_shape = {0, 0, 0};
@@ -1343,6 +1345,7 @@ namespace pdflib
                               image.r_x1, image.r_y1,
                               image.r_x2, image.r_y2,
                               image.r_x3, image.r_y3,
+                              source,
                               std::move(clip_state));
     binstr.set_blend_mode(grph_state.get_blend_mode());
 

--- a/src/parse/pdf_states/bitmap.h
+++ b/src/parse/pdf_states/bitmap.h
@@ -228,6 +228,8 @@ namespace pdflib
       image.raw_stream_data    = xobj.get_raw_stream_data();
       image.decoded_stream_data = xobj.get_decoded_stream_data();
       image.soft_mask_data     = xobj.get_soft_mask_data();
+      image.soft_mask_width    = xobj.get_soft_mask_width();
+      image.soft_mask_height   = xobj.get_soft_mask_height();
 
       LOG_S(INFO) << "image with ("
 		  << image.x0 << ", " << image.y0 << ") x ("
@@ -1279,6 +1281,53 @@ namespace pdflib
 
         LOG_S(INFO) << "bitmap: converted " << pixels << " tint sample(s) to RGB"
                     << " for xobject_key=" << image.xobject_key;
+      }
+
+    // The soft mask may have been resolved onto a finer grid than the colour
+    // plane (see init_soft_mask_data). Compositing needs both on one grid, so
+    // upsample the colour to match; nearest-neighbour mirrors how the mask
+    // itself is resampled, and is exact for the flat swatches this affects.
+    if(pixel_data
+       and pixel_shape.size() == 3
+       and image.soft_mask_data
+       and image.soft_mask_width > pixel_shape[1]
+       and image.soft_mask_height > pixel_shape[0])
+      {
+        const int src_h = pixel_shape[0];
+        const int src_w = pixel_shape[1];
+        const int ncomp = pixel_shape[2];
+        const int dst_w = image.soft_mask_width;
+        const int dst_h = image.soft_mask_height;
+
+        if(src_h > 0 and src_w > 0 and ncomp > 0
+           and pixel_data->size() >= static_cast<size_t>(src_h) * src_w * ncomp)
+          {
+            auto scaled = std::make_shared<std::vector<uint8_t>>();
+            scaled->resize(static_cast<size_t>(dst_w) * dst_h * ncomp);
+
+            for(int row = 0; row < dst_h; ++row)
+              {
+                const size_t src_row = (static_cast<size_t>(row) * src_h) / dst_h;
+                for(int col = 0; col < dst_w; ++col)
+                  {
+                    const size_t src_col = (static_cast<size_t>(col) * src_w) / dst_w;
+                    const size_t si = (src_row * src_w + src_col) * ncomp;
+                    const size_t di = (static_cast<size_t>(row) * dst_w + col) * ncomp;
+                    for(int c = 0; c < ncomp; ++c)
+                      {
+                        (*scaled)[di + c] = (*pixel_data)[si + c];
+                      }
+                  }
+              }
+
+            LOG_S(INFO) << "bitmap: upsampled colour plane to the soft-mask grid "
+                        << "for xobject_key=" << image.xobject_key
+                        << " " << src_w << "x" << src_h
+                        << " -> " << dst_w << "x" << dst_h;
+
+            pixel_data  = std::move(scaled);
+            pixel_shape = {dst_h, dst_w, ncomp};
+          }
       }
 
     bitmap_instruction binstr(image.xobject_key,

--- a/src/parse/pdf_states/shape.h
+++ b/src/parse/pdf_states/shape.h
@@ -137,6 +137,9 @@ namespace pdflib
     
     page_item<PAGE_SHAPES> curr_shapes;
     page_item<PAGE_SHAPES> clippings;
+    // group id of each entry in `clippings`: one W/W* capture = one group
+    std::vector<int> clipping_groups;
+    int next_clip_group = 0;
 
     clipping_path_mode_type clipping_path_mode;
     bool clipping_path_pending;
@@ -190,6 +193,8 @@ namespace pdflib
   {
     this->curr_shapes = other.curr_shapes;
     this->clippings  = other.clippings;
+    this->clipping_groups = other.clipping_groups;
+    this->next_clip_group = other.next_clip_group;
     this->clipping_path_mode = other.clipping_path_mode;
     this->clipping_path_pending = other.clipping_path_pending;
 
@@ -446,7 +451,9 @@ namespace pdflib
         paths.emplace_back(shape.get_x(),
                            shape.get_y(),
                            shape.get_closing_type(),
-                           shape.get_shape_type());
+                           shape.get_shape_type(),
+                           l < static_cast<int>(clipping_groups.size())
+                             ? clipping_groups[l] : 0);
       }
 
     return clip_state_instruction(rule, std::move(paths));
@@ -468,6 +475,9 @@ namespace pdflib
   {
     if(not clipping_path_pending) { return; }
 
+    // Every subpath of this capture belongs to one clip operation.
+    const int group_id = next_clip_group++;
+
     // Per spec the new clip is the *intersection* of the old and new clip
     // regions; appending approximates that, since the renderer ANDs the
     // clip paths it applies.
@@ -483,6 +493,7 @@ namespace pdflib
         if(keep_shape(shape))
           {
             clippings.push_back(shape);
+            clipping_groups.push_back(group_id);
           }
         else if(shape.size() >= 2)
           {

--- a/src/parse/pdf_states/text.h
+++ b/src/parse/pdf_states/text.h
@@ -808,7 +808,8 @@ namespace pdflib
                   true,
                   grph_state.get_rgb_filling_ops(),
                   grph_state.get_fill_alpha(),
-                  x0, y0, x1, y1, x2, y2, x3, y3);
+                  x0, y0, x1, y1, x2, y2, x3, y3,
+                  BITMAP_SOURCE_TYPE3_GLYPH);
 
                 instructions.add_bitmap_instruction(std::move(b3));
               }

--- a/src/parse/utils/bitmap/bitmap_exporter.h
+++ b/src/parse/utils/bitmap/bitmap_exporter.h
@@ -70,10 +70,20 @@ namespace bitmap_export
     std::string safe_pdf_stem = sanitize_path_component(
       std::filesystem::path(pdf_path).stem().string());
     std::string safe_key = sanitize_path_component(instr.get_key());
+
+    // A rasterised Type3 glyph is a character, not page artwork, and there is
+    // one per painted character: left in the same directory they bury the
+    // handful of real images. They go to their own `glyphs/` subdirectory.
+    if(instr.is_glyph())
+      {
+        out_dir = out_dir / "glyphs";
+        std::filesystem::create_directories(out_dir);
+      }
+
     std::string stem =
       safe_pdf_stem + "_p" + std::to_string(page_number + 1) +
       "_xobj_" + safe_key +
-      "_bitmap_" + std::to_string(bitmap_index);
+      (instr.is_glyph() ? "_glyph_" : "_bitmap_") + std::to_string(bitmap_index);
 
     if(instr.get_pixel_format() == PIXEL_FORMAT_GRAY)
       {

--- a/src/render/blend2d_font_resolver.h
+++ b/src/render/blend2d_font_resolver.h
@@ -48,8 +48,10 @@ namespace pdflib
     // directory scan runs at most once per resolver instance.
     void warm();
 
-    // Resolves the PDF font identifiers to a Blend2D font face. font_name is
-    // preferred unless it is empty or "null", otherwise base_font is used.
+    // Resolves the PDF font identifiers to a Blend2D font face. base_font is
+    // preferred, being the PostScript name of the typeface; font_name carries
+    // the font dictionary's /Name, a resource label, and is used only when
+    // there is no base font.
     // When resolve_fonts is true the selected name is matched against indexed
     // system fonts using deterministic aliases, exact metadata matches, style
     // selection, and finally fuzzy matching. If lookup fails, or resolving is
@@ -123,7 +125,6 @@ namespace pdflib
     // Strips leading PDF name slash and six-letter subset prefixes such as
     // ABCDEF+Times-Roman.
     static std::string strip_subset_prefix(const std::string& name);
-    static bool is_pdf_resource_font_key(const std::string& name);
     static std::string select_font_query(const std::string& font_name,
                                          const std::string& base_font);
 
@@ -344,28 +345,23 @@ namespace pdflib
     return s;
   }
 
-  inline bool blend2d_font_resolver::is_pdf_resource_font_key(const std::string& name)
-  {
-    const std::string s = strip_subset_prefix(name);
-    if (s.size() < 2 or (s[0] != 'F' and s[0] != 'f')) { return false; }
-
-    return std::all_of(s.begin() + 1, s.end(),
-                       [](char c)
-                       {
-                         return std::isdigit(static_cast<unsigned char>(c));
-                       });
-  }
-
   inline std::string blend2d_font_resolver::select_font_query(
                                                               const std::string& font_name,
                                                               const std::string& base_font)
   {
+    // /BaseFont is the PostScript name of the typeface. The other name is
+    // whatever the font dictionary's /Name says, which is the label the
+    // resource dictionary references the font by and is deprecated as of PDF
+    // 1.7 (32000-1, Table 111) -- producers put arbitrary strings there.
+    // Preferring it loses the typeface: an arXiv stamp declared
+    // `/BaseFont /Times-Roman /Name /arXivStAmP` matched nothing under its
+    // label and fell through to the generic sans fallback, so the stamp came
+    // out in the wrong face while every other renderer set it in a serif.
+    //
+    // Only `F<digits>` used to be recognised as a label, which is the common
+    // shape but not a rule any producer follows.
     const bool has_base_font = not base_font.empty() and base_font != "null";
-    if (has_base_font and
-        (font_name.empty() or font_name == "null" or is_pdf_resource_font_key(font_name)))
-      {
-        return base_font;
-      }
+    if (has_base_font) { return base_font; }
 
     if (not font_name.empty() and font_name != "null") { return font_name; }
     return base_font;
@@ -418,17 +414,40 @@ namespace pdflib
           }
       }
 
-    for (const auto& suf : {" psmt", " ps", " mt"})
-      {
-        const std::string sfx(suf);
-        if (expanded.size() >= sfx.size() and
-            expanded.compare(expanded.size() - sfx.size(),
-                             sfx.size(), sfx) == 0)
-          {
-            expanded.resize(expanded.size() - sfx.size());
-            break;
-          }
-      }
+    // "PS" and "MT" are Monotype's PostScript vendor tags, and they sit around
+    // the style rather than only after it: TimesNewRomanPSMT normalises to
+    // "times new roman", but TimesNewRomanPS-BoldMT put a "ps" in the middle
+    // and only the trailing "mt" was ever removed. The leftover
+    // "times new roman ps bold" matched no alias, so the regular weight of a
+    // Times document resolved to a serif while its bold and italic fell
+    // through to the generic sans -- one paragraph set in three faces.
+    //
+    // Dropping the tags as whole tokens wherever they appear keeps the family
+    // and the style together. They are only ever vendor tags, never a family
+    // of their own, and a name that is nothing else is left alone.
+    {
+      std::vector<std::string> kept;
+      std::istringstream stream(expanded);
+      std::string token;
+      while (stream >> token)
+        {
+          if (token != "ps" and token != "mt" and token != "psmt")
+            {
+              kept.push_back(token);
+            }
+        }
+
+      if (not kept.empty())
+        {
+          std::ostringstream rebuilt;
+          for (size_t l = 0; l < kept.size(); l++)
+            {
+              if (l > 0) { rebuilt << ' '; }
+              rebuilt << kept[l];
+            }
+          expanded = rebuilt.str();
+        }
+    }
 
     std::string collapsed;
     bool pending_space = false;

--- a/src/render/blend2d_font_resolver.h
+++ b/src/render/blend2d_font_resolver.h
@@ -55,6 +55,15 @@ namespace pdflib
     // selection, and finally fuzzy matching. If lookup fails, or resolving is
     // disabled, the method falls back to a known system font.
     // Returns an invalid BLFontFace when no fallback font can be loaded.
+
+    // Chooses a face by the SCRIPT of the text, for runs the name-based
+    // resolution cannot draw: an Arabic or CJK run through a Latin fallback
+    // shapes to .notdef boxes. Returns an invalid face for Latin-only text.
+    BLFontFace resolve_face_for_text(const std::string& utf8_text);
+
+    // True when every glyph of a shaped run is .notdef.
+    static bool shaped_run_all_notdef(const BLGlyphBuffer& gb);
+
     BLFontFace resolve_font_face(const std::string& font_name,
                                  const std::string& base_font,
                                  bool resolve_fonts,
@@ -150,6 +159,16 @@ namespace pdflib
     static bool is_cjk_font_request(const std::string& name);
     static std::vector<std::filesystem::path> cjk_fallback_candidates();
 
+    static std::vector<std::filesystem::path> arabic_fallback_candidates();
+
+    // Maps text to a coarse script bucket ("arabic", "cjk", "hebrew", ...);
+    // false for Latin-only text.
+    static bool text_script_key(const std::string& utf8_text, std::string& script_key);
+
+    // Whether `face` shapes `utf8_text` to something other than all-.notdef.
+    static bool face_covers_text(BLFontFace& face, const std::string& utf8_text);
+
+
     static std::string bl_string_to_std(const BLString& s);
     static std::string font_ref_key(const font_face_ref& ref);
 
@@ -183,6 +202,9 @@ namespace pdflib
     std::unordered_map<std::string, indexed_font_face> face_metadata_;
     std::vector<std::filesystem::path> fallback_candidates_;
     std::vector<std::filesystem::path> cjk_candidates_;
+    std::vector<std::filesystem::path> arabic_candidates_;
+    mutable std::shared_mutex script_cache_mutex_;
+    std::unordered_map<std::string, BLFontFace> script_face_cache_;
 
     mutable std::shared_mutex match_cache_mutex_;
     std::unordered_map<match_cache_key,
@@ -634,6 +656,227 @@ namespace pdflib
         if (s.find(t) != std::string::npos) { return true; }
       }
     return false;
+  }
+
+
+  inline std::vector<std::filesystem::path>
+  blend2d_font_resolver::arabic_fallback_candidates()
+  {
+    namespace fs = std::filesystem;
+    std::vector<fs::path> paths;
+
+    if (auto override_path = getenv_string("DOCLING_PARSE_ARABIC_FALLBACK_FONT"))
+      {
+        paths.emplace_back(*override_path);
+      }
+
+    // Filename stems of faces that carry Arabic, best first. The generic
+    // faces at the end matter more here than in the CJK list: DejaVu and
+    // Arial both cover Arabic, so most hosts can draw it even with no
+    // purpose-built Arabic font installed.
+    static const std::array<const char*, 18> wanted = {
+      // Linux distributions
+      "notonaskharabic", "notosansarabic", "notokufiarabic",
+      "amiri", "scheherazade", "kacst", "droidsansarabic",
+      // Windows (%WINDIR%\Fonts)
+      "arabtype",    // Arabic Typesetting
+      "trado",       // Traditional Arabic
+      "majalla",     // Sakkal Majalla
+      "andlso",      // Andalus
+      "simpo",       // Simplified Arabic
+      // macOS
+      "geezapro", "albayan", "baghdad", "damascus",
+      // broad faces that happen to include Arabic
+      "dejavusans", "arial",
+    };
+
+    constexpr std::size_t max_entries = 20000;
+    std::size_t seen = 0;
+    std::vector<fs::path> ranked(wanted.size());
+
+    for (const auto& dir : system_font_directories())
+      {
+        std::error_code ec;
+        if (not fs::is_directory(dir, ec)) { continue; }
+        fs::recursive_directory_iterator it(
+          dir, fs::directory_options::skip_permission_denied, ec);
+        fs::recursive_directory_iterator end;
+        for (; it != end and seen < max_entries; it.increment(ec))
+          {
+            if (ec) { break; }
+            ++seen;
+            const fs::path& p = it->path();
+            if (not is_font_file(p)) { continue; }
+            std::string stem = p.stem().string();
+            std::transform(stem.begin(), stem.end(), stem.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            for (std::size_t i = 0; i < wanted.size(); i++)
+              {
+                if (ranked[i].empty() and stem.find(wanted[i]) != std::string::npos)
+                  {
+                    ranked[i] = p;
+                  }
+              }
+          }
+        if (seen >= max_entries) { break; }
+      }
+
+    for (const auto& p : ranked)
+      {
+        if (not p.empty()) { paths.push_back(p); }
+      }
+    return paths;
+  }
+
+
+  inline bool blend2d_font_resolver::text_script_key(const std::string& utf8_text,
+                                                     std::string& script_key)
+  {
+    // Minimal UTF-8 decode: only the codepoint ranges matter, and the text is
+    // already known-good UTF-8 by the time it reaches the renderer.
+    const unsigned char* s = reinterpret_cast<const unsigned char*>(utf8_text.data());
+    const std::size_t n = utf8_text.size();
+
+    for (std::size_t i = 0; i < n;)
+      {
+        uint32_t cp = 0;
+        std::size_t len = 1;
+
+        if (s[i] < 0x80)            { cp = s[i]; len = 1; }
+        else if ((s[i] & 0xE0) == 0xC0) { cp = s[i] & 0x1F; len = 2; }
+        else if ((s[i] & 0xF0) == 0xE0) { cp = s[i] & 0x0F; len = 3; }
+        else if ((s[i] & 0xF8) == 0xF0) { cp = s[i] & 0x07; len = 4; }
+        else { i += 1; continue; }
+
+        if (i + len > n) { break; }
+        for (std::size_t k = 1; k < len; ++k)
+          {
+            cp = (cp << 6) | (s[i + k] & 0x3F);
+          }
+        i += len;
+
+        if (cp < 0x0250) { continue; }  // Latin, punctuation, digits
+
+        if ((cp >= 0x0600 and cp <= 0x06FF) or (cp >= 0x0750 and cp <= 0x077F) or
+            (cp >= 0xFB50 and cp <= 0xFDFF) or (cp >= 0xFE70 and cp <= 0xFEFF))
+          { script_key = "arabic"; return true; }
+
+        if ((cp >= 0x2E80 and cp <= 0x9FFF) or (cp >= 0x3040 and cp <= 0x30FF) or
+            (cp >= 0xAC00 and cp <= 0xD7AF) or (cp >= 0xF900 and cp <= 0xFAFF) or
+            (cp >= 0x20000 and cp <= 0x2FA1F))
+          { script_key = "cjk"; return true; }
+
+        if (cp >= 0x0590 and cp <= 0x05FF) { script_key = "hebrew"; return true; }
+        if (cp >= 0x0900 and cp <= 0x097F) { script_key = "devanagari"; return true; }
+        if (cp >= 0x0E00 and cp <= 0x0E7F) { script_key = "thai"; return true; }
+        if (cp >= 0x0400 and cp <= 0x04FF) { script_key = "cyrillic"; return true; }
+        if (cp >= 0x0370 and cp <= 0x03FF) { script_key = "greek"; return true; }
+
+        script_key = "other";
+        return true;
+      }
+
+    return false;
+  }
+
+
+  inline bool blend2d_font_resolver::shaped_run_all_notdef(const BLGlyphBuffer& gb)
+  {
+    const std::size_t count = gb.size();
+    const uint32_t* ids = gb.glyph_run().glyph_data_as<uint32_t>();
+    if (count == 0 or ids == nullptr) { return true; }
+    for (std::size_t i = 0; i < count; ++i)
+      {
+        if (ids[i] != 0) { return false; }
+      }
+    return true;
+  }
+
+
+  inline bool blend2d_font_resolver::face_covers_text(BLFontFace& face,
+                                                      const std::string& utf8_text)
+  {
+    if (not face.is_valid()) { return false; }
+
+    BLFont probe;
+    if (probe.create_from_face(face, 16.0f) != BL_SUCCESS) { return false; }
+
+    BLGlyphBuffer gb;
+    gb.set_utf8_text(utf8_text.c_str());
+    if (probe.shape(gb) != BL_SUCCESS or gb.is_empty()) { return false; }
+
+    return not shaped_run_all_notdef(gb);
+  }
+
+
+  inline BLFontFace blend2d_font_resolver::resolve_face_for_text(const std::string& utf8_text)
+  {
+    std::string script;
+    if (not text_script_key(utf8_text, script))
+      {
+        return BLFontFace();  // Latin-only: the name-based path is correct
+      }
+
+    warm();
+
+    {
+      std::shared_lock<std::shared_mutex> lock(script_cache_mutex_);
+      auto it = script_face_cache_.find(script);
+      if (it != script_face_cache_.end()) { return it->second; }
+    }
+
+    // Script-specific faces first, then every indexed face in discovery order,
+    // so a host with nothing purpose-built still finds a broad face that
+    // happens to cover the script.
+    std::vector<font_face_ref> refs;
+    const std::vector<std::filesystem::path>& preferred =
+      (script == "cjk") ? cjk_candidates_
+                        : (script == "arabic" ? arabic_candidates_ : fallback_candidates_);
+
+    for (const auto& p : preferred)
+      {
+        std::error_code ec;
+        if (std::filesystem::exists(p, ec)) { refs.push_back({p.string(), 0}); }
+      }
+
+    std::vector<const indexed_font_face*> indexed;
+    indexed.reserve(face_metadata_.size());
+    for (const auto& kv : face_metadata_) { indexed.push_back(&kv.second); }
+    std::sort(indexed.begin(), indexed.end(),
+              [](const indexed_font_face* a, const indexed_font_face* b)
+              { return a->discovery_order < b->discovery_order; });
+    for (const auto* meta : indexed) { refs.push_back(meta->ref); }
+
+    // Probing means shaping, so bound the work; the answer is cached per script.
+    constexpr std::size_t max_probes = 80;
+
+    BLFontFace chosen;
+    std::size_t probes = 0;
+    for (const auto& ref : refs)
+      {
+        if (probes++ >= max_probes) { break; }
+        BLFontFace face = load_font_face(ref);
+        if (face_covers_text(face, utf8_text))
+          {
+            chosen = face;
+            LOG_S(INFO) << "blend2d font resolver: script '" << script
+                        << "' resolved to " << ref.path
+                        << " after " << probes << " probe(s)";
+            break;
+          }
+      }
+
+    if (not chosen.is_valid())
+      {
+        LOG_S(WARNING) << "blend2d font resolver: no installed face covers script '"
+                       << script << "'; text will render as .notdef boxes";
+      }
+
+    {
+      std::unique_lock<std::shared_mutex> lock(script_cache_mutex_);
+      script_face_cache_[script] = chosen;
+    }
+    return chosen;
   }
 
   inline std::vector<std::filesystem::path> blend2d_font_resolver::cjk_fallback_candidates()
@@ -1113,6 +1356,7 @@ namespace pdflib
     const std::vector<fs::path> font_dirs = system_font_directories();
     fallback_candidates_ = fallback_font_candidates();
     cjk_candidates_ = cjk_fallback_candidates();
+    arabic_candidates_ = arabic_fallback_candidates();
 
     LOG_S(INFO) << "blend2d font resolver: scanning font directories";
     for (const auto& dir : font_dirs)

--- a/src/render/blend2d_renderer.h
+++ b/src/render/blend2d_renderer.h
@@ -973,13 +973,17 @@ namespace pdflib
     {
       const double ink[4] = {c / 255.0, m / 255.0, y / 255.0, k / 255.0};
 
-      if (convention == CMYK_CONVENTION_PROCESS)
+      // CMYK samples are ink values unless something positively established
+      // the Adobe-inverted convention. Treating "unknown" as inverted made
+      // the default a silent negation, which every decode path then had to
+      // cancel by luck.
+      if (convention == CMYK_CONVENTION_ADOBE_INVERTED)
         {
-          return color::cmyk_to_rgb255(ink[0], ink[1], ink[2], ink[3]);
+          return color::cmyk_to_rgb255(1.0 - ink[0], 1.0 - ink[1],
+                                       1.0 - ink[2], 1.0 - ink[3]);
         }
 
-      return color::cmyk_to_rgb255(1.0 - ink[0], 1.0 - ink[1],
-                                   1.0 - ink[2], 1.0 - ink[3]);
+      return color::cmyk_to_rgb255(ink[0], ink[1], ink[2], ink[3]);
     }
 
     // Maps an ExtGState /BM to the Blend2D compositing operator (11.3.5,

--- a/src/render/blend2d_renderer.h
+++ b/src/render/blend2d_renderer.h
@@ -143,6 +143,12 @@ namespace pdflib
       double hy = 0.0;
       double quad_h = 0.0;
       double size = 0.0;
+      // Horizontal condensation: the ratio of the cell's width edge to the
+      // natural advance of the shaped run. PDF text may be anisotropically
+      // scaled (Tz, or a text matrix with sx != sy); a transform built from
+      // the up-vector alone draws every glyph at full width, and a condensed
+      // newspaper headline turns into overlapping strokes.
+      double h_scale = 1.0;
     };
 
     struct text_draw_adjustment
@@ -355,6 +361,31 @@ namespace pdflib
     // Computes the canvas-space baseline, bounding quad, text cell height
     // vector, and Blend2D font size for one text instruction.
     text_geometry make_text_geometry(text_instruction& instr) const;
+
+    // Sets geom.h_scale from the cell's width edge and the natural advance of
+    // the given run; identity when either is degenerate or nearly equal.
+    static void apply_condensation(text_geometry& geom,
+                                   const BLFont& font,
+                                   BLGlyphBuffer& gb)
+    {
+      const double wx = geom.bbox.x1 - geom.bbox.x0;
+      const double wy = geom.bbox.y1 - geom.bbox.y0;
+      const double cell_w = std::hypot(wx, wy);
+      if (cell_w <= 0.5) { return; }
+
+      BLTextMetrics tm;
+      if (font.get_text_metrics(gb, tm) != BL_SUCCESS) { return; }
+      const double natural = tm.advance.x;
+      if (natural <= 0.5) { return; }
+
+      const double h = cell_w / natural;
+      // Only meaningful, bounded deviations: runaway ratios mean the metrics
+      // and the cell disagree for other reasons (fallback face substitution).
+      if (h >= 0.30 and h <= 3.0 and std::abs(h - 1.0) > 0.03)
+        {
+          geom.h_scale = h;
+        }
+    }
 
     // Builds the affine transform that maps Blend2D text coordinates into the
     // target PDF text cell in canvas space.
@@ -631,8 +662,19 @@ namespace pdflib
     {
       if(not clip_state.has_clip()) { return false; }
 
+      std::unordered_map<int, int> group_sizes;
       for(const auto& clip_path : clip_state.get_paths())
         {
+          group_sizes[clip_path.get_clip_group()]++;
+        }
+
+      for(const auto& clip_path : clip_state.get_paths())
+        {
+          // Subpaths of one W/W* operation only mean anything together (one
+          // path under the clip's fill rule), which clip_to_rect cannot
+          // express even when each subpath happens to be rectangular.
+          if(group_sizes[clip_path.get_clip_group()] > 1) { return true; }
+
           BLRect unused;
           if(not get_axis_aligned_clip_rect(clip_path, unused)) { return true; }
         }
@@ -676,18 +718,53 @@ namespace pdflib
       mctx.set_comp_op(BL_COMP_OP_SRC_COPY);
       mctx.fill_all(BLRgba32(0x00000000u));
 
-      bool first = true;
-      std::vector<BLImage> pending_planes;
+      // One W/W* capture = one clip path, whatever its subpath count; the
+      // subpaths compose under the clip's fill rule (a stencil of outline
+      // art, a text-shaped clip). Only DIFFERENT captures intersect.
+      // Intersecting the subpaths individually made any such stencil empty,
+      // and everything filled through it vanished.
+      std::vector<std::pair<int, BLPath> > group_paths;
       for(const auto& clip_path : clip_state.get_paths())
         {
           BLRect unused;
-          if(get_axis_aligned_clip_rect(clip_path, unused)) { continue; }
+          const bool is_rect = get_axis_aligned_clip_rect(clip_path, unused);
 
-          BLPath path = make_clip_path(clip_path, this);
-          if(path.is_empty()) { continue; }
+          // rect paths that are alone in their group were already applied
+          // through the context clip
+          bool grouped = false;
+          for(const auto& other : clip_state.get_paths())
+            {
+              if(&other != &clip_path and
+                 other.get_clip_group() == clip_path.get_clip_group())
+                {
+                  grouped = true;
+                  break;
+                }
+            }
+          if(is_rect and not grouped) { continue; }
 
+          BLPath sub = make_clip_path(clip_path, this);
+          if(sub.is_empty()) { continue; }
+
+          BLPath* dst = nullptr;
+          for(auto& gp : group_paths)
+            {
+              if(gp.first == clip_path.get_clip_group()) { dst = &gp.second; break; }
+            }
+          if(dst == nullptr)
+            {
+              group_paths.emplace_back(clip_path.get_clip_group(), BLPath());
+              dst = &group_paths.back().second;
+            }
+          dst->add_path(sub);
+        }
+
+      bool first = true;
+      std::vector<BLImage> pending_planes;
+      for(auto& gp : group_paths)
+        {
           BLPath shifted;
-          shifted.add_path(path, BLMatrix2D::make_translation(-area.x, -area.y));
+          shifted.add_path(gp.second, BLMatrix2D::make_translation(-area.x, -area.y));
 
           if(first)
             {
@@ -698,7 +775,7 @@ namespace pdflib
               continue;
             }
 
-          // Rasterise this path on its own, then fold it in by multiplying.
+          // Rasterise this capture on its own, then fold it in by multiplying.
           BLImage plane;
           if(plane.create(area.w, area.h, BL_FORMAT_A8) != BL_SUCCESS) { continue; }
           {
@@ -710,7 +787,6 @@ namespace pdflib
             pctx.fill_path(shifted, BLRgba32(0xFFFFFFFFu));
             pctx.end();
           }
-
           pending_planes.push_back(std::move(plane));
         }
 
@@ -739,9 +815,19 @@ namespace pdflib
           return CLIP_NONE;
         }
 
+      std::unordered_map<int, int> group_sizes;
+      for(const auto& clip_path : clip_state.get_paths())
+        {
+          group_sizes[clip_path.get_clip_group()]++;
+        }
+
       bool applied_clip = false;
       for(const auto& clip_path : clip_state.get_paths())
         {
+          // A subpath that shares its W/W* capture with others is not a clip
+          // on its own; the whole group is handled through the coverage mask.
+          if(group_sizes[clip_path.get_clip_group()] > 1) { continue; }
+
           BLRect clip_rect;
           if(get_axis_aligned_clip_rect(clip_path, clip_rect))
             {
@@ -1422,7 +1508,7 @@ namespace pdflib
     const double dn_x  = -up_x;
     const double dn_y  = -up_y;
 
-    return BLMatrix2D(adv_x,  adv_y,
+    return BLMatrix2D(adv_x * geom.h_scale, adv_y * geom.h_scale,
                       dn_x,   dn_y,
                       geom.bx, geom.by);
   }
@@ -1715,20 +1801,39 @@ namespace pdflib
     if (geom.size <= 0.5) { return false; }
 
     BLPath text_path;
+    double natural_advance = 0.0;
     if (not freetype_font_cache_->build_text_path(instr.get_embedded_font(),
                                                   instr.get_text(),
                                                   instr.get_char_code(),
                                                   instr.get_glyph_name(),
                                                   geom.size,
-                                                  text_path))
+                                                  text_path,
+                                                  &natural_advance))
       {
         return false;
       }
 
+    // Same condensation handling as the Blend2D path: fit the run to the
+    // cell's width edge when the text matrix is anisotropic.
+    text_geometry draw_geom = geom;
+    {
+      const double wx = geom.bbox.x1 - geom.bbox.x0;
+      const double wy = geom.bbox.y1 - geom.bbox.y0;
+      const double cell_w = std::hypot(wx, wy);
+      if (cell_w > 0.5 and natural_advance > 0.5)
+        {
+          const double h = cell_w / natural_advance;
+          if (h >= 0.30 and h <= 3.0 and std::abs(h - 1.0) > 0.03)
+            {
+              draw_geom.h_scale = h;
+            }
+        }
+    }
+
     BLContext& ctx = page_context();
 
     ctx.save();
-    const BLResult transform_res = ctx.apply_transform(make_text_transform(geom));
+    const BLResult transform_res = ctx.apply_transform(make_text_transform(draw_geom));
     if (transform_res != BL_SUCCESS)
       {
         ctx.restore();
@@ -2018,7 +2123,9 @@ namespace pdflib
                 return;
               }
 
-            const BLMatrix2D ctm = make_text_transform(geom);
+            text_geometry draw_geom = geom;
+            apply_condensation(draw_geom, font, gb);
+            const BLMatrix2D ctm = make_text_transform(draw_geom);
             ctx.save();
             const BLResult transform_res = ctx.apply_transform(ctm);
             if (transform_res != BL_SUCCESS)

--- a/src/render/blend2d_renderer.h
+++ b/src/render/blend2d_renderer.h
@@ -183,6 +183,12 @@ namespace pdflib
     std::shared_ptr<blend2d_font_resolver> font_resolver_;
     std::shared_ptr<blend2d_embedded_font_cache> embedded_font_cache_;
     std::shared_ptr<freetype_embedded_font_cache> freetype_font_cache_;
+
+    // Embedded faces (by blob cache key) whose outlines Blend2D decoded
+    // implausibly; every later cell in them is drawn through FreeType so one
+    // run is not rasterised by two engines. Scoped to this renderer, which
+    // draws one page.
+    mutable std::unordered_set<std::string> distrusted_embedded_faces_;
     std::unordered_map<std::string, BLFontFace> local_font_cache_;
 
     // Returns the active Blend2D context for the page, starting it lazily if
@@ -281,6 +287,56 @@ namespace pdflib
         }
 
       return true;
+    }
+
+    // Blend2D loads some SFNT faces and then decodes part of them into
+    // outlines that are orders of magnitude too large: a valid CJK subset
+    // (PMingLiU, 1024 units/em, every glyph simple and well formed) rendered
+    // eight of its eleven glyphs as page-sized wedges and bars, while
+    // FreeType read all eleven correctly at the same size. The face loads,
+    // shaping succeeds and the glyph ids are right, so nothing upstream of
+    // the outline reports a problem.
+    //
+    // A glyph cannot be many times its own em, so an outline that overshoots
+    // by that much is a failed decode rather than a document asking for
+    // something enormous, and the cell is better drawn through FreeType.
+    static bool glyph_outlines_are_implausible(const BLFont& font,
+                                               const BLGlyphBuffer& gb,
+                                               double size)
+    {
+      const size_t count = gb.size();
+      const uint32_t* glyph_ids = gb.glyph_run().glyph_data_as<uint32_t>();
+      if (size <= 0.0 or count == 0 or glyph_ids == nullptr) { return false; }
+
+      // Loose on purpose. A stretched delimiter or a swash is a few em; the
+      // misdecodes seen here overshoot by one to two orders of magnitude.
+      constexpr double max_em_multiple = 8.0;
+      const double limit = max_em_multiple * size;
+
+      const BLMatrix2D identity(1.0, 0.0,
+                                0.0, 1.0,
+                                0.0, 0.0);
+
+      for (size_t l = 0; l < count; ++l)
+        {
+          BLPath path;
+          if (font.get_glyph_outlines(glyph_ids[l], identity, path) != BL_SUCCESS)
+            {
+              continue;
+            }
+
+          if (path.is_empty()) { continue; }
+
+          BLBox box;
+          if (path.get_bounding_box(&box) != BL_SUCCESS) { continue; }
+
+          if ((box.x1 - box.x0) > limit or (box.y1 - box.y0) > limit)
+            {
+              return true;
+            }
+        }
+
+      return false;
     }
 
     // Draws a text cell whose embedded font program Blend2D cannot load
@@ -1851,6 +1907,21 @@ namespace pdflib
     if (not text_path.is_empty())
       {
         ctx.fill_path(text_path);
+
+        // Text render modes with a stroke component (1, 2, 5, 6) are how
+        // producers synthesise bold from a regular face (PDF 32000-1, 9.3.6),
+        // and the Blend2D path strokes the run for exactly that reason. This
+        // path has to do the same or a heading routed here comes out lighter
+        // than the rest of the page -- which is how it looks when only some
+        // of a face's glyphs land here.
+        const int mode = instr.get_rendering_mode();
+        if (mode == 1 or mode == 2 or mode == 5 or mode == 6)
+          {
+            ctx.set_stroke_style(make_rgba32(instr.get_rgb_filling(),
+                                             instr.get_fill_alpha()));
+            ctx.set_stroke_width(std::max(0.3, geom.size * 0.03));
+            ctx.stroke_path(text_path);
+          }
       }
     ctx.restore();
 
@@ -2123,6 +2194,41 @@ namespace pdflib
                                << " base_font=`" << instr.get_base_font() << "`";
                 draw_bbox_fallback();
                 return;
+              }
+
+            // The face loaded and shaped, but its outlines can still come back
+            // mangled; FreeType reads the same glyphs correctly, so hand the
+            // cell to it rather than stamping a page-sized wedge on the page.
+            //
+            // The whole face goes with it, not just the glyphs caught. The
+            // misdecode hits some glyphs of a face and not others, and the two
+            // rasterisers differ slightly in weight, so drawing one word from
+            // both leaves it visibly patchy. One bad outline condemns the face
+            // for the rest of the page.
+            if (using_embedded_font)
+              {
+                const std::string& face_key =
+                  instr.get_embedded_font()->get_cache_key();
+                const bool distrusted =
+                  distrusted_embedded_faces_.count(face_key) > 0;
+
+                if (distrusted or glyph_outlines_are_implausible(font, gb, geom.size))
+                  {
+                    if (not distrusted)
+                      {
+                        LOG_S(WARNING) << "render_text: embedded face decoded an"
+                                       << " outline far larger than its em"
+                                       << " text=`" << instr.get_text() << "`"
+                                       << " font_name=`" << instr.get_font_name() << "`"
+                                       << " — drawing this face through FreeType";
+                        distrusted_embedded_faces_.insert(face_key);
+                      }
+
+                    if (render_text_freetype(instr, geom, bbox_path))
+                      {
+                        return;
+                      }
+                  }
               }
 
             const auto* placement_data = gb.placement_data();

--- a/src/render/blend2d_renderer.h
+++ b/src/render/blend2d_renderer.h
@@ -2022,7 +2022,12 @@ namespace pdflib
 
             if (char_code_first)
               {
-                shaped = recover_embedded_glyphs(font, instr, gb);
+                // A recovery that resolves every code to glyph 0 has not
+                // recovered anything: accepting it draws a row of .notdef
+                // boxes where the page has an unmapped glyph and every other
+                // renderer draws nothing.
+                shaped = recover_embedded_glyphs(font, instr, gb)
+                         and not glyph_run_all_notdef(gb);
               }
 
             if (not shaped)
@@ -2044,8 +2049,9 @@ namespace pdflib
                 // glyph-name/builtin-encoding resolution, then re-shape
                 // against the system face — drawing the .notdef run would
                 // produce blank/tofu output.
-                shaped = (not char_code_first) and
-                  recover_embedded_glyphs(font, instr, gb);
+                shaped = (not char_code_first)
+                         and recover_embedded_glyphs(font, instr, gb)
+                         and not glyph_run_all_notdef(gb);
 
                 if (not shaped)
                   {

--- a/src/render/blend2d_renderer.h
+++ b/src/render/blend2d_renderer.h
@@ -1971,6 +1971,34 @@ namespace pdflib
                   }
               }
 
+            // Last resort before giving up on the run: choose a face by the
+            // SCRIPT of the text. Name-based resolution hands Arabic or CJK
+            // runs a Latin face, which shapes every glyph to .notdef -- the
+            // page fills with boxes. Type3 stays out: its ink arrives as
+            // parse-time bitmaps, and shaping its cell text against a system
+            // face would smear placeholder boxes over that ink.
+            if (font_resolver_ and not instr.is_type3() and
+                (not shaped or glyph_run_all_notdef(gb)))
+              {
+                BLFontFace script_face =
+                  font_resolver_->resolve_face_for_text(instr.get_text());
+                BLFont script_font;
+                if (script_face.is_valid() and
+                    script_font.create_from_face(
+                      script_face, static_cast<float>(geom.size)) == BL_SUCCESS)
+                  {
+                    gb.set_utf8_text(instr.get_text().c_str());
+                    shape_res = script_font.shape(gb);
+                    if (shape_res == BL_SUCCESS and not gb.is_empty() and
+                        not glyph_run_all_notdef(gb))
+                      {
+                        font = script_font;
+                        using_embedded_font = false;
+                        shaped = true;
+                      }
+                  }
+              }
+
             if (not shaped)
               {
                 LOG_S(WARNING) << "render_text: shaping failed or produced no glyphs"

--- a/src/render/freetype_embedded_font_cache.h
+++ b/src/render/freetype_embedded_font_cache.h
@@ -69,7 +69,8 @@ namespace pdflib
                          int64_t char_code,
                          const std::string& glyph_name,
                          double size,
-                         BLPath& path);
+                         BLPath& path,
+                         double* out_advance = nullptr);
 
   private:
 
@@ -156,7 +157,8 @@ namespace pdflib
       int64_t char_code,
       const std::string& glyph_name,
       double size,
-      BLPath& path)
+      BLPath& path,
+      double* out_advance)
   {
     if(library_ == nullptr or blob == nullptr or not blob->has_bytes() or size <= 0.0)
       {
@@ -199,6 +201,13 @@ namespace pdflib
         path.add_path(glyph->path, m);
 
         pen_x += glyph->advance;
+      }
+
+    if(out_advance != nullptr)
+      {
+        const double units_per_em2 =
+          (entry.face->units_per_EM > 0) ? entry.face->units_per_EM : 1000.0;
+        *out_advance = pen_x * (size / units_per_em2);
       }
 
     return true;

--- a/src/render/freetype_embedded_font_cache.h
+++ b/src/render/freetype_embedded_font_cache.h
@@ -185,6 +185,18 @@ namespace pdflib
 
     path.clear();
 
+    // A run that resolves to nothing but .notdef has not been resolved. Many
+    // subset fonts draw .notdef as a hollow box, so emitting those outlines
+    // stamps boxes across the page exactly where a glyph could not be mapped
+    // -- down the middle of a matrix, through the gaps of a table -- while
+    // every other renderer leaves the spot empty.
+    bool any_real_glyph = false;
+    for(FT_UInt glyph_index : glyph_indices)
+      {
+        if(glyph_index != 0) { any_real_glyph = true; break; }
+      }
+    if(not any_real_glyph) { return false; }
+
     double pen_x = 0.0;
     for(FT_UInt glyph_index : glyph_indices)
       {
@@ -192,6 +204,14 @@ namespace pdflib
         if(glyph == nullptr)
           {
             return false;
+          }
+
+        // Keep the advance of a .notdef so the rest of the run stays in place,
+        // but do not draw its box.
+        if(glyph_index == 0)
+          {
+            pen_x += glyph->advance;
+            continue;
           }
 
         // Font units (y-up) -> Blend2D text space (y-down, pixels).

--- a/tests/README.md
+++ b/tests/README.md
@@ -71,6 +71,13 @@ For each selected rendered page, the test can compare:
 - bitmap artifact metadata and exported bitmap image bytes from
   `_export_bitmap_artifacts()`.
 
+Each bitmap artifact reports a `source`: `xobject` (an image XObject painted by
+`Do`), `inline` (a `BI ... ID ... EI` image) or `type3_glyph` (one rasterised
+Type3 glyph). Type3 glyphs reach the renderer as image masks, and one is emitted
+per painted character, so their groundtruth is written to
+`tests/data/groundtruth/render/glyphs/` with its own numbering, leaving
+`tests/data/groundtruth/render/bitmaps/` for the images a PDF actually embeds.
+
 Full-page image comparison is intentionally tolerant rather than exact. The
 comparison requires identical dimensions, then checks mean absolute error and
 changed-pixel ratio after applying a per-pixel threshold. This avoids making CI

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,5 +1,5 @@
 HF_DATASET_REPO_ID = "docling-project/regression-dataset-for-docling-parse"
-HF_DATASET_REVISION = "0e0ddfa0c87f84ca513c536b5fb5bc1cdfddaa2f"
+HF_DATASET_REVISION = "17e49e24fbbf80777a9eb48622ac9fd5fbd9718b"
 
 REGRESSION_DIR = "tests/data/regression"
 

--- a/tests/data_utils.py
+++ b/tests/data_utils.py
@@ -12,6 +12,10 @@ TEST_DATA_GROUNDTRUTH_DIR = TEST_DATA_DIR / "groundtruth"
 PARSER_GROUNDTRUTH_DIR = TEST_DATA_GROUNDTRUTH_DIR / "parser"
 RENDER_GROUNDTRUTH_DIR = TEST_DATA_GROUNDTRUTH_DIR / "render"
 RENDER_GROUNDTRUTH_BITMAPS_DIR = RENDER_GROUNDTRUTH_DIR / "bitmaps"
+# Rasterised Type3 glyphs come out of the same instruction stream as images,
+# but there is one per painted character: a single page of Type3 text yields
+# hundreds. They are kept apart so `bitmaps/` stays a directory of pictures.
+RENDER_GROUNDTRUTH_GLYPHS_DIR = RENDER_GROUNDTRUTH_DIR / "glyphs"
 RENDER_GROUNDTRUTH_INSTRUCTIONS_DIR = RENDER_GROUNDTRUTH_DIR / "instructions"
 RENDER_GROUNDTRUTH_PAGES_DIR = RENDER_GROUNDTRUTH_DIR / "pages"
 

--- a/tests/rendering_regression.py
+++ b/tests/rendering_regression.py
@@ -8,6 +8,7 @@ from PIL import Image, ImageChops, ImageDraw, ImageFont, ImageStat
 
 from tests.data_utils import (
     RENDER_GROUNDTRUTH_BITMAPS_DIR,
+    RENDER_GROUNDTRUTH_GLYPHS_DIR,
     RENDER_GROUNDTRUTH_INSTRUCTIONS_DIR,
     RENDER_GROUNDTRUTH_PAGES_DIR,
 )
@@ -59,8 +60,30 @@ def renderer_instructions_path(doc_name: str, page_no: int) -> Path:
     )
 
 
-def renderer_bitmap_path(filename: str) -> Path:
-    return RENDER_GROUNDTRUTH_BITMAPS_DIR / filename
+def bitmap_artifact_targets(prefix: str, result) -> list[tuple[dict[str, Any], Path]]:
+    """Pair every bitmap artifact with the path stem it is stored under.
+
+    A rasterised Type3 glyph is a character rather than page artwork, and one
+    is emitted per painted character, so a single page of Type3 text buries
+    the handful of real images under hundreds of glyph masks. The decoder
+    labels each bitmap with its `source`; glyphs go to their own directory and
+    carry their own numbering, so adding an image to a page does not renumber
+    every glyph on it.
+    """
+    targets: list[tuple[dict[str, Any], Path]] = []
+    counters = {"bitmap": 0, "glyph": 0}
+
+    for artifact in result._export_bitmap_artifacts():
+        kind = "glyph" if artifact.get("source") == "type3_glyph" else "bitmap"
+        counters[kind] += 1
+        directory = (
+            RENDER_GROUNDTRUTH_GLYPHS_DIR
+            if kind == "glyph"
+            else RENDER_GROUNDTRUTH_BITMAPS_DIR
+        )
+        targets.append((artifact, directory / f"{prefix}.{kind}_{counters[kind]}"))
+
+    return targets
 
 
 def _write_json(path: Path, data: Any) -> None:
@@ -97,6 +120,7 @@ def write_renderer_groundtruth(doc_name: str, page_no: int, result) -> None:
     RENDER_GROUNDTRUTH_PAGES_DIR.mkdir(parents=True, exist_ok=True)
     RENDER_GROUNDTRUTH_INSTRUCTIONS_DIR.mkdir(parents=True, exist_ok=True)
     RENDER_GROUNDTRUTH_BITMAPS_DIR.mkdir(parents=True, exist_ok=True)
+    RENDER_GROUNDTRUTH_GLYPHS_DIR.mkdir(parents=True, exist_ok=True)
 
     prefix = renderer_artifact_prefix(doc_name, page_no)
     result.get_image().save(renderer_image_path(doc_name, page_no))
@@ -105,15 +129,12 @@ def write_renderer_groundtruth(doc_name: str, page_no: int, result) -> None:
         normalized_render_instructions(result),
     )
 
-    for artifact in result._export_bitmap_artifacts():
-        index = artifact["index"]
-        extension = artifact["extension"]
-        exported_filename = f"{prefix}.bitmap_{index}{extension}"
-        image_path = renderer_bitmap_path(exported_filename)
+    for artifact, stem in bitmap_artifact_targets(prefix, result):
+        image_path = stem.with_name(stem.name + artifact["extension"])
         image_path.write_bytes(bytes(artifact.get("encoded_data", b"")))
         _write_json(
-            renderer_bitmap_path(f"{prefix}.bitmap_{index}.json"),
-            _bitmap_metadata(artifact, exported_filename),
+            stem.with_name(stem.name + ".json"),
+            _bitmap_metadata(artifact, image_path.name),
         )
 
 
@@ -130,14 +151,11 @@ def renderer_groundtruth_exists(doc_name: str, page_no: int, result) -> bool:
         return False
 
     prefix = renderer_artifact_prefix(doc_name, page_no)
-    for artifact in result._export_bitmap_artifacts():
-        index = artifact["index"]
-        extension = artifact["extension"]
-
-        if not renderer_bitmap_path(f"{prefix}.bitmap_{index}{extension}").exists():
+    for artifact, stem in bitmap_artifact_targets(prefix, result):
+        if not stem.with_name(stem.name + artifact["extension"]).exists():
             return False
 
-        if not renderer_bitmap_path(f"{prefix}.bitmap_{index}.json").exists():
+        if not stem.with_name(stem.name + ".json").exists():
             return False
 
     return True
@@ -434,14 +452,10 @@ def compare_images(
 
 def compare_bitmap_artifacts(doc_name: str, page_no: int, result) -> None:
     prefix = renderer_artifact_prefix(doc_name, page_no)
-    artifacts = result._export_bitmap_artifacts()
 
-    for artifact in artifacts:
-        index = artifact["index"]
-        extension = artifact["extension"]
-        exported_filename = f"{prefix}.bitmap_{index}{extension}"
-        image_path = renderer_bitmap_path(exported_filename)
-        metadata_path = renderer_bitmap_path(f"{prefix}.bitmap_{index}.json")
+    for artifact, stem in bitmap_artifact_targets(prefix, result):
+        image_path = stem.with_name(stem.name + artifact["extension"])
+        metadata_path = stem.with_name(stem.name + ".json")
 
         assert image_path.exists(), f"missing bitmap image groundtruth: {image_path}"
         assert metadata_path.exists(), (
@@ -449,10 +463,11 @@ def compare_bitmap_artifacts(doc_name: str, page_no: int, result) -> None:
         )
 
         expected_metadata = _load_json(metadata_path)
-        actual_metadata = _bitmap_metadata(artifact, exported_filename)
+        actual_metadata = _bitmap_metadata(artifact, image_path.name)
         stable_keys = [
             "index",
             "xobject_key",
+            "source",
             "shape",
             "pixel_format",
             "image_mask",

--- a/tests/test_font_name_resolution.py
+++ b/tests/test_font_name_resolution.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Which of a font's names decides the typeface (PDF 32000-1, 9.6.2).
+
+A font dictionary can carry two names. /BaseFont is the PostScript name of the
+typeface. /Name is the label the resource dictionary references the font by,
+and is deprecated as of PDF 1.7 -- producers put arbitrary strings there. An
+arXiv stamp declaring `/BaseFont /Times-Roman /Name /arXivStAmP` matched
+nothing under its label and fell through to the generic sans fallback, while
+every other renderer set it in a serif.
+
+The test compares two renders of the same /BaseFont against each other rather
+than against a named face, so it holds whatever fonts the machine has
+installed: adding a label must not move the result.
+
+The other half of that fix -- dropping the Monotype "PS"/"MT" vendor tags
+wherever they appear, so TimesNewRomanPS-BoldMT resolves with the same family
+as TimesNewRomanPSMT instead of missing the alias on an infix "ps" -- has no
+test here. Two font names that differ only in those tags also reach the width
+metrics differently in the parse layer, so comparing renders cannot isolate the
+face, and asserting a specific face would only hold on a machine that has it.
+That change is measured on the comparison corpus instead: 13 pages improved and
+none regressed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from tests.pdf_builder import build_pdf, content_stream, render_page
+from tests.rendering_regression import coverage_ratio, region_image
+
+TEXT_BOX = (10.0, 60.0, 290.0, 140.0)
+CONTENT = "BT\n/FT 36 Tf\n20 100 Td\n(Hamburg 123) Tj\nET\n"
+
+
+def _pdf(font_entries: str) -> bytes:
+    return build_pdf(
+        [
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 200] "
+            "/Resources << /Font << /FT 5 0 R >> >> /Contents 4 0 R >>",
+            content_stream(CONTENT),
+            f"<< /Type /Font /Subtype /Type1 {font_entries} >>",
+        ]
+    )
+
+
+def _render(font_entries: str):
+    return region_image(render_page(_pdf(font_entries)), TEXT_BOX)
+
+
+def test_resource_label_does_not_decide_the_typeface():
+    """/Name is a label; adding one must not change the face that is drawn.
+
+    This is the arXiv stamp: same /BaseFont, one of them additionally
+    labelled, and the labelled one used to resolve somewhere else entirely.
+    """
+    plain_image = _render("/BaseFont /Times-Roman")
+    labelled_image = _render("/BaseFont /Times-Roman /Name /arXivStAmP")
+
+    assert coverage_ratio(plain_image) > 0.01, (
+        "the fixture drew no text, so the comparison would be vacuous"
+    )
+
+    plain = np.asarray(plain_image.convert("L"), dtype=np.float64)
+    labelled = np.asarray(labelled_image.convert("L"), dtype=np.float64)
+    assert plain.shape == labelled.shape, (
+        f"renders differ in size: {plain.shape} vs {labelled.shape}"
+    )
+
+    difference = float(np.abs(plain - labelled).mean())
+    assert difference < 1.0, (
+        f"a /Name label changed the rendered face (mean abs difference "
+        f"{difference:.2f}); /BaseFont names the typeface, /Name does not"
+    )

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -142,7 +142,8 @@ def test_pattern_is_bounded_by_the_filled_path():
     """
     content = "/Pattern cs /P0 scn\n80 80 40 40 re f\n"
     pdf = simple_page_pdf(
-        content, resources="/Pattern << /P0 5 0 R >>",
+        content,
+        resources="/Pattern << /P0 5 0 R >>",
         extra_objects=[_solid_pattern_object()],
     )
     page = render_page(pdf)

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -122,6 +122,88 @@ def test_pattern_matrix_is_relative_to_the_page():
     ), "a CTM in force when the pattern is used moved the lattice"
 
 
+def _solid_pattern_object() -> bytes:
+    """A cell that paints its whole step, so any leak outside the fill shows."""
+    return stream_object(
+        "/Type /Pattern /PatternType 1 /PaintType 1 /TilingType 1 "
+        f"/BBox [0 0 {CELL} {CELL}] /XStep {CELL} /YStep {CELL} "
+        "/Resources << >> /Matrix [1 0 0 1 0 0]",
+        f"1 0 0 rg\n0 0 {CELL} {CELL} re f\n".encode("latin-1"),
+    )
+
+
+def test_pattern_is_bounded_by_the_filled_path():
+    """The lattice paints only inside the path being filled (8.7.3.1).
+
+    The cells are laid out to cover the page box, so without the filled path
+    bounding them the pattern tiles the entire page: a document whose pattern
+    fill was one small shape came out with a block of cells in the corner that
+    no other renderer draws.
+    """
+    content = "/Pattern cs /P0 scn\n80 80 40 40 re f\n"
+    pdf = simple_page_pdf(
+        content, resources="/Pattern << /P0 5 0 R >>",
+        extra_objects=[_solid_pattern_object()],
+    )
+    page = render_page(pdf)
+
+    inside = coverage_ratio(region_image(page, (85.0, 85.0, 115.0, 115.0)))
+    assert inside > 0.9, (
+        f"the pattern did not paint inside the filled path ({inside:.3f} coverage)"
+    )
+
+    for name, box in (
+        ("top-left", (0.0, 0.0, 60.0, 60.0)),
+        ("top-right", (140.0, 0.0, 200.0, 60.0)),
+        ("bottom-left", (0.0, 140.0, 60.0, 200.0)),
+        ("bottom-right", (140.0, 140.0, 200.0, 200.0)),
+    ):
+        outside = coverage_ratio(region_image(page, box))
+        assert outside < 0.02, (
+            f"the pattern painted outside the filled path: the {name} corner "
+            f"has {outside:.3f} coverage and the fill never reached it"
+        )
+
+
+def test_pattern_bound_honours_the_even_odd_rule():
+    """`f*` bounds the pattern by the even-odd rule, so a hole stays a hole.
+
+    Two nested rectangles wound the same way: under even-odd the inner one is a
+    hole, under nonzero it is filled. Bounding the pattern with the wrong rule
+    fills the hole with cells.
+    """
+    rects = "40 40 120 120 re\n70 70 60 60 re\n"
+    hole = (90.0, 90.0, 110.0, 110.0)
+    ring = (50.0, 50.0, 65.0, 65.0)
+
+    even_odd = render_page(
+        simple_page_pdf(
+            f"/Pattern cs /P0 scn\n{rects}f*\n",
+            resources="/Pattern << /P0 5 0 R >>",
+            extra_objects=[_solid_pattern_object()],
+        )
+    )
+    nonzero = render_page(
+        simple_page_pdf(
+            f"/Pattern cs /P0 scn\n{rects}f\n",
+            resources="/Pattern << /P0 5 0 R >>",
+            extra_objects=[_solid_pattern_object()],
+        )
+    )
+
+    assert coverage_ratio(region_image(even_odd, ring)) > 0.9, (
+        "the pattern did not paint the ring between the two rectangles"
+    )
+    assert coverage_ratio(region_image(even_odd, hole)) < 0.02, (
+        "f* left the inner rectangle filled; the pattern was bounded by the "
+        "nonzero rule instead of even-odd"
+    )
+    assert coverage_ratio(region_image(nonzero, hole)) > 0.9, (
+        "f left the inner rectangle empty; the same-wound subpath is not a hole "
+        "under the nonzero rule"
+    )
+
+
 def test_unresolved_pattern_paints_nothing():
     """A fill naming a pattern that cannot be resolved is skipped, not blackened.
 

--- a/tests/test_widget_appearances.py
+++ b/tests/test_widget_appearances.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""Form-field widget appearance streams (PDF 32000-1, 12.5.5 and 12.7).
+
+A widget's /AP normal appearance draws the field: its frame, its background,
+and whatever mark the field's value puts inside it. The frame is form chrome
+rather than page content, and painting it is visible damage on real documents
+-- a producer that cannot embed a glyph is free to leave a bordered
+placeholder button in its place, and those pages come out peppered with empty
+squares that no viewer draws. pdfium paints none of it, even with the form
+environment initialised and form drawing requested.
+
+What the field draws *inside* itself is content and has to survive; a checkbox
+whose tick disappeared would be a worse bug than the one being fixed. These
+tests pin both halves of that split.
+"""
+
+from __future__ import annotations
+
+from tests.pdf_builder import build_pdf, content_stream, render_page, stream_object
+from tests.rendering_regression import coverage_ratio, region_image
+
+# the widget sits well inside the page so its frame has empty margin around it
+RECT = (60.0, 60.0, 140.0, 140.0)
+SIDE = RECT[2] - RECT[0]
+
+# region_image takes top-left coordinates; the page is 200pt tall
+FRAME_BAND = (58.0, 58.0, 142.0, 72.0)
+INSIDE = (80.0, 80.0, 120.0, 120.0)
+
+
+def _widget_pdf(appearance: bytes) -> bytes:
+    """One page whose only mark is a widget annotation's normal appearance."""
+    return build_pdf(
+        [
+            "<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [5 0 R] >> >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] "
+            "/Contents 4 0 R /Annots [5 0 R] >>",
+            content_stream(""),
+            "<< /Type /Annot /Subtype /Widget /FT /Btn /F 4 "
+            f"/Rect [{RECT[0]} {RECT[1]} {RECT[2]} {RECT[3]}] "
+            "/T (field0) /MK << /BC [0 0 0] >> /AP << /N 6 0 R >> >>",
+            stream_object(
+                f"/Type /XObject /Subtype /Form /BBox [0 0 {SIDE} {SIDE}]",
+                appearance,
+            ),
+        ]
+    )
+
+
+def _frame_appearance() -> bytes:
+    """Exactly what the placeholder buttons carry: a stroked border, nothing else."""
+    return f"0 G\n1 w\n0.5 0.5 {SIDE - 1} {SIDE - 1} re s\n".encode("latin-1")
+
+
+def test_widget_frame_is_not_painted():
+    """The border a field draws around itself does not reach the page."""
+    page = render_page(_widget_pdf(_frame_appearance()))
+
+    coverage = coverage_ratio(region_image(page, FRAME_BAND))
+    assert coverage < 0.02, (
+        f"the widget's frame painted ({coverage:.3f} coverage along its top "
+        "edge); an empty field must leave the page as it was"
+    )
+
+
+def test_widget_background_fill_is_not_painted():
+    """A field that fills its whole rectangle is background, not content."""
+    appearance = f"0.5 g\n0 0 {SIDE} {SIDE} re f\n".encode("latin-1")
+    page = render_page(_widget_pdf(appearance))
+
+    coverage = coverage_ratio(region_image(page, INSIDE))
+    assert coverage < 0.02, (
+        f"the widget's background fill painted ({coverage:.3f} coverage); it "
+        "covers the field rectangle and is chrome like the frame"
+    )
+
+
+def test_widget_mark_inside_the_frame_is_kept():
+    """A checkbox tick is the field's value and has to survive.
+
+    Drawn together with the frame, so this also pins that dropping the frame
+    does not take the rest of the appearance stream with it.
+    """
+    quarter = SIDE / 4
+    appearance = (
+        f"0 G\n1 w\n0.5 0.5 {SIDE - 1} {SIDE - 1} re s\n"
+        f"4 w\n{quarter} {quarter} m\n{SIDE - quarter} {SIDE - quarter} l\ns\n"
+    ).encode("latin-1")
+    page = render_page(_widget_pdf(appearance))
+
+    assert coverage_ratio(region_image(page, INSIDE)) > 0.02, (
+        "the mark drawn inside the field did not paint; only the frame is chrome"
+    )
+    frame = coverage_ratio(region_image(page, FRAME_BAND))
+    assert frame < 0.06, (
+        f"the frame still painted ({frame:.3f} coverage) when a mark was drawn "
+        "alongside it"
+    )


### PR DESCRIPTION
Follow-up render fixes for Linux.

### Script-aware font fallback and soft-mask grid resolution
When the name-resolved face cannot draw a run (e.g. Arabic through a Latin fallback), probe faces by script before giving up. Soft masks that are finer than their image (common for text-as-mask) now resolve onto the finer grid instead of downsampling the mask and smearing detail.

### Clip paths and text condensation
Subpaths captured by a single `W`/`W*` clip now compose into one path per clip operation; only separate clip operations intersect (ISO 32000-1 §8.5.4). Fixes multi-subpath clips (outline stencils, Qt “shape as clip, fill bbox”) that previously produced empty regions. Anisotropically scaled text (`Tz`, non-uniform text matrix) is fitted to the cell width in both Blend2D and FreeType paths.

### Stencil masks (`/Mask`) with CCITT decoding
`/Mask` streams (1-bit stencils that knock pixels out, inverse of `/SMask`) are now composited through the same resample path as soft masks. CCITTFax-compressed stencils are decoded via the vendored CCITT decoder, honouring `/K` and `/BlackIs1`.

### Indexed palettes over tint bases
`/Indexed` colour spaces built on `/Separation` or `/DeviceN` now convert palette entries through the base tint transform at load time (e.g. QR codes as Indexed-over-Separation no longer render as placeholders).

### CMYK polarity
Default `/DeviceCMYK` `/Decode` is the identity (ISO table 89). CMYK inversion applies only when the Adobe-inverted convention is positively established — fixes CMYK JPEG2000 negatives and accidental double-inversion elsewhere.
### Symbol bracket pieces and `.notdef` guards
Legacy Symbol bracket/brace/parenthesis piece codes (Adobe GL private-use area) are rewritten to Unicode U+239B..U+23AD at glyph-list load time. Glyph-identity recovery that maps every code to glyph 0 is rejected; FreeType skips drawing `.notdef` outlines while preserving advance.
