### PR TITLE
fix: emit glyph marker for symbolic/composite fonts with no usable cmap

### DIFF
--- a/src/parse.h
+++ b/src/parse.h
@@ -83,6 +83,7 @@
 
 // pdf-resource
 #include <parse/pdf_resources/page_font/glyphs.h>
+#include <parse/pdf_resources/page_font/builtin_encoding.h>
 #include <parse/pdf_resources/page_font/font_cid.h>
 #include <parse/pdf_resources/page_font/font_cids.h>
 #include <parse/pdf_resources/page_font/encoding.h>

--- a/src/parse/pdf_resources/page_font.h
+++ b/src/parse/pdf_resources/page_font.h
@@ -760,19 +760,24 @@ namespace pdflib
   {
     // Fallback for codes that none of the authoritative sources resolved
     // (/Encoding/Differences, the /ToUnicode or predefined CID cmap, or a
-    // known base-font table). When an explicit cmap exists but does not
-    // cover this code, and the code bears no relation to the standard
-    // Latin encodings (symbolic font, or composite font whose codes are
-    // CIDs), the encoding tables would fabricate unrelated text — e.g. an
-    // Arabic ligature glyph subsetted at code 0x23 coming out as '#'
-    // (docling#3802). Emit a glyph marker instead, so downstream consumers
-    // can detect the unresolved glyph.
-    if(cmap_initialized and (is_symbolic or subtype==TYPE_0))
+    // known base-font table). For a symbolic font, or a composite (Type0/CID)
+    // font, the standard Latin encoding tables bear no relation to the font's
+    // codes, so applying them here fabricates unrelated text — e.g. an Arabic
+    // ligature glyph subsetted at code 0x23 coming out as '#' (docling#3802).
+    // Emit a glyph marker instead, so downstream consumers can detect the
+    // unresolved glyph.
+    //
+    // This covers both a cmap that misses the code AND a symbolic/composite
+    // font with no usable cmap at all — a /ToUnicode that failed to parse
+    // ("could not find cmap in '/ToUnicode'"), or none present — where
+    // cmap_initialized is false but fabricating from the standard tables is
+    // still wrong (docling-parse#299 follow-up).
+    if(is_symbolic or subtype==TYPE_0)
       {
         unknown_numbs[c] += 1;
 
-        LOG_S(WARNING) << "Symbol not in the cmap of a symbolic or composite font: "
-                       << int(c) << "; font-name: " << font_name
+        LOG_S(WARNING) << "No authoritative mapping for code in a symbolic or "
+                       << "composite font: " << int(c) << "; font-name: " << font_name
                        << "; emitting glyph marker instead of encoding fallback";
 
         return "GLYPH<" + std::to_string(c) + ">";

--- a/src/parse/pdf_resources/page_font.h
+++ b/src/parse/pdf_resources/page_font.h
@@ -183,6 +183,12 @@ namespace pdflib
     void init_charprocs();
     void init_space_index();
 
+    // The embedded program's builtin encoding as the source of reading text
+    // (9.6.6.2 / 9.6.6.4); read lazily, on the first code that needs it.
+    bool uses_builtin_encoding() const;
+    bool resolve_builtin_encoding(uint32_t c, std::string& text);
+    void init_builtin_encoding();
+
     void print_tables();
 
   private:
@@ -274,6 +280,9 @@ namespace pdflib
 
     bool font_blob_initialized = false;
     std::shared_ptr<const embedded_font_blob> font_blob;
+
+    bool builtin_encoding_initialized = false;
+    std::map<uint32_t, std::string> builtin_numb_to_char;
   };
 
   font_glyphs    pdf_resource<PAGE_FONT>::glyphs = font_glyphs();
@@ -671,6 +680,8 @@ namespace pdflib
     // first and only falls back to glyph-name based methods. For codes
     // not covered by /Differences, the cmap is consulted directly below.
 
+    std::string builtin_text;
+
     if(diff_initialized and diff_numb_to_char.count(c)>0)
       {
         return diff_numb_to_char.at(c);
@@ -678,6 +689,14 @@ namespace pdflib
     else if(cmap_initialized and cmap_numb_to_char.count(c)>0)
       {
         return cmap_numb_to_char.at(c);
+      }
+    // A symbolic font without a declared base encoding maps its codes
+    // through the embedded program's builtin encoding (9.6.6.2 / 9.6.6.4).
+    // That is the producer's own statement of what each code draws, so it
+    // outranks a name-matched base-font table and the encoding fallback.
+    else if(uses_builtin_encoding() and resolve_builtin_encoding(c, builtin_text))
+      {
+        return builtin_text;
       }
     else if(matched_font_name().font)
       {
@@ -776,6 +795,10 @@ namespace pdflib
     // /Differences legitimately resolve through the declared base encoding
     // (PDF 32000-1 9.6.6), so falling through is not fabrication
     // (docling-parse#299 follow-up; #322 regression fix).
+    //
+    // By the time a code reaches this point the embedded program's builtin
+    // encoding has already been consulted (get_correct_character), so a
+    // marker here means the program itself carries no text for the glyph.
     const bool has_declared_simple_encoding =
       (has_explicit_encoding and encoding != CMAP_RESOURCES) or diff_initialized;
 
@@ -792,6 +815,51 @@ namespace pdflib
       }
 
     return get_character_from_encoding(c);
+  }
+
+  bool pdf_resource<PAGE_FONT>::uses_builtin_encoding() const
+  {
+    // Type 0 codes are CIDs and Type 3 glyphs are content streams: neither
+    // has a builtin encoding to read. A declared base encoding (a name, or
+    // /BaseEncoding in an /Encoding dict) overrides the builtin one; a bare
+    // /Differences array only overrides the codes it lists (9.6.6.1).
+    const bool has_declared_base_encoding =
+      has_explicit_encoding and encoding != CMAP_RESOURCES;
+
+    return subtype != TYPE_0 and subtype != TYPE_3 and
+      is_symbolic and not has_declared_base_encoding;
+  }
+
+  bool pdf_resource<PAGE_FONT>::resolve_builtin_encoding(uint32_t c, std::string& text)
+  {
+    if(not builtin_encoding_initialized)
+      {
+        init_builtin_encoding();
+      }
+
+    auto itr = builtin_numb_to_char.find(c);
+    if(itr == builtin_numb_to_char.end())
+      {
+        return false;
+      }
+
+    text = itr->second;
+    return true;
+  }
+
+  void pdf_resource<PAGE_FONT>::init_builtin_encoding()
+  {
+    builtin_encoding_initialized = true;
+
+    auto blob = get_embedded_font_blob();
+    if(not blob or not blob->get_bytes())
+      {
+        LOG_S(INFO) << __FUNCTION__ << ": no embedded font program for " << font_name
+                    << "; builtin encoding unavailable";
+        return;
+      }
+
+    builtin_numb_to_char = builtin_font_encoding::decode(*(blob->get_bytes()), glyphs, font_name);
   }
 
   std::string pdf_resource<PAGE_FONT>::get_character_from_encoding(uint32_t c)

--- a/src/parse/pdf_resources/page_font.h
+++ b/src/parse/pdf_resources/page_font.h
@@ -767,12 +767,20 @@ namespace pdflib
     // Emit a glyph marker instead, so downstream consumers can detect the
     // unresolved glyph.
     //
-    // This covers both a cmap that misses the code AND a symbolic/composite
-    // font with no usable cmap at all — a /ToUnicode that failed to parse
-    // ("could not find cmap in '/ToUnicode'"), or none present — where
-    // cmap_initialized is false but fabricating from the standard tables is
-    // still wrong (docling-parse#299 follow-up).
-    if(is_symbolic or subtype==TYPE_0)
+    // Beyond the parsed-cmap-misses-the-code case (#299), this also covers a
+    // symbolic font with no usable cmap at all — a /ToUnicode that failed to
+    // parse ("could not find cmap in '/ToUnicode'"), or none present — but
+    // ONLY when the font also declares no simple encoding. Many producers set
+    // the symbolic flag on fonts that nonetheless declare /WinAnsiEncoding or
+    // an /Encoding dict with /Differences; for those, codes outside
+    // /Differences legitimately resolve through the declared base encoding
+    // (PDF 32000-1 9.6.6), so falling through is not fabrication
+    // (docling-parse#299 follow-up; #322 regression fix).
+    const bool has_declared_simple_encoding =
+      (has_explicit_encoding and encoding != CMAP_RESOURCES) or diff_initialized;
+
+    if(subtype==TYPE_0 or
+       (is_symbolic and (cmap_initialized or not has_declared_simple_encoding)))
       {
         unknown_numbs[c] += 1;
 

--- a/src/parse/pdf_resources/page_font/builtin_encoding.h
+++ b/src/parse/pdf_resources/page_font/builtin_encoding.h
@@ -1,0 +1,308 @@
+//-*-C++-*-
+
+#ifndef PDF_PAGE_FONT_BUILTIN_ENCODING_H
+#define PDF_PAGE_FONT_BUILTIN_ENCODING_H
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+namespace pdflib
+{
+  // Reading text for the character codes of a simple font that maps them
+  // through the builtin encoding of its embedded program (PDF 32000-1,
+  // 9.6.6.2 and 9.6.6.4): a symbolic font with no declared base encoding.
+  // Its codes bear no relation to the standard Latin tables; only the font
+  // program says which glyph a code selects, and the glyph is what carries
+  // the reading text.
+  //
+  // FreeType exposes the builtin mapping as a charmap: Adobe custom /
+  // standard / Latin-1 for Type 1 and CFF programs, the Microsoft symbol
+  // (3,0) table with the 0xF000 convention for TrueType, and whatever
+  // single table a subsetter left behind. The glyph then yields text through
+  // its PostScript name (AGL, uniXXXX, uXXXX[XX]) or, failing that, through
+  // the program's own Unicode charmap. A glyph that neither names nor maps
+  // stays unresolved so the caller can emit a marker rather than fabricate;
+  // a blank glyph (no contours) reads as a space.
+  //
+  // This is the text-side twin of the glyph-identity lookup the renderer
+  // performs for the same fonts (freetype_font_cache::char_code_to_glyph_index),
+  // so the extracted text and the drawn glyph agree on what a code means.
+  //
+  // Each decode() opens its own FT_Library and closes it before returning:
+  // FreeType is only thread-safe across separate libraries, and the
+  // threaded parser decodes fonts of different pages concurrently.
+  class builtin_font_encoding
+  {
+  public:
+
+    // code -> utf8 for every single-byte code the program resolves.
+    static std::map<uint32_t, std::string> decode(const std::vector<uint8_t>& program,
+                                                  font_glyphs& glyphs,
+                                                  const std::string& font_name);
+
+    // Glyph index of a character code through the builtin charmaps; 0 when
+    // none of them maps the code.
+    static FT_UInt char_code_to_glyph_index(FT_Face face, FT_ULong code);
+
+    // Reading text of a PostScript glyph name; empty when the name carries
+    // no text (an index-style name such as g12 or gid00012, or a name found
+    // in no table).
+    static std::string glyph_name_to_utf8(const std::string& glyph_name,
+                                          font_glyphs& glyphs);
+
+  private:
+
+    static bool glyph_is_blank(FT_Face face, FT_UInt glyph_index);
+
+    static void append_code_point(std::string& text, uint32_t code_point);
+  };
+
+  inline std::map<uint32_t, std::string>
+  builtin_font_encoding::decode(const std::vector<uint8_t>& program,
+                                font_glyphs& glyphs,
+                                const std::string& font_name)
+  {
+    std::map<uint32_t, std::string> result;
+
+    FT_Library library = nullptr;
+    if(FT_Init_FreeType(&library) != 0)
+      {
+        LOG_S(WARNING) << "FreeType unavailable: builtin encoding of " << font_name
+                       << " not read";
+        return result;
+      }
+
+    FT_Face face = nullptr;
+    const FT_Error error = FT_New_Memory_Face(library,
+                                              program.data(),
+                                              static_cast<FT_Long>(program.size()),
+                                              0, &face);
+    if(error != 0 or face == nullptr)
+      {
+        LOG_S(WARNING) << "FreeType could not open the embedded program of "
+                       << font_name << " (error " << error << "): builtin encoding not read";
+        FT_Done_FreeType(library);
+        return result;
+      }
+
+    // glyph index -> code point through the program's Unicode charmap, when
+    // it has one (FreeType also synthesizes one from glyph names).
+    std::unordered_map<FT_UInt, FT_ULong> code_point_of_glyph;
+    if(FT_Select_Charmap(face, FT_ENCODING_UNICODE) == 0)
+      {
+        FT_UInt glyph_index = 0;
+        FT_ULong code_point = FT_Get_First_Char(face, &glyph_index);
+        while(glyph_index != 0)
+          {
+            code_point_of_glyph.emplace(glyph_index, code_point);
+            code_point = FT_Get_Next_Char(face, code_point, &glyph_index);
+          }
+      }
+
+    const bool has_glyph_names = FT_HAS_GLYPH_NAMES(face);
+
+    int unresolved = 0;
+    for(uint32_t code = 0; code < 256; code++)
+      {
+        const FT_UInt glyph_index = char_code_to_glyph_index(face, code);
+        if(glyph_index == 0)
+          {
+            continue;
+          }
+
+        std::string text;
+
+        if(has_glyph_names)
+          {
+            char buffer[128] = {0};
+            if(FT_Get_Glyph_Name(face, glyph_index, buffer, sizeof(buffer)) == 0)
+              {
+                text = glyph_name_to_utf8(buffer, glyphs);
+              }
+          }
+
+        if(text.empty())
+          {
+            auto itr = code_point_of_glyph.find(glyph_index);
+            if(itr != code_point_of_glyph.end())
+              {
+                append_code_point(text, static_cast<uint32_t>(itr->second));
+              }
+          }
+
+        if(text.empty() and glyph_is_blank(face, glyph_index))
+          {
+            text = " ";
+          }
+
+        if(text.empty())
+          {
+            unresolved += 1;
+            continue;
+          }
+
+        result[code] = text;
+      }
+
+    LOG_S(INFO) << "builtin encoding of " << font_name << ": " << result.size()
+                << " code(s) resolved, " << unresolved << " glyph(s) without text"
+                << " (glyph-names=" << has_glyph_names
+                << ", unicode-charmap=" << (not code_point_of_glyph.empty()) << ")";
+
+    FT_Done_Face(face);
+    FT_Done_FreeType(library);
+
+    return result;
+  }
+
+  // Twin of freetype_font_cache::char_code_to_glyph_index in the renderer:
+  // the two must agree, or the text would describe a different glyph than
+  // the one drawn.
+  inline FT_UInt builtin_font_encoding::char_code_to_glyph_index(FT_Face face, FT_ULong code)
+  {
+    // The builtin encodings of Type 1 / CFF programs; Adobe custom comes
+    // first because a subset program exposes its own encoding through it.
+    const FT_Encoding encodings[] = {
+      FT_ENCODING_ADOBE_CUSTOM,
+      FT_ENCODING_ADOBE_STANDARD,
+      FT_ENCODING_ADOBE_LATIN_1,
+    };
+
+    for(FT_Encoding encoding : encodings)
+      {
+        if(FT_Select_Charmap(face, encoding) != 0)
+          {
+            continue;
+          }
+
+        const FT_UInt glyph_index = FT_Get_Char_Index(face, code);
+        if(glyph_index != 0)
+          {
+            return glyph_index;
+          }
+      }
+
+    // Symbolic TrueType programs carry a (3,0) symbol cmap whose codes live
+    // by convention in the private-use range at 0xF000 (9.6.6.4).
+    if(code <= 0xFF and FT_Select_Charmap(face, FT_ENCODING_MS_SYMBOL) == 0)
+      {
+        const FT_UInt glyph_index = FT_Get_Char_Index(face, 0xF000u + code);
+        if(glyph_index != 0)
+          {
+            return glyph_index;
+          }
+
+        const FT_UInt raw_index = FT_Get_Char_Index(face, code);
+        if(raw_index != 0)
+          {
+            return raw_index;
+          }
+      }
+
+    // Last resort: every charmap the program actually carries, whatever its
+    // platform -- subsetters leave single (1,0) format-6 tables that none of
+    // the named lookups above select.
+    for(FT_Int i = 0; i < face->num_charmaps; i++)
+      {
+        if(FT_Set_Charmap(face, face->charmaps[i]) != 0)
+          {
+            continue;
+          }
+
+        FT_UInt glyph_index = FT_Get_Char_Index(face, code);
+        if(glyph_index == 0 and code <= 0xFF)
+          {
+            glyph_index = FT_Get_Char_Index(face, 0xF000u + code);
+          }
+        if(glyph_index != 0)
+          {
+            return glyph_index;
+          }
+      }
+
+    return 0;
+  }
+
+  inline std::string builtin_font_encoding::glyph_name_to_utf8(const std::string& glyph_name,
+                                                               font_glyphs& glyphs)
+  {
+    std::string name = glyph_name;
+
+    if(name.empty() or name == ".notdef")
+      {
+        return "";
+      }
+
+    // A stylistic suffix (/a.sc, /one.oldstyle, /uni0041.alt) does not
+    // change the reading text.
+    const std::size_t dot = name.find('.');
+    if(dot != std::string::npos and dot > 0)
+      {
+        name = name.substr(0, dot);
+      }
+
+    // Index-style names (g12, glyph12, gid00012, cid12, index12) identify
+    // the glyph inside the program but carry no text (docling-parse#238).
+    static const std::regex re_index(R"((gid|glyph|g|cid|index)\d+)", std::regex::icase);
+    if(std::regex_match(name, re_index))
+      {
+        return "";
+      }
+
+    if(glyphs.has(name))
+      {
+        return glyphs[name];
+      }
+
+    std::string text;
+    std::smatch match;
+
+    // uniXXXX, or a sequence of them for a ligature (Adobe glyph naming)
+    static const std::regex re_uni(R"(uni((?:[0-9A-Fa-f]{4})+))");
+    if(std::regex_match(name, match, re_uni))
+      {
+        const std::string hex = match[1].str();
+        for(std::size_t i = 0; i + 4 <= hex.size(); i += 4)
+          {
+            append_code_point(text, std::stoul(hex.substr(i, 4), nullptr, 16));
+          }
+        return text;
+      }
+
+    // uXXXX to uXXXXXX
+    static const std::regex re_u(R"(u([0-9A-Fa-f]{4,6}))");
+    if(std::regex_match(name, match, re_u))
+      {
+        append_code_point(text, std::stoul(match[1].str(), nullptr, 16));
+        return text;
+      }
+
+    return "";
+  }
+
+  inline bool builtin_font_encoding::glyph_is_blank(FT_Face face, FT_UInt glyph_index)
+  {
+    const FT_Int32 flags = FT_LOAD_NO_SCALE | FT_LOAD_NO_HINTING | FT_LOAD_NO_BITMAP;
+    if(FT_Load_Glyph(face, glyph_index, flags) != 0)
+      {
+        return false;
+      }
+
+    const FT_GlyphSlot slot = face->glyph;
+    return slot->format == FT_GLYPH_FORMAT_OUTLINE and
+      slot->outline.n_contours == 0 and
+      slot->outline.n_points == 0;
+  }
+
+  inline void builtin_font_encoding::append_code_point(std::string& text, uint32_t code_point)
+  {
+    // Surrogates and values beyond U+10FFFF have no UTF-8 form.
+    if(utf8::internal::is_code_point_valid(code_point))
+      {
+        utf8::append(code_point, std::back_inserter(text));
+      }
+  }
+
+}
+
+#endif

--- a/tests/test_unit_builtin_encoding.py
+++ b/tests/test_unit_builtin_encoding.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+"""Reading text through the builtin encoding of an embedded font program.
+
+A symbolic simple font without a declared base encoding maps its character
+codes through the builtin encoding of its font program (PDF 32000-1, 9.6.6.2
+and 9.6.6.4): the Adobe custom encoding of a Type 1 / CFF program, or the
+(3,0) symbol cmap of a TrueType program. The standard Latin tables say
+nothing about such codes: reading them there turned the Cyrillic of a
+subsetted CFF into Latin-1 look-alikes and glyph indices into digits. The
+reading text comes from the glyph the program selects, through its
+PostScript name (AGL, uniXXXX) or the program's Unicode cmap; a glyph with
+neither stays a GLYPH marker, and a blank glyph reads as a space.
+
+The fonts are built in memory with fontTools.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+
+from tests.pdf_builder import parse_page, simple_page_pdf, stream_object
+
+pytest.importorskip("fontTools", reason="building the test fonts needs fontTools")
+
+
+def _box(pen) -> None:
+    pen.moveTo((50, 0))
+    pen.lineTo((450, 0))
+    pen.lineTo((450, 700))
+    pen.lineTo((50, 700))
+    pen.closePath()
+
+
+def _symbol_truetype(*, glyph_names: bool) -> bytes:
+    """A TrueType subset with only a (3,0) symbol cmap at 0xF000 + code.
+
+    Code 0x23 draws Ccaron, 0x32 draws two, 0x20 a blank glyph and 0x41 a
+    glyph whose name (g4) is a bare index. Without `glyph_names` the post
+    table is format 3, so nothing but the cmap describes the glyphs.
+    """
+    from fontTools.fontBuilder import FontBuilder
+    from fontTools.pens.ttGlyphPen import TTGlyphPen
+    from fontTools.ttLib.tables._c_m_a_p import CmapSubtable, table__c_m_a_p
+
+    order = [".notdef", "Ccaron", "two", "space", "g4"]
+    builder = FontBuilder(1000, isTTF=True)
+    builder.setupGlyphOrder(order)
+
+    cmap = table__c_m_a_p()
+    cmap.tableVersion = 0
+    subtable = CmapSubtable.newSubtable(4)
+    subtable.platformID, subtable.platEncID, subtable.language = 3, 0, 0
+    subtable.cmap = {0xF023: "Ccaron", 0xF032: "two", 0xF020: "space", 0xF041: "g4"}
+    cmap.tables = [subtable]
+    builder.font["cmap"] = cmap
+
+    def glyph(blank: bool = False):
+        pen = TTGlyphPen(None)
+        if not blank:
+            _box(pen)
+        return pen.glyph()
+
+    builder.setupGlyf(
+        {
+            ".notdef": glyph(blank=True),
+            "Ccaron": glyph(),
+            "two": glyph(),
+            "space": glyph(blank=True),
+            "g4": glyph(),
+        }
+    )
+    builder.setupHorizontalMetrics(dict.fromkeys(order, (500, 0)))
+    builder.setupHorizontalHeader(ascent=800, descent=-200)
+    builder.setupNameTable(
+        {
+            "familyName": "DoclingSymbol",
+            "styleName": "Regular",
+            "psName": "DoclingSymbol",
+        }
+    )
+    builder.setupOS2(sTypoAscender=800, sTypoDescender=-200)
+    builder.setupPost()
+    if not glyph_names:
+        builder.font["post"].formatType = 3.0
+
+    out = BytesIO()
+    builder.save(out)
+    return out.getvalue()
+
+
+def _custom_cff() -> bytes:
+    """A bare CFF whose builtin encoding puts Cyrillic and Arabic at Latin codes.
+
+    0xE8 draws afii10074 (U+0438), 0x32 draws two and 0x23 draws uni0634.
+    """
+    from fontTools.fontBuilder import FontBuilder
+    from fontTools.pens.t2CharStringPen import T2CharStringPen
+
+    order = [".notdef", "afii10074", "two", "uni0634"]
+    builder = FontBuilder(1000, isTTF=False)
+    builder.setupGlyphOrder(order)
+    builder.setupCharacterMap({0x0438: "afii10074", 0x32: "two", 0x0634: "uni0634"})
+
+    charstrings = {}
+    for name in order:
+        pen = T2CharStringPen(500, None)
+        if name != ".notdef":
+            _box(pen)
+        charstrings[name] = pen.getCharString()
+
+    builder.setupCFF(
+        "DoclingCyrillic", {"FullName": "Docling Cyrillic"}, charstrings, {}
+    )
+    builder.setupHorizontalMetrics(dict.fromkeys(order, (500, 0)))
+    builder.setupHorizontalHeader(ascent=800, descent=-200)
+    builder.setupNameTable(
+        {
+            "familyName": "DoclingCyrillic",
+            "styleName": "Regular",
+            "psName": "DoclingCyrillic",
+        }
+    )
+    builder.setupOS2(sTypoAscender=800, sTypoDescender=-200)
+    builder.setupPost()
+
+    encoding = [".notdef"] * 256
+    encoding[0xE8] = "afii10074"
+    encoding[0x32] = "two"
+    encoding[0x23] = "uni0634"
+    builder.font["CFF "].cff.topDictIndex[0].Encoding = encoding
+
+    out = BytesIO()
+    builder.font["CFF "].cff.compile(out, builder.font)
+    return out.getvalue()
+
+
+def _page(
+    program: bytes,
+    text: str,
+    *,
+    subtype: str,
+    font_file: str,
+    base_font: str = "/ABCDEF+DoclingTestFace",
+    encoding: str = "",
+    flags: int = 4,
+) -> bytes:
+    """One line of `text` (a PDF string literal body) in the embedded font."""
+    widths = " ".join(["500"] * 256)
+    font = (
+        f"<< /Type /Font /Subtype {subtype} /BaseFont {base_font} "
+        f"/FirstChar 0 /LastChar 255 /Widths [{widths}] "
+        f"{encoding}/FontDescriptor 6 0 R >>"
+    )
+    descriptor = (
+        f"<< /Type /FontDescriptor /FontName {base_font} /Flags {flags} "
+        "/FontBBox [0 -200 1000 800] /ItalicAngle 0 /Ascent 800 /Descent -200 "
+        f"/CapHeight 700 /StemV 80 {font_file} 7 0 R >>"
+    )
+    if font_file == "/FontFile2":
+        stream = stream_object(f"/Length1 {len(program)}", program)
+    else:
+        stream = stream_object("/Subtype /Type1C", program)
+
+    return simple_page_pdf(
+        f"BT /F1 24 Tf 20 100 Td ({text}) Tj ET\n",
+        resources="/Font << /F1 5 0 R >>",
+        extra_objects=[font, descriptor, stream],
+    )
+
+
+def _text(pdf_bytes: bytes) -> str:
+    page = parse_page(pdf_bytes)
+    return "".join(cell.text for cell in page.textline_cells)
+
+
+def _truetype_page(text: str, *, glyph_names: bool = True, **kwargs) -> bytes:
+    return _page(
+        _symbol_truetype(glyph_names=glyph_names),
+        text,
+        subtype="/TrueType",
+        font_file="/FontFile2",
+        **kwargs,
+    )
+
+
+def test_symbol_cmap_codes_read_through_the_glyph_names():
+    # 0x23 is '#' in every standard table, but this program draws Ccaron there.
+    text = _text(_truetype_page("#2"))
+    assert text == "Č2"
+
+
+def test_glyphs_without_names_or_unicode_stay_markers():
+    text = _text(_truetype_page("#2", glyph_names=False))
+    assert "#" not in text
+    assert "GLYPH<35>" in text and "GLYPH<50>" in text
+
+
+def test_blank_glyph_reads_as_a_space():
+    text = _text(_truetype_page("# 2", glyph_names=False))
+    assert text == "GLYPH<35> GLYPH<50>"
+
+
+def test_index_style_glyph_name_stays_a_marker():
+    text = _text(_truetype_page("A"))
+    assert text == "GLYPH<65>"
+
+
+def test_cff_custom_encoding_reads_its_own_glyphs():
+    # 0xE8 is egrave in Latin-1 and Lslash in StandardEncoding; the program
+    # says it is Cyrillic i. 0x23 names its glyph uni0634.
+    pdf = _page(
+        _custom_cff(),
+        "\\3502#",
+        subtype="/Type1",
+        font_file="/FontFile3",
+        base_font="/ABCDEF+DoclingCyrillic",
+    )
+    assert _text(pdf) == "и2ش"
+
+
+def test_builtin_encoding_outranks_a_core_14_alias():
+    # A subset named after a core-14 alias used to resolve through the
+    # Helvetica metrics table, which fabricates '#' for a symbol-coded glyph.
+    text = _text(_truetype_page("#2", base_font="/ABCDEF+Arial"))
+    assert text == "Č2"
+
+
+def test_declared_base_encoding_still_wins():
+    # A symbolic-flagged font that declares /WinAnsiEncoding keeps it.
+    text = _text(_truetype_page("#2", encoding="/Encoding /WinAnsiEncoding "))
+    assert text == "#2"
+
+
+def test_differences_override_only_the_codes_they_list():
+    # /Differences without /BaseEncoding: the listed code follows the array,
+    # the others still read through the builtin encoding (9.6.6.1).
+    text = _text(
+        _truetype_page("#2", encoding="/Encoding << /Differences [35 /Zcaron] >> ")
+    )
+    assert text == "Ž2"
+
+
+def test_nonsymbolic_font_is_untouched():
+    # Flags bit 6 (nonsymbolic): the standard tables apply as before.
+    text = _text(_truetype_page("#2", flags=32))
+    assert text == "#2"

--- a/tests/test_unit_tounicode_fallback.py
+++ b/tests/test_unit_tounicode_fallback.py
@@ -19,7 +19,11 @@ from docling_parse.pdf_parser import DecodeConfig, DoclingPdfParser
 
 
 def _build_pdf(
-    include_ligature: bool, symbolic: bool, with_tounicode: bool = True
+    include_ligature: bool,
+    symbolic: bool,
+    with_tounicode: bool = True,
+    with_encoding: bool = True,
+    basefont: str = "/Arial",
 ) -> bytes:
     bfchars = ["<21> <0634>", "<22> <0623>"]  # ش , أ
     if include_ligature:
@@ -48,14 +52,15 @@ def _build_pdf(
         "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
         "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
         "/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
-        "<< /Type /Font /Subtype /TrueType /BaseFont /Arial "
+        f"<< /Type /Font /Subtype /TrueType /BaseFont {basefont} "
         "/FirstChar 33 /LastChar 35 /Widths [500 500 500] "
-        "/Encoding /WinAnsiEncoding /FontDescriptor 7 0 R "
+        + ("/Encoding /WinAnsiEncoding " if with_encoding else "")
+        + "/FontDescriptor 7 0 R "
         + ("/ToUnicode 6 0 R " if with_tounicode else "")
         + ">>",
         f"<< /Length {len(content)} >>\nstream\n{content}\nendstream",
         f"<< /Length {len(cmap)} >>\nstream\n{cmap}\nendstream",
-        f"<< /Type /FontDescriptor /FontName /Arial /Flags {flags} "
+        f"<< /Type /FontDescriptor /FontName {basefont} /Flags {flags} "
         "/FontBBox [0 -200 1000 900] /ItalicAngle 0 /Ascent 900 /Descent -200 "
         "/CapHeight 700 /StemV 80 >>",
     ]
@@ -83,11 +88,17 @@ def _extract_text(
     symbolic: bool,
     keep_glyphs: bool = True,
     with_tounicode: bool = True,
+    with_encoding: bool = True,
+    basefont: str = "/Arial",
 ) -> str:
     parser = DoclingPdfParser(loglevel="fatal")
     config = DecodeConfig(keep_glyphs=keep_glyphs)
     doc = parser.load(
-        path_or_stream=BytesIO(_build_pdf(include_ligature, symbolic, with_tounicode)),
+        path_or_stream=BytesIO(
+            _build_pdf(
+                include_ligature, symbolic, with_tounicode, with_encoding, basefont
+            )
+        ),
         decode_config=config,
     )
     _, page = next(doc.iterate_pages())
@@ -121,12 +132,34 @@ def test_nonsymbolic_font_keeps_encoding_fallback():
 def test_symbolic_font_without_usable_cmap_yields_glyph_marker():
     # docling-parse#299 follow-up: the guard must also fire when a symbolic
     # font has NO usable cmap (cmap_initialized == false) — a /ToUnicode that
-    # failed to parse, or none at all — not only when a cmap exists and misses
-    # the code. Otherwise every code falls through to the Standard/WinAnsi
-    # tables and fabricates ('!"#').
-    text = _extract_text(include_ligature=False, symbolic=True, with_tounicode=False)
+    # failed to parse, or none at all — AND declares no simple encoding
+    # either. With neither source of intent, falling through to the standard
+    # tables fabricates ('!"#'). A subset-style BaseFont name keeps the core-14
+    # alias table out of the picture (real-world shape: an Arabic subset font,
+    # not an /Arial alias).
+    text = _extract_text(
+        include_ligature=False,
+        symbolic=True,
+        with_tounicode=False,
+        with_encoding=False,
+        basefont="/QWERTY+SymTest",
+    )
     assert "#" not in text
     assert "GLYPH<33>" in text and "GLYPH<34>" in text and "GLYPH<35>" in text
+
+
+def test_symbolic_font_with_declared_encoding_keeps_encoding():
+    # Guard must NOT fire when the symbolic flag is set but the font
+    # explicitly declares /WinAnsiEncoding and no cmap parsed at all: many
+    # producers set the symbolic flag spuriously (e.g. font_01.pdf,
+    # deep-mediabox-inheritance.pdf, the DocLayNet dln_* regression docs), and
+    # the declared encoding is the producer's authoritative statement that
+    # unlisted codes follow it (PDF 32000-1 9.6.6).
+    text = _extract_text(
+        include_ligature=False, symbolic=True, with_tounicode=False, with_encoding=True
+    )
+    assert text.strip() == '!"#'
+    assert "GLYPH" not in text
 
 
 def test_nonsymbolic_font_without_tounicode_keeps_encoding():

--- a/tests/test_unit_tounicode_fallback.py
+++ b/tests/test_unit_tounicode_fallback.py
@@ -18,7 +18,9 @@ from io import BytesIO
 from docling_parse.pdf_parser import DecodeConfig, DoclingPdfParser
 
 
-def _build_pdf(include_ligature: bool, symbolic: bool) -> bytes:
+def _build_pdf(
+    include_ligature: bool, symbolic: bool, with_tounicode: bool = True
+) -> bytes:
     bfchars = ["<21> <0634>", "<22> <0623>"]  # ش , أ
     if include_ligature:
         bfchars.append("<23> <0641064A>")  # في (one glyph, two codepoints)
@@ -48,7 +50,9 @@ def _build_pdf(include_ligature: bool, symbolic: bool) -> bytes:
         "/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
         "<< /Type /Font /Subtype /TrueType /BaseFont /Arial "
         "/FirstChar 33 /LastChar 35 /Widths [500 500 500] "
-        "/Encoding /WinAnsiEncoding /FontDescriptor 7 0 R /ToUnicode 6 0 R >>",
+        "/Encoding /WinAnsiEncoding /FontDescriptor 7 0 R "
+        + ("/ToUnicode 6 0 R " if with_tounicode else "")
+        + ">>",
         f"<< /Length {len(content)} >>\nstream\n{content}\nendstream",
         f"<< /Length {len(cmap)} >>\nstream\n{cmap}\nendstream",
         f"<< /Type /FontDescriptor /FontName /Arial /Flags {flags} "
@@ -75,12 +79,15 @@ def _build_pdf(include_ligature: bool, symbolic: bool) -> bytes:
 
 
 def _extract_text(
-    include_ligature: bool, symbolic: bool, keep_glyphs: bool = True
+    include_ligature: bool,
+    symbolic: bool,
+    keep_glyphs: bool = True,
+    with_tounicode: bool = True,
 ) -> str:
     parser = DoclingPdfParser(loglevel="fatal")
     config = DecodeConfig(keep_glyphs=keep_glyphs)
     doc = parser.load(
-        path_or_stream=BytesIO(_build_pdf(include_ligature, symbolic)),
+        path_or_stream=BytesIO(_build_pdf(include_ligature, symbolic, with_tounicode)),
         decode_config=config,
     )
     _, page = next(doc.iterate_pages())
@@ -108,6 +115,25 @@ def test_nonsymbolic_font_keeps_encoding_fallback():
     # encoding: 0x23 in WinAnsi genuinely is '#'.
     text = _extract_text(include_ligature=False, symbolic=False)
     assert "#" in text
+    assert "GLYPH" not in text
+
+
+def test_symbolic_font_without_usable_cmap_yields_glyph_marker():
+    # docling-parse#299 follow-up: the guard must also fire when a symbolic
+    # font has NO usable cmap (cmap_initialized == false) — a /ToUnicode that
+    # failed to parse, or none at all — not only when a cmap exists and misses
+    # the code. Otherwise every code falls through to the Standard/WinAnsi
+    # tables and fabricates ('!"#').
+    text = _extract_text(include_ligature=False, symbolic=True, with_tounicode=False)
+    assert "#" not in text
+    assert "GLYPH<33>" in text and "GLYPH<34>" in text and "GLYPH<35>" in text
+
+
+def test_nonsymbolic_font_without_tounicode_keeps_encoding():
+    # The widened guard must not touch non-symbolic fonts: WinAnsi genuinely
+    # maps 0x21/0x22/0x23 to '!"#', so those still resolve normally.
+    text = _extract_text(include_ligature=False, symbolic=False, with_tounicode=False)
+    assert text.strip() == '!"#'
     assert "GLYPH" not in text
 
 


### PR DESCRIPTION
Follow-up to #299 (thanks @yalsaffar for the report).

The guard added in #299 only fired when a `/ToUnicode` cmap *parsed* (`cmap_initialized == true`) and merely missed the code. A symbolic or Type0/CID font whose `/ToUnicode` **fails to parse** (`could not find cmap in '/ToUnicode'`), or that carries **none**, sets `cmap_initialized = false`, skips the guard, and falls through to the Standard/WinAnsi tables — which fabricate unrelated text again (e.g. `!"#`).

This drops the `cmap_initialized` requirement for symbolic/composite fonts: their codes bear no relation to the standard encodings, so an unresolved code must surface as a `GLYPH<>` marker regardless of whether a cmap was parsed. Non-symbolic fonts are unaffected (they legitimately use the declared encoding).

Adds two tests: a symbolic font with no usable `/ToUnicode` (must emit markers, not fabricate) and a non-symbolic control (encoding preserved). Reproduced against the current build; the change is a one-line guard widening.