### PR TITLE
fix: open input PDFs with UTF-8 path semantics on Windows

### DIFF
--- a/src/parse/pdf_decoders/document.h
+++ b/src/parse/pdf_decoders/document.h
@@ -3,6 +3,7 @@
 #ifndef PDF_DOCUMENT_DECODER_H
 #define PDF_DOCUMENT_DECODER_H
 
+#include <filesystem>
 #include <fstream>
 #include <mutex>
 #include <optional>
@@ -189,8 +190,21 @@ namespace pdflib
 
     utils::timer timer;
 
-    // Read the file into a buffer
-    std::ifstream ifs(filename, std::ios::binary | std::ios::ate);
+    // Read the file into a buffer.
+    //
+    // The filename arrives UTF-8 encoded from the Python layer. On Windows a
+    // narrow ifstream hands it to the ANSI codepage (GBK, cp1252, ...), so any
+    // non-ASCII path fails to open (docling-parse#324; regression from #274,
+    // which replaced qpdf's UTF-8-aware processFile with this read). Build a
+    // std::filesystem::path from the bytes as UTF-8 so MSVC opens via the
+    // wide-char API; POSIX keeps byte-passthrough semantics either way.
+#ifdef _WIN32
+    std::filesystem::path fs_path(
+      std::u8string(filename.begin(), filename.end()));
+#else
+    std::filesystem::path fs_path(filename);
+#endif
+    std::ifstream ifs(fs_path, std::ios::binary | std::ios::ate);
     if(!ifs.is_open())
       {
         LOG_S(ERROR) << "could not open file: " << filename;

--- a/tests/test_unicode_paths.py
+++ b/tests/test_unicode_paths.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Loading PDFs from paths that contain non-ASCII characters.
+
+The filename travels UTF-8 encoded from Python into the native parser, which
+must open it with UTF-8 semantics on every platform. On Windows a narrow
+byte-path open goes through the ANSI codepage instead, so any path with
+characters outside it fails to load (docling-parse#324) — on POSIX the bytes
+pass through and the bug is invisible, so these tests guard intent everywhere
+but only bite on Windows runners.
+"""
+
+from io import BytesIO
+
+from docling_parse.pdf_parser import DoclingPdfParser
+from tests.pdf_builder import build_pdf
+
+CONTENT = "BT /F1 12 Tf 72 720 Td (Title Case Workers) Tj ET"
+
+
+def _tiny_pdf() -> bytes:
+    return build_pdf(
+        [
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            "/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            f"<< /Length {len(CONTENT)} >>\nstream\n{CONTENT}\nendstream",
+        ]
+    )
+
+
+def test_load_from_non_ascii_path(tmp_path):
+    """A path with CJK directory and filename components loads like any other."""
+    cjk_dir = tmp_path / "导出的条目"
+    cjk_dir.mkdir()
+    pdf_path = cjk_dir / "2005 - Chiou 等 - test.pdf"
+    pdf_path.write_bytes(_tiny_pdf())
+
+    parser = DoclingPdfParser(loglevel="fatal")
+    doc = parser.load(path_or_stream=str(pdf_path))
+
+    assert doc.number_of_pages() == 1
+
+
+def test_load_from_bytesio_is_path_independent():
+    """The BytesIO route never touches the filesystem and must always work."""
+    parser = DoclingPdfParser(loglevel="fatal")
+    doc = parser.load(path_or_stream=BytesIO(_tiny_pdf()))
+
+    assert doc.number_of_pages() == 1


### PR DESCRIPTION
Fixes #324.

### Bug

On Windows, any PDF whose path contains non-ASCII characters fails to load with `could not open file` — every file under e.g. a Chinese-named directory is unconvertible. Regression introduced in #274 (first shipped in v6.1.0): the previous `qpdf_document.processFile(filename.c_str())` treats narrow filenames as UTF-8 on Windows and converts to wide internally, while the `std::ifstream(std::string)` that replaced it hands the UTF-8 bytes to the ANSI codepage (GBK, cp1252, cp437, …), where they resolve to a nonexistent name.

Not locale-specific: reproduced on a cp437 (US English) host with docling-parse 7.15.0 — ASCII sibling path loads, CJK path fails, BytesIO route loads. Details and repro output in [#324 (comment)](https://github.com/docling-project/docling-parse/issues/324#issuecomment-5364501962).

### Fix

In `process_document_from_file`, build a `std::filesystem::path` from the UTF-8 bytes (as `char8_t`, C++20) under `_WIN32` so the open goes through the wide-char API. POSIX keeps byte-passthrough semantics unchanged (paths that are raw bytes rather than valid UTF-8 behave exactly as before).

### Verification

- **Windows, end-to-end**: built a cp312/win_amd64 wheel from this branch with the repo's own MinGW wheel recipe and installed it on the same cp437 host that reproduces the bug with stock 7.15.0. Result: `ascii path: OK / cjk path: OK (1 pages) / cjk via BytesIO: OK` — where stock fails the cjk path.
- **Linux**: full test suite passes; the two new tests in `tests/test_unicode_paths.py` (CJK path load, BytesIO path-independence) pass.

Caveat for reviewers: CI runs tests on Linux only, so the new regression test guards intent on POSIX and will only actually bite on Windows if a Windows test lane is added — the wheel-based verification above is the real Windows evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)