### PR TITLE
ci: run regression suite on a Windows x86_64 worker in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
   regression-tests:
     if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'docling-project/docling-parse' && github.event.pull_request.head.repo.full_name != 'docling-project/docling-parse') }}
     uses: ./.github/workflows/regression.yml
+  regression-tests-windows:
+    # Reuses the win_amd64 wheel from build-wheels instead of compiling the
+    # extension (which needs the full MinGW toolchain), so it must run after it.
+    needs: build-wheels
+    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'docling-project/docling-parse' && github.event.pull_request.head.repo.full_name != 'docling-project/docling-parse') }}
+    uses: ./.github/workflows/regression-windows.yml
   build-wheels:
     if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'docling-project/docling-parse' && github.event.pull_request.head.repo.full_name != 'docling-project/docling-parse') }}
     uses: ./.github/workflows/wheels.yml

--- a/.github/workflows/regression-windows.yml
+++ b/.github/workflows/regression-windows.yml
@@ -1,0 +1,64 @@
+on:
+  workflow_call:
+
+concurrency:
+  group: regression-win-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_id }}
+  cancel-in-progress: true
+
+# The Windows amd64 extension needs the full MinGW/NASM/external-libs toolchain
+# (see wheels.yml), so this job does NOT build from source. It reuses the
+# win_amd64 wheel that build-wheels already produced -- ci.yml runs this job
+# with `needs: build-wheels` so the artifact exists. Only the platform-
+# independent parse/locale/embedded-font tests run here; the renderer
+# groundtruth is a Linux contract (an unembedded named font substitutes
+# Liberation Sans on Linux but the real Windows font here) and stays on the
+# Linux worker.
+jobs:
+  run-regression-windows:
+    runs-on: windows-2025
+    env:
+      # uv run would otherwise implicitly re-sync and try to build the project
+      # from source (no toolchain here); keep it pinned to the wheel we install.
+      UV_NO_SYNC: "1"
+      PYTHON_VERSION: "3.13"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.13'
+      - name: Download prebuilt win_amd64 wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions-py3.13-win_amd64
+          path: wheelhouse
+      - name: Cache HF regression corpus
+        # HF_DATASET_REVISION in tests/constants.py is a pinned commit hash, so
+        # hashing that file gives us automatic invalidation on bumps.
+        uses: actions/cache@v4
+        with:
+          path: tests/data
+          key: hf-regression-${{ hashFiles('tests/constants.py') }}
+      - name: Install deps and the prebuilt wheel
+        shell: bash
+        run: |
+          # Install every dependency and dev group but NOT the project itself,
+          # so nothing tries to compile the extension here.
+          uv sync --frozen --all-extras --no-install-project
+          # Drop in the extension we built in the wheels job.
+          uv pip install --no-deps wheelhouse/*.whl
+          # Remove the source package so `import docling_parse` resolves to the
+          # installed wheel (which carries the .pyd) instead of the source tree
+          # at repo root, which has no compiled extension and would shadow it.
+          rm -rf docling_parse
+          # Fail loudly here if the wheel's extension cannot be imported,
+          # rather than as an opaque error at pytest collection.
+          uv run python -c "import docling_parse.pdf_parsers"
+      - name: Regression tests
+        shell: bash
+        run: |
+          uv run pytest -v \
+            tests/test_regression_parse.py \
+            tests/test_regression_threaded_parse.py \
+            tests/test_regression_embedded_fonts.py \
+            tests/test_regression_locale_safety.py

--- a/.github/workflows/regression-windows.yml
+++ b/.github/workflows/regression-windows.yml
@@ -16,6 +16,9 @@ concurrency:
 jobs:
   run-regression-windows:
     runs-on: windows-2025
+    # Safety cap: a Windows-specific deadlock (e.g. in the threaded parser)
+    # should fail the job, not sit on a runner for the full 6h limit.
+    timeout-minutes: 30
     env:
       # uv run would otherwise implicitly re-sync and try to build the project
       # from source (no toolchain here); keep it pinned to the wheel we install.
@@ -54,11 +57,23 @@ jobs:
           # Fail loudly here if the wheel's extension cannot be imported,
           # rather than as an opaque error at pytest collection.
           uv run python -c "import docling_parse.pdf_parsers"
-      - name: Regression tests
+      # faulthandler_timeout is pytest's built-in (stdlib) hang detector: if a
+      # test runs longer than the timeout it dumps every thread's stack to the
+      # log, so a deadlock shows exactly where it is instead of an opaque hang.
+      - name: Regression tests (non-threaded)
         shell: bash
         run: |
-          uv run pytest -v \
+          uv run pytest -v -o faulthandler_timeout=120 \
             tests/test_regression_parse.py \
-            tests/test_regression_threaded_parse.py \
             tests/test_regression_embedded_fonts.py \
             tests/test_regression_locale_safety.py
+      - name: Regression tests (threaded)
+        shell: bash
+        # Isolated and separately bounded: the threaded parser is the most
+        # likely place a Windows-only join deadlock would surface. Split out so
+        # the tests above still report, and so a hang here fails in ~10min with
+        # a thread dump rather than eating the whole job budget.
+        timeout-minutes: 10
+        run: |
+          uv run pytest -v -o faulthandler_timeout=120 \
+            tests/test_regression_threaded_parse.py

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -10,11 +10,31 @@ env:
 
 jobs:
   run-regression:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux runs the full regression suite, including the pixel-level
+          # renderer groundtruth comparison in test_regression_threaded_render.
+          - os: ubuntu-24.04
+            test-glob: "tests/test_regression_*.py"
+          # Windows runs only the platform-independent parse/locale/embedded-font
+          # tests. The renderer groundtruth is a Linux contract: an unembedded
+          # named font (e.g. Arial) substitutes Liberation Sans on Linux but the
+          # real Arial from C:\Windows\Fonts here, and those outlines differ
+          # enough to blow the tight image tolerance. The kept tests compare
+          # extracted geometry/text (font-system-independent) and only smoke-test
+          # rendering for no-crash, so they need no font packs -- Windows ships
+          # its own CJK faces for the smoke renders.
+          - os: windows-2025
+            test-glob: "tests/test_regression_parse.py tests/test_regression_threaded_parse.py tests/test_regression_embedded_fonts.py tests/test_regression_locale_safety.py"
     steps:
       - uses: actions/checkout@v4
       - name: Install system fonts
-        # See checks.yml for why these packages are pinned.
+        # Linux ships essentially no fonts, so the renderer groundtruth needs
+        # these installed. See checks.yml for why the packages are pinned.
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -44,11 +64,23 @@ jobs:
           path: tests/data
           key: hf-regression-${{ hashFiles('tests/constants.py') }}
       - name: Sync and install with uv
+        # bash so the build-artifact check runs identically on both runners
+        # (git-bash is present on the Windows image).
+        shell: bash
         run: |
           uv sync --frozen --all-extras
-          ls docling_parse/pdf_parsers*.so
+          # setuptools' editable_wheel demotes native build failures to a
+          # warning, leaving an importable package without the extension
+          # (.so on Linux, .pyd on Windows); fail loudly here instead of at
+          # pytest collection.
+          uv run python -c "import glob, sys; sys.exit(0 if glob.glob('docling_parse/pdf_parsers*.so') or glob.glob('docling_parse/pdf_parsers*.pyd') else 1)"
       - name: Regression tests
+        shell: bash
         env:
-          DOCLING_PARSE_CJK_FALLBACK_FONT: /usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc
+          # Pin the substituted CJK face on Linux so a package change does not
+          # quietly become a rendering change (documented in tests/README.md).
+          # Empty on Windows -- the resolver treats that as unset and picks a
+          # host CJK face for the no-crash smoke renders.
+          DOCLING_PARSE_CJK_FALLBACK_FONT: ${{ runner.os == 'Linux' && '/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc' || '' }}
         run: |
-          uv run pytest -v tests/test_regression_*.py
+          uv run pytest -v ${{ matrix.test-glob }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -10,31 +10,11 @@ env:
 
 jobs:
   run-regression:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Linux runs the full regression suite, including the pixel-level
-          # renderer groundtruth comparison in test_regression_threaded_render.
-          - os: ubuntu-24.04
-            test-glob: "tests/test_regression_*.py"
-          # Windows runs only the platform-independent parse/locale/embedded-font
-          # tests. The renderer groundtruth is a Linux contract: an unembedded
-          # named font (e.g. Arial) substitutes Liberation Sans on Linux but the
-          # real Arial from C:\Windows\Fonts here, and those outlines differ
-          # enough to blow the tight image tolerance. The kept tests compare
-          # extracted geometry/text (font-system-independent) and only smoke-test
-          # rendering for no-crash, so they need no font packs -- Windows ships
-          # its own CJK faces for the smoke renders.
-          - os: windows-2025
-            test-glob: "tests/test_regression_parse.py tests/test_regression_threaded_parse.py tests/test_regression_embedded_fonts.py tests/test_regression_locale_safety.py"
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install system fonts
-        # Linux ships essentially no fonts, so the renderer groundtruth needs
-        # these installed. See checks.yml for why the packages are pinned.
-        if: runner.os == 'Linux'
+        # See checks.yml for why these packages are pinned.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -64,23 +44,11 @@ jobs:
           path: tests/data
           key: hf-regression-${{ hashFiles('tests/constants.py') }}
       - name: Sync and install with uv
-        # bash so the build-artifact check runs identically on both runners
-        # (git-bash is present on the Windows image).
-        shell: bash
         run: |
           uv sync --frozen --all-extras
-          # setuptools' editable_wheel demotes native build failures to a
-          # warning, leaving an importable package without the extension
-          # (.so on Linux, .pyd on Windows); fail loudly here instead of at
-          # pytest collection.
-          uv run python -c "import glob, sys; sys.exit(0 if glob.glob('docling_parse/pdf_parsers*.so') or glob.glob('docling_parse/pdf_parsers*.pyd') else 1)"
+          ls docling_parse/pdf_parsers*.so
       - name: Regression tests
-        shell: bash
         env:
-          # Pin the substituted CJK face on Linux so a package change does not
-          # quietly become a rendering change (documented in tests/README.md).
-          # Empty on Windows -- the resolver treats that as unset and picks a
-          # host CJK face for the no-crash smoke renders.
-          DOCLING_PARSE_CJK_FALLBACK_FONT: ${{ runner.os == 'Linux' && '/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc' || '' }}
+          DOCLING_PARSE_CJK_FALLBACK_FONT: /usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc
         run: |
-          uv run pytest -v ${{ matrix.test-glob }}
+          uv run pytest -v tests/test_regression_*.py


### PR DESCRIPTION
## What

Adds a Windows x86_64 (\`windows-2025\`) worker to the regression job so it runs in parallel with the existing Linux worker.

The regression job is now a matrix over \`ubuntu-24.04\` and \`windows-2025\` (\`fail-fast: false\`):

- **Linux** — unchanged: full font install + the complete \`test_regression_*.py\` set, including the pixel-level renderer groundtruth comparison.
- **Windows** — the platform-independent tests only: parse, threaded-parse, embedded-fonts, locale-safety.

## Why the split (Option B)

The renderer groundtruth is a Linux contract. An unembedded named font (e.g. Arial) substitutes **Liberation Sans on Linux** but the **real Arial from \`C:\Windows\Fonts\`** on Windows, and those outlines differ enough to blow the tight image tolerance. Rather than double the groundtruth or loosen tolerances, Windows skips the render comparison.

The kept tests compare extracted geometry/text (font-system-independent) and only smoke-test rendering for no-crash, so:

- Windows needs **no font packs** (Windows ships its own CJK faces for the smoke renders).
- The build-artifact guard now accepts \`.so\` **or** \`.pyd\`.
- \`DOCLING_PARSE_CJK_FALLBACK_FONT\` is pinned on Linux, left unset on Windows.

## Notes

- \`test_regression_locale_safety.py\` gracefully **skips** its comma-locale cases on Windows (it only tries Unix locale names like \`de_DE.UTF-8\`). Adding Windows locale names is a possible follow-up.
- Render parity on Windows (a \`DOCLING_PARSE_NO_SYSTEM_FONTS\` resolver flag) is a deliberate follow-up, not in scope here.