### PR TITLE
ci: bump gh-action-sigstore-python to v3.5.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -398,7 +398,7 @@ jobs:
         run: |
           ls ./dist
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.5.0
         with:
           release-signing-artifacts: false
           inputs: >-


### PR DESCRIPTION
## What

Bumps `sigstore/gh-action-sigstore-python` from `v3.0.0` → `v3.5.0` in `.github/workflows/wheels.yml`.

## Why

The `v7.16.0` release CD failed at the Sigstore signing step ([run](https://github.com/docling-project/docling-parse/actions/runs/32851695571/job/97822208979)). All wheels built fine; only the publish job died with:

```
tuf.api.exceptions.UnsignedMetadataError: root was signed by 0/3 keys
```

`sigstore-python` bundles a copy of Sigstore's production TUF `root.json` as its bootstrap trust anchor. Sigstore periodically rotates those keys in a root-signing ceremony. The `v3.0.0` pin (2024-07-15) ships a `sigstore-python` whose embedded root predates the current rotation, so TUF can no longer verify the live root against the keys baked into the client — hence `0/3 keys`. Nothing changed on our side; the trust anchor simply aged out.

`v3.5.0` (2026-07-29) ships an embedded root that verifies the current Sigstore production trust root.

## Notes

- The signing step runs *before* the PyPI publish step, so **nothing was published for `v7.16.0`** — re-releasing is collision-free.
- Follow-up option (not in this PR): pin to a commit SHA + Dependabot so the anchor can't silently rot again.