### PR TITLE
feat: resolve-bookmarks-using-page-aware-PDF-outlines

### DIFF
--- a/.plans/resolve-bookmarks-using-page-aware-PDF-outlines.md
+++ b/.plans/resolve-bookmarks-using-page-aware-PDF-outlines.md
@@ -1,0 +1,740 @@
+# Page-aware PDF outlines in docling-parse
+
+> Plan for extending docling-parse so that the docling backends can resolve PDF bookmarks
+> to a **page** (and a **position on that page**) without falling back to pypdfium2.
+>
+> Upstream context: [docling#4169](https://github.com/docling-project/docling/pull/4169)
+> — *fix(pdf): resolve bookmarks using page-aware PDF outlines*, resolving docling#4162.
+>
+> Three PRs, in order (§7):
+> **A** `docling-core` — the shared destination model (§11) — **merged and released** in
+>   [v2.95.0](https://github.com/docling-project/docling-core/releases/tag/v2.95.0)
+>   ([#747](https://github.com/docling-project/docling-core/pull/747), commit `4631492`)
+> **B** `docling-parse` — extraction and API (§4, §5) — **implemented**, depending on the
+>   released `docling-core>=2.95.0`
+> **C** `docling` — rework of #4169 on top of them (§6) — not started
+
+---
+
+## 1. What docling#4169 does, and why it is a workaround
+
+docling's heading-hierarchy stage uses the PDF outline (bookmarks) as the most authoritative
+heading signal. `_PdfOutlineItem` carries:
+
+| field     | meaning                                                     |
+| --------- | ----------------------------------------------------------- |
+| `title`   | bookmark title                                               |
+| `level`   | 0-based depth                                                |
+| `page_no` | **1-based target page**                                      |
+| `y_top`   | **vertical position of the target, top-left origin**          |
+
+Two extractors feed it:
+
+* `extract_outline_from_pdfium()` — fills all four fields (PDFium resolves the destination).
+* `extract_outline_from_docling_parse()` — fills only `title` and `level`; `page_no` and
+  `y_top` are `None`, because docling-parse's `get_table_of_contents()` returns titles and
+  hierarchy only.
+
+Without `page_no`, every bookmark is fuzzy-matched against *every* heading in the document.
+That is both **wrong** (a bookmark matches a same-titled heading on an unrelated page —
+docling#4162) and **slow** (the PR reports 1140 s → 11 s on a large document once matching is
+narrowed per page).
+
+PR #4169 fixes this by making **both docling-parse backends open a second, throwaway PDFium
+document** purely to read the outline, keeping the native docling-parse ToC as a fallback.
+For `ThreadedDoclingParseDocumentBackend` this is on top of an *already existing* workaround
+that loads a whole extra lazy `DoclingPdfParser` document just to read the ToC.
+
+That is the wart we remove: **docling-parse already has the PDF open in qpdf and already knows
+every page's geometry. It should be the one answering this question.**
+
+### 1.1 Consequences of fixing it here
+
+* Both docling-parse backends drop the PDFium detour and the transient-document dance
+  (`extract_outline_from_pdfium_path_or_stream`, the `BytesIO` seek/restore, the
+  `PdfiumError`/`RuntimeError` handling, the second `DoclingPdfParser` load).
+* `docling-parse` becomes usable for bookmark resolution *without* pypdfium2 at all, which is
+  the stated goal of the `extract_outline_from_docling_parse` code path.
+* The threaded backend stops paying a full second document open per conversion.
+* docling-parse's own `PdfTocEntry.page` field — declared public since it was introduced and
+  **always `None`**, because the C++ side never emitted it — is replaced by a destination that
+  actually carries data.
+* The two duplicate Python views of the same ToC JSON (§2.2) collapse into one shared model in
+  `docling-core`, so `get_table_of_contents()` and `get_annotations().table_of_contents` stop
+  being different types of the same thing.
+
+---
+
+## 2. Gap analysis in docling-parse (as of `8cff78a`)
+
+### 2.1 C++
+
+`src/parse/qpdf/annots.h`, `extract_toc_entry_in_json()`:
+
+```cpp
+    // Extract title
+    if(node.hasKey("/A"))
+      {
+        //toc_entry["link"] = to_json(node.getKey("/A"), {}, 0, 8);
+      }
+
+    // Extract destination
+    if(node.hasKey("/Dest"))
+      {
+        //auto dest = node.getKey("/Dest");
+        //toc_entry["destination"] = to_json(dest, {}, 0, 8);
+      }
+```
+
+Destination handling is commented out entirely. The emitted JSON per node is
+`{"title", "level", "children"}` — nothing else.
+
+Secondary weaknesses in the same routine:
+
+1. **Loop detection uses `first.unparse()` as the key.** That serialises the whole object to a
+   string on every node — expensive — and is not an identity test: two structurally identical
+   but distinct outline items collide and the second is silently dropped.
+2. **The `visited` set is shared across recursion levels but only guards `/First`/`/Next`
+   chains**, not `/Parent` cycles.
+3. `extract_toc_in_json()` walks `/Outlines` by hand and re-implements what qpdf's
+   `QPDFOutlineDocumentHelper` already does correctly, including named-destination resolution.
+
+### 2.2 Python — and the duplicate ToC model
+
+There are **two** Python views of the *same* C++ JSON blob (`json_annots["table_of_contents"]`):
+
+| view | model | shape | built by |
+| ---- | ----- | ----- | -------- |
+| `PdfDocument.get_table_of_contents()` | `docling_core…PdfTableOfContents` | `{text, orig, marker, children}`, wrapped in a synthetic `<root>` node | `_to_table_of_contents()` |
+| `PdfDocument.get_annotations().table_of_contents` | `docling_parse…PdfTocEntry` | `{title, level, page, children}`, a flat list of roots | `_to_pdf_toc_entry()` |
+
+Neither carries a destination:
+
+* `PdfTocEntry.page: int | None` is **never populated** — the C++ side emits no such key. Dead
+  weight, not a usable extension point.
+* `PdfTableOfContents` **structurally cannot carry a page**, and it lives in `docling-core`.
+
+So the honest answer is not "pick one and bolt a field on", it is: **there should be one ToC
+model, it should live in docling-core next to every other PDF page model, and it should carry
+the destination.** That is what §5 and §11 do.
+
+Separately, `DoclingThreadedPdfParser` exposes no outline/annotation accessor at all, even
+though `docling_threaded_base` holds a full `pdf_decoder<DOCUMENT>` per document key.
+
+---
+
+## 3. Design principles for this change
+
+1. **Resolve destinations with qpdf, not by hand.** `QPDFOutlineDocumentHelper` /
+   `QPDFOutlineObjectHelper` already implement ISO 32000-1 §12.3.3 traversal and §12.3.2.3
+   named-destination resolution (both the catalog `/Dests` dictionary and the `/Names /Dests`
+   name tree), plus `/A` actions with `/S /GoTo`. Verified against the vendored qpdf 12.2.0
+   source in `externals/`.
+2. **Ground the destination semantics in ISO 32000-1 §12.3.2.2**, not in "whatever PDFium
+   returns". Deliberate deviations get named in comments.
+3. **Reuse the page-geometry code that decodes pages.** The outline's coordinates must land in
+   *exactly* the frame that `PdfTextCell` coordinates land in, or matching a bookmark against a
+   heading's provenance is meaningless. That means reusing
+   `page_item<PAGE_DIMENSION>::execute()` and `::rotate()`, not re-deriving `/MediaBox` +
+   `/Rotate` maths.
+4. **Structure-only, no page decoding.** Outline extraction stays as cheap as it is today:
+   dictionary reads only, no content streams, no fonts.
+5. **One representation.** docling-parse has *two* Python views of one ToC JSON blob today
+   (§2.2). This change leaves **one**, and puts it where every other PDF page model already
+   lives: `docling_core…PdfTableOfContents`, enriched with the destination (§11). No new
+   parallel model in either repo.
+6. **Additive JSON.** The C++ → Python JSON contract gains keys; nothing existing changes shape.
+
+---
+
+## 4. C++ design
+
+### 4.1 New file: `src/parse/qpdf/outline.h`
+
+A single class replaces `extract_toc_in_json()` / `extract_toc_entry_in_json()` in
+`annots.h` (which are deleted, not commented out).
+
+```cpp
+namespace pdflib
+{
+  // Extracts the document outline (ISO 32000-1, 12.3.3 "Document Outline") together with the
+  // resolved destination of each item (12.3.2 "Destinations").
+  //
+  // Destination coordinates are reported in the same frame as decoded page content: the page
+  // is normalised by its /Rotate angle exactly as pdf_decoder<PAGE>::rotate_contents() does,
+  // and the result is expressed with a bottom-left origin.
+  class pdf_outline
+  {
+  public:
+
+    pdf_outline(QPDF& qpdf_document,
+                const std::vector<QPDFObjectHandle>& qpdf_pages);
+    ~pdf_outline();
+
+    nlohmann::json get();
+
+  private:
+
+    struct page_frame
+    {
+      int                   page_number;  // 1-based
+      int                   angle;
+      std::pair<double, double> delta;
+      std::array<double, 4> bbox;         // rotated page rectangle, bottom-left origin
+    };
+
+    nlohmann::json to_json(QPDFOutlineObjectHelper& item, int level);
+
+    nlohmann::json resolve_destination(QPDFOutlineObjectHelper& item);
+    std::optional<int> resolve_destination_page(QPDFObjectHandle dest);
+
+    const page_frame& get_page_frame(int page_number);
+
+    std::string title_of(QPDFOutlineObjectHelper& item);
+
+  private:
+
+    QPDF& qpdf_document;
+    const std::vector<QPDFObjectHandle>& qpdf_pages;
+
+    std::map<QPDFObjGen, int> page_number_of;   // page object -> 1-based page number
+    std::map<int, page_frame> page_frames;      // lazily filled, only for targeted pages
+  };
+}
+```
+
+Implementations live outside the class body, matching the house style.
+
+### 4.2 Destination resolution — ISO 32000-1, Table 151 (§12.3.2.2)
+
+`QPDFOutlineObjectHelper::getDest()` returns the destination **array** for direct, named, and
+`/GoTo`-action destinations, and a null object otherwise (notably for `/GoToR` and `/GoToE`
+remote destinations, which have no page in *this* document — correctly reported as "no
+destination").
+
+The array is `[page, /Kind, args…]`. The kinds and the argument we care about:
+
+| syntax                                    | `kind`   | `x`      | `y`     |
+| ----------------------------------------- | -------- | -------- | ------- |
+| `[p /XYZ left top zoom]`                  | `XYZ`    | `left`   | `top`   |
+| `[p /Fit]`                                | `FIT`    | —        | —       |
+| `[p /FitH top]`                           | `FIT_H`  | —        | `top`   |
+| `[p /FitV left]`                          | `FIT_V`  | `left`   | —       |
+| `[p /FitR left bottom right top]`         | `FIT_R`  | `left`   | `top`   |
+| `[p /FitB]`                               | `FIT_B`  | —        | —       |
+| `[p /FitBH top]`                          | `FIT_BH` | —        | `top`   |
+| `[p /FitBV left]`                         | `FIT_BV` | `left`   | —       |
+
+Rules taken straight from the spec:
+
+* Any coordinate **may be `null`**, meaning "leave the current value unchanged"
+  (§12.3.2.2). A `null` is reported as absent, never as `0`.
+* `[p /XYZ …]` with a `null` `top` is common in real files; such an item still has a usable
+  `page`, so `page` and the point are independent optionals.
+* `dest[0]` is a **page object** for a destination inside this document. A few producers write
+  a **page number** there instead (legal only for remote destinations, §12.3.2.2). We accept an
+  integer as a 0-based page index — a named, deliberate deviation, logged at `WARNING`.
+* An unknown/missing kind name yields a destination with a page and no point, rather than
+  dropping the item.
+
+`pdf_destination_kind` and its `to_string()` go into `src/parse/enums.h` alongside the other
+parse enums.
+
+### 4.3 Coordinate frame — the part that must be exactly right
+
+Destination coordinates are in the target page's **default user space** (unrotated, origin at
+the `/MediaBox` lower-left). Decoded page content is *not*: `pdf_decoder<PAGE>::rotate_contents()`
+normalises the page by its `/Rotate` angle and moves every cell with it.
+
+So the destination point is put through the *same* transform, using the *same* code:
+
+```cpp
+  page_item<PAGE_DIMENSION> dimension;
+  dimension.execute(qpdf_pages.at(page_number - 1));   // reads /Rotate, /MediaBox, /CropBox,
+                                                       // including page-tree inheritance
+  int angle = dimension.get_angle();
+  std::pair<double, double> delta = {0.0, 0.0};
+
+  if((angle % 360) != 0)
+    {
+      delta = dimension.rotate(angle);                 // identical to rotate_contents()
+    }
+
+  utils::values::rotate_inplace(angle, x, y);          // identical to page_cell::rotate()
+  utils::values::translate_inplace(delta, x, y);
+```
+
+`page_item<PAGE_DIMENSION>` and `utils::values` are therefore the single source of truth for
+this maths; the outline extractor adds none of its own.
+
+The `page_frame` cache means a page targeted by 300 bookmarks is measured once.
+
+> Note: this is *more* correct than the PDFium path docling uses today, which subtracts an
+> unrotated destination `y` from a **rotated** page height. On a `/Rotate 90` page that is
+> simply wrong. Our fixtures will cover it (§8).
+
+**Include ordering.** `src/parse.h` includes `parse/qpdf/annots.h` (line 57) *before*
+`parse/page_item.h` / `parse/page_items/page_dimension.h` (lines 66–67), so the outline
+extractor cannot live in `annots.h`. `parse/qpdf/outline.h` is included immediately after the
+page-items block, with a one-line comment stating the dependency.
+
+Correspondingly, `extract_document_annotations_in_json()` **stops** producing
+`"table_of_contents"`; `pdf_decoder<DOCUMENT>::ensure_annots_loaded()` composes it:
+
+```cpp
+    json_annots = extract_document_annotations_in_json(qpdf_document, qpdf_root);
+    json_annots["table_of_contents"] = pdf_outline(qpdf_document, qpdf_pages).get();
+```
+
+Both stay inside the existing `KEY_EXTRACT_DOC_ANNOTATIONS` timing block and behind the same
+lazy `annots_loaded` guard, so nothing new is paid unless a caller asks.
+
+### 4.4 JSON contract (additive)
+
+Per outline node:
+
+```jsonc
+{
+  "title": "Model Architecture",
+  "level": 1,
+  "destination": {                 // absent when the item has no resolvable destination
+    "page_no": 7,                  // 1-based
+    "kind": "XYZ",                 // ISO 32000-1, table 151; "UNKNOWN" when unnamed
+    "coord_origin": "BOTTOMLEFT",
+    "point": [72.0, 690.4],        // absent when the destination gives no vertical position
+    "page_size": {                 // target page, same frame as "point"
+      "width": 595.276,
+      "height": 841.89
+    }
+  },
+  "children": [ … ]
+}
+```
+
+The key names are exactly the `PdfDestination` field names (§11.1), so the sub-dictionary is
+handed to pydantic as it comes and the field list is not restated on the Python side.
+
+`page_size` is carried on the destination deliberately: it lets a consumer flip to a top-left
+origin **without decoding the target page**, which is the whole point of keeping this path
+cheap. See decision **D1**.
+
+**When `point` is present.** A destination may leave any coordinate `null`, meaning "retain the
+current value" (12.3.2.2), and four of the eight syntaxes carry no vertical position at all.
+Since the point exists to locate a heading *vertically*, it is emitted only when the destination
+actually specifies a top — so `/Fit`, `/FitB`, `/FitV`, `/FitBV` and an `/XYZ` with a null `top`
+produce a destination with a page and no point. The horizontal coordinate is filled from the
+page's left edge when the destination omits it, because the rotation in §4.3 mixes the two axes
+and needs both; on an unrotated page it cannot influence the reported vertical position.
+
+`"title"`, `"level"` and `"children"` keep today's exact meaning and placement.
+
+---
+
+## 5. Python design
+
+The models move to **docling-core** (§11 is the companion PR). This section describes the
+resulting docling-parse surface.
+
+### 5.1 One ToC model, carrying its destination
+
+`docling_core.types.doc.page` gains `PdfDestinationKind` and `PdfDestination`, and
+`PdfTableOfContents` gains a `destination` field and an `iterate()` walk. In docling-parse that
+collapses the duplication in §2.2:
+
+```python
+# docling_parse/pdf_parser.py
+from docling_core.types.doc.page import PdfTableOfContents   # already imported
+
+
+class PdfAnnotations(BaseModel):
+    form: dict[str, Any] | None = None
+    language: str | None = None
+    meta_xml: str | None = None
+    table_of_contents: PdfTableOfContents | None = None      # was list[PdfTocEntry] | None
+```
+
+* **`PdfTocEntry` is deleted.** With `PdfTableOfContents.destination` in place it is a byte-for-byte
+  duplicate of a docling-core model, built from the same JSON by a second converter. It is not
+  re-exported from `docling_parse/__init__.py`; its only references are `pdf_parser.py` itself
+  and one assertion block in `tests/test_regression_parse.py`.
+* `_to_pdf_toc_entry()` is deleted; `_to_table_of_contents()` becomes the single converter and
+  learns to fill `destination`.
+* `PdfAnnotations.table_of_contents` and `PdfDocument.get_table_of_contents()` now return **the
+  same object** — the synthetic `<root>` node, matching `ParsedPdfDocument.table_of_contents`.
+  `get_table_of_contents()` becomes a one-line delegation to `get_annotations()`, so the two can
+  no longer drift, and the existing `self._toc` cache collapses into the existing
+  `self._annotations` cache.
+
+There is deliberately **no `level` field** on the model: level is depth, and a stored copy can
+only ever disagree with the tree. `PdfTableOfContents.iterate()` yields it (§11.2). The C++ JSON
+keeps emitting `"level"` — it is the pre-existing contract of the raw
+`parser.get_table_of_contents(key)` binding, and it is useful when eyeballing the JSON — but no
+typed model mirrors it.
+
+### 5.2 Threaded parser
+
+`docling_threaded_base` already stores a `pdf_decoder<DOCUMENT>` per key, so this is a
+pass-through, mirroring `number_of_pages`:
+
+* `src/pybind/docling_threaded_base.h` → `nlohmann::json get_annotations(std::string key) const;`
+* `app/pybind_parse.cpp` → `.def("get_annotations", …)` on `_threaded_pdf_parser`
+* `docling_parse/pdf_parser.py` → `DoclingThreadedPdfParser.get_annotations(doc_key) -> PdfAnnotations | None`
+
+The `PdfAnnotations` construction currently inlined in `PdfDocument.get_annotations()` moves to
+a module-level `_to_annotations(dict) -> PdfAnnotations`, used by both, so the threaded and
+non-threaded paths cannot drift.
+
+### 5.3 No new `PdfDocument` accessor
+
+`get_annotations().table_of_contents` and `get_table_of_contents()` already return the enriched
+tree, and `PdfTableOfContents.iterate()` covers the only thing consumers were missing — a
+recursion-safe pre-order walk. A third name for one concept would be a regression, not a feature.
+
+## 6. What this lets docling delete
+
+Once both PRs are released, docling#4169 reduces to:
+
+```python
+def extract_outline_from_docling_parse(dp_doc) -> list[_PdfOutlineItem]:
+    toc = dp_doc.get_table_of_contents()
+    if toc is None:
+        return []
+
+    items: list[_PdfOutlineItem] = []
+    for level, entry in toc.iterate():
+        title = (entry.text or entry.orig or "").strip()
+        if not title:
+            continue
+        dest = entry.destination
+        top_left = dest.to_top_left_origin() if dest else None
+        items.append(_PdfOutlineItem(
+            title=title,
+            level=level,
+            page_no=dest.page_no if dest else None,
+            y_top=top_left.point.y if top_left and top_left.point else None,
+        ))
+    return items
+```
+
+and the threaded backend calls `self.parser.get_annotations(self.doc_key)` instead of loading a
+second document. `extract_outline_from_pdfium_path_or_stream()` and both PDFium preference
+branches in `docling_parse_backend.py` disappear, as does docling's hand-rolled explicit-stack
+tree walk and the comment explaining why it exists. `extract_outline_from_pdfium()` stays for
+the pypdfium2 backend, which is its proper home.
+
+The page-indexing change in `heading_hierarchy_model.py` (the actual bug fix) is orthogonal and
+stays exactly as PR #4169 has it.
+
+## 7. Work breakdown
+
+### PR A — `docling-core` (companion, lands first)
+
+| # | Change | Files |
+| - | ------ | ----- |
+| A1 | `PdfDestinationKind`, `PdfDestination` (+ `to_top_left_origin()` / `to_bottom_left_origin()`) | `docling_core/types/doc/page.py` |
+| A2 | `PdfTableOfContents.destination` + `PdfTableOfContents.iterate()` | `docling_core/types/doc/page.py` |
+| A3 | Re-export the two new names | `docling_core/types/doc/__init__.py` |
+| A4 | Tests | `tests/test_page.py` |
+
+### PR B — `docling-parse` (this repo, depends on PR A) — **implemented**
+
+| # | Change | Files |
+| - | ------ | ----- |
+| 1 | `pdf_destination_kind` + `to_string()` | `src/parse/enums.h` |
+| 2 | `pdf_outline` class: traversal, destination resolution, page-frame cache, JSON emission | `src/parse/qpdf/outline.h` *(new)* |
+| 3 | Delete `extract_toc_in_json` / `extract_toc_entry_in_json`; drop `"table_of_contents"` from `extract_document_annotations_in_json` | `src/parse/qpdf/annots.h` |
+| 4 | Include `parse/qpdf/outline.h` after the page-items block, with the ordering comment | `src/parse.h` |
+| 5 | Compose the outline in `ensure_annots_loaded()` | `src/parse/pdf_decoders/document.h` |
+| 6 | `get_annotations(key)` on the threaded base + bindings on **both** `_threaded_pdf_parser` and `_threaded_pdf_renderer` (a `DoclingThreadedPdfParser` with a `render_config` is renderer-backed) | `src/pybind/docling_threaded_base.h`, `app/pybind_parse.cpp` |
+| 7 | Delete `PdfTocEntry` + `_to_pdf_toc_entry()`; retype `PdfAnnotations.table_of_contents`; `_to_annotations()`; `get_table_of_contents()` delegates; `DoclingThreadedPdfParser.get_annotations()` | `docling_parse/pdf_parser.py` |
+| 8 | Raise the `docling-core` floor from `>=2.85.0` to `>=2.95.0` (the release carrying PR A); the temporary `[tool.uv.sources]` git pin is gone | `pyproject.toml`, `uv.lock` |
+| 9 | In-memory fixture builders + tests | `tests/outline_fixtures.py` *(new)*, `tests/test_regression_parse.py` |
+
+Steps 1–5 are one commit (C++ extraction), 6–8 a second (API surface), 9 a third.
+
+Both translation units that reach the new code pass `c++ -fsyntax-only` with `-Wall` clean:
+`app/parse.cpp` (covers `parse.h`, `outline.h`, `document.h`) and `app/pybind_parse.cpp`
+(covers `docling_threaded_base.h` and the new bindings).
+
+### PR C — `docling` (upstream, depends on PR B)
+
+Rework of docling#4169 per §6.
+
+## 8. Tests
+
+Extending `tests/test_regression_parse.py::test_table_of_contents` and adding cases:
+
+1. **`table_of_contents_01.pdf`** — every entry now has `destination.page_no`; `Introduction`
+   is on page 1; nested entries resolve to pages `>=` their parent's; `y` is inside
+   `[0, page_size.height]`.
+2. **Named destinations** — a fixture using `/Names /Dests` (name tree) and one using the
+   legacy catalog `/Dests` dictionary; both must resolve to the same pages as an equivalent
+   file with explicit destinations.
+3. **`/A` `/GoTo` action destinations** — resolve identically to `/Dest`.
+4. **`/GoToR` remote action** — `destination is None`, entry still present with title + level.
+5. **Destination kinds** — one bookmark per kind in Table 151; assert `kind`, and that
+   `point` is `None` exactly for `FIT`, `FIT_B` and for `XYZ` with a `null` `top`.
+6. **Rotated pages** — a ToC pointing into `/Rotate 90/180/270` pages. Assert the destination
+   point lands within the bounding box of the heading cell decoded from that page. This is the
+   test that pins §4.3 and that the current PDFium path would fail.
+7. **Cyclic / malformed outlines** — `/First` loop, `/Next` loop, missing `/Title`,
+   `/Dest` pointing at a page not in the page tree. Must terminate and degrade, not throw.
+8. **Threaded parity** — `DoclingThreadedPdfParser.get_annotations(key).table_of_contents`
+   equals `DoclingPdfParser` + `PdfDocument.get_annotations().table_of_contents`.
+9. **Model consolidation** — `get_table_of_contents()` and
+   `get_annotations().table_of_contents` return the *same* object; the existing
+   `PdfTocEntry` assertion block in `test_table_of_contents` is rewritten against
+   `PdfTableOfContents` + `iterate()`.
+
+The repo ships no PDF-authoring dependency, **and `tests/data/**` is gitignored** — it is a
+pinned Hugging Face snapshot (`docling-project/regression-dataset-for-docling-parse`), not
+repository content, so a new fixture file there would need a dataset publish and an
+`HF_DATASET_REVISION` bump before CI could see it.
+
+So the fixtures are not files. `tests/outline_fixtures.py` assembles them from raw PDF objects
+and returns `bytes`, which the tests wrap in a `BytesIO` and hand to
+`DoclingPdfParser.load()`. Nothing to publish, nothing to keep in sync, and the PDF being
+tested is readable right next to the assertion. All four were validated with `qpdf --check`
+while being written:
+
+| builder | covers |
+| ------- | ------ |
+| `build_destination_kinds()` | all eight syntaxes of table 151, `/XYZ` with a null `top`, all-null `/XYZ`, a bare `[page]` dest, an item with no destination at all |
+| `build_destination_references()` | explicit array, name-tree byte string, catalog `/Dests` name written as a destination *dictionary*, `/A /GoTo` with an array and with a name, `/A /GoToR` |
+| `build_rotated_pages()` | `/Rotate` 0 / 90 / 180 / 270, each with a heading the bookmark must land on |
+| `build_malformed_outline()` | a `/Next` cycle, a `/First` cycle back to the parent, a missing `/Title`, a destination page outside the page tree |
+
+`table_of_contents_01.pdf` turned out to be the ideal case-1 fixture: every bookmark is an
+`/A << /S /GoTo /D (section.N) >>` resolved through the `/Names /Dests` name tree to
+`[<page> /XYZ 108 490.534 null]` — precisely the path that produced nothing before.
+
+`docs/PDF32000_2008.pdf` §12.3.2–12.3.3 is the reference for every assertion above.
+
+---
+
+## 9. Risks and deliberate limits
+
+* **qpdf skips direct (non-indirect) outline items.** `QPDFOutlineObjectHelper`'s constructor
+  walks `/First`/`/Next` only while `cur.isIndirect()`. Today's hand-rolled walk accepts direct
+  dictionaries. Such files are rare and malformed (§12.3.3 requires indirect references), but
+  this is a behaviour change — it will be called out in the PR body and covered by fixture 7.
+* **Depth limits.** Today: hard-coded `level >= 16`. qpdf: 50. Adopting qpdf's traversal raises
+  the cap to 50, which is a strict improvement; nothing downstream assumes 16.
+* **Cost.** Extraction stays dictionary-only. The added work is one `page_item<PAGE_DIMENSION>::execute()`
+  per *targeted* page (cached) plus a `QPDFObjGen → page number` map built once from the
+  already-materialised `qpdf_pages`. Negligible next to page decoding, and still fully lazy.
+* **Encrypted documents.** Handled by qpdf at load; nothing outline-specific.
+* **`PdfTocEntry` removal and the `PdfAnnotations.table_of_contents` retype are public-model
+  changes** (D2). `PdfTocEntry` is not re-exported from `docling_parse/__init__.py` and its
+  `page` field never carried a value, so the failure mode for any caller is a loud `ImportError`
+  / `AttributeError`, not a silent wrong answer. `table_of_contents` changes from
+  `list[PdfTocEntry] | None` to `PdfTableOfContents | None` (the `<root>` node) — a caller
+  iterating it directly now iterates `.children`. Both called out in the PR body and release notes.
+* **Cross-repo ordering.** PR B does not build against a `docling-core` without PR A. The
+  `docling-core` floor bump (step 8) is what enforces it; until PR A is released, PR B can be
+  developed against a local `_references/docling-core` checkout but must not be merged.
+* This changes no rendering or parsing output — no groundtruth regeneration.
+
+---
+
+## 10. Design decisions (settled)
+
+**D1 — Coordinate origin of the emitted destination: bottom-left, with `page_size`.**
+The destination point is reported in `CoordOrigin.BOTTOMLEFT`, docling-parse's uniform
+convention (the only origin `pdf_parser.py` uses today), in the same rotated page frame as the
+target page's cells. `PdfDestination.page_size` carries the target page's rectangle in that
+same frame, so a consumer flips to a top-left origin with `page_size.height - point.y` **without
+decoding the target page** — which is what keeps this path structure-only and cheap.
+
+*Rejected:* emitting `y_top` in top-left origin directly. It would be a one-line drop-in for
+docling's `_PdfOutlineItem`, but it would put a second coordinate convention inside
+docling-parse for the sake of exactly one consumer.
+
+*Rejected:* bottom-left with no `page_size`. Leaner model, but it pushes the consumer into
+loading the target page just to learn its height, which defeats the point.
+
+**D2 — `PdfTocEntry` is removed entirely, not just its `page` field.**
+Once `PdfTableOfContents` carries a destination (D4), `PdfTocEntry` is a duplicate model built
+from the same JSON by a second converter — exactly the redundancy this change exists to remove.
+Its `page` field has *always* been `None`, so no caller can depend on a value; a caller that
+merely names the class or the field fails loudly at import or attribute access rather than
+silently reading a stale duplicate. It is not re-exported from `docling_parse/__init__.py`.
+Listed as a model change in the release notes.
+
+**D3 — No new `PdfDocument` outline accessor.**
+After D4 both `get_annotations().table_of_contents` and `get_table_of_contents()` return the
+same enriched tree, and `PdfTableOfContents.iterate()` covers the only thing consumers were
+missing — a recursion-safe pre-order walk. A third name for one concept would be a regression.
+
+**D4 — The destination model lives in `docling-core`, on `PdfTableOfContents`.**
+*(Reverses the earlier "leave docling-core alone" position, on the user's call to open a
+companion PR.)* Every other PDF page/document model docling-parse emits — `PdfTextCell`,
+`PdfPageGeometry`, `PdfHyperlink`, `BoundingRectangle`, `Coord2D`, `PdfMetaData`,
+`PdfTableOfContents` itself — already lives in `docling-core`. Defining a *second* ToC model
+inside docling-parse to carry the destination would entrench the duplication described in §2.2
+instead of removing it, and would force docling to import a docling-parse-private type to read a
+bookmark. Enriching the existing shared model gives one producer, one JSON contract, one typed
+model, one tree. See §11.
+
+---
+
+## 11. Companion PR in `docling-core` — **implemented**
+
+Branch `feat/extending-table-of-contents` in `_references/docling-core` (off `main` @ `a59c38c`,
+version `2.94.1`). Three files touched, +236 / -3.
+All changes are in `docling_core/types/doc/page.py`, in the `PdfMetaData` /
+`PdfTableOfContents` / `ParsedPdfDocument` block at the end of the file.
+
+`PdfTableOfContents` today is referenced only by `ParsedPdfDocument.table_of_contents` and the
+`docling_core.types.doc` re-export; it has **no tests** and appears in **no** JSON schema
+snapshot (`docs/schemas/` covers `DoclingDocument` only). So this is a low-blast-radius,
+purely additive change.
+
+### 11.1 New models
+
+```python
+class PdfDestinationKind(str, Enum):
+    """Explicit-destination syntax (ISO 32000-1, 12.3.2.2, Table 151)."""
+
+    XYZ = "XYZ"
+    FIT = "FIT"
+    FIT_H = "FIT_H"
+    FIT_V = "FIT_V"
+    FIT_R = "FIT_R"
+    FIT_B = "FIT_B"
+    FIT_BH = "FIT_BH"
+    FIT_BV = "FIT_BV"
+    UNKNOWN = "UNKNOWN"
+
+    def __str__(self) -> str:
+        """Return string representation of the enum value."""
+        return str(self.value)
+
+
+class PdfDestination(BaseModel):
+    """Model representing a resolved PDF destination (ISO 32000-1, 12.3.2).
+
+    ``point`` is in the target page's own coordinate frame, i.e. the frame that page's cells
+    are reported in: the page normalised by its ``/Rotate`` angle. It is ``None`` when the
+    destination kind carries no position (``FIT``, ``FIT_B``) or when the PDF left the
+    coordinate ``null`` -- the spec allows ``null`` for "retain the current value".
+
+    ``page_size`` is the target page's rectangle in that same frame, so a consumer can change
+    the coordinate origin without loading the page.
+    """
+
+    page_no: PageNumber
+    kind: PdfDestinationKind = PdfDestinationKind.UNKNOWN
+
+    point: Coord2D | None = None
+    coord_origin: CoordOrigin = CoordOrigin.BOTTOMLEFT
+
+    page_size: Size
+
+    def to_top_left_origin(self) -> "PdfDestination":
+        """Return this destination with a top-left coordinate origin."""
+
+    def to_bottom_left_origin(self) -> "PdfDestination":
+        """Return this destination with a bottom-left coordinate origin."""
+```
+
+Both converters are no-ops when the origin already matches and flip
+`y -> page_size.height - y` otherwise, mirroring `BoundingBox.to_top_left_origin()` /
+`to_bottom_left_origin()` in `docling_core/types/doc/base.py`. Because `page_size` is on the
+model they take **no** `page_height` argument — that is the whole reason it is carried.
+
+`Size` must be added to the existing `from docling_core.types.doc.base import (…)` block in
+`page.py`; `Coord2D`, `CoordOrigin` and `PageNumber` are already in scope there.
+
+### 11.2 `PdfTableOfContents`
+
+```python
+class PdfTableOfContents(BaseModel):
+    """Model representing a PDF table of contents entry with hierarchical structure."""
+
+    text: str
+    orig: str = ""
+
+    marker: str = ""
+
+    destination: PdfDestination | None = None      # NEW
+
+    children: list["PdfTableOfContents"] = []
+
+    def iterate(self) -> Iterator[tuple[int, "PdfTableOfContents"]]:
+        """Yield ``(level, entry)`` for every descendant, depth-first in document order.
+
+        ``self`` is not yielded and its direct children are at level ``0``, matching the
+        convention that a document's outline hangs under a single synthetic root node.
+        """
+```
+
+* `destination` is optional and defaults to `None`, so every existing construction site,
+  serialized payload and `load_from_json()` file keeps validating unchanged.
+* `iterate()` uses an **explicit stack**, not recursion. Deeply nested outlines are real
+  (technical manuals, legal filings) and malformed PDFs can nest further still; docling
+  currently hand-rolls exactly this walk with a comment saying why. Putting it here means
+  neither docling nor docling-parse writes it again.
+* **No `level` field.** Level is depth; a stored copy can only ever disagree with the tree.
+  `iterate()` is where level comes from.
+* `export_to_dict()` uses `exclude_none=True`, so entries without a destination serialize
+  exactly as they do today.
+
+`ParsedPdfDocument` needs no change — it already holds a `PdfTableOfContents`.
+
+### 11.3 Exports
+
+Add `PdfDestination` and `PdfDestinationKind` to the `docling_core.types.doc.page` import block
+and the `__all__` list in `docling_core/types/doc/__init__.py`, keeping the existing
+alphabetical order (they sort just before `PdfHyperlink`).
+
+### 11.4 Tests (`tests/test_page.py`)
+
+`PdfTableOfContents` has no test coverage at all today, so this PR adds the first:
+
+1. **Backwards compatibility** — a `PdfTableOfContents` built and round-tripped
+   (`export_to_dict()` / `model_validate`) without a destination is identical to the
+   pre-change output; `exclude_none=True` keeps `destination` out of the payload.
+2. **`iterate()` order and levels** — a three-deep tree yields pre-order document order with
+   levels `0,1,2,…`; the root itself is not yielded; an empty tree yields nothing.
+3. **`iterate()` on a deep chain** — 5000 nested single-child nodes complete without
+   `RecursionError`. This is the test that pins the explicit stack.
+4. **Origin conversion** — `to_top_left_origin()` flips `y` to `page_size.height - y`, sets
+   `coord_origin`, leaves `x`, `kind`, `page_no` and `page_size` untouched, and is a no-op when
+   already top-left; `to_top_left_origin().to_bottom_left_origin()` round-trips; a destination
+   with `point=None` converts to `point=None` rather than raising.
+5. **Validation** — `page_no` rejects `0` and negatives (it is `PageNumber`, `ge=1`);
+   an unknown `kind` string fails validation, while `PdfDestinationKind.UNKNOWN` is accepted.
+
+### 11.5 Release coupling
+
+`docling-core` is versioned from tags (`version_source = "tag_only"`, currently `2.94.1`), so
+PR A must be **released** before PR B's `pyproject.toml` floor bump (step 8) can point at it.
+Until then PR B is developed against the local `_references/docling-core` checkout.
+
+Everything in PR A is additive: new enum, new model, one new optional field, one new method,
+two new exports. No existing field changes type, name or default, so no `docling-core` consumer
+needs to do anything.
+
+---
+
+## 12. Build & validation commands (for the user to run)
+
+```bash
+# --- PR A: docling-core -------------------------------------------------
+# merged and released as v2.95.0; nothing left to run here
+
+# --- PR B: docling-parse ------------------------------------------------
+# re-resolve after the docling-core floor bump, then rebuild in-place
+uv lock
+uv sync --reinstall-package docling-parse
+
+# targeted tests
+uv run pytest tests/test_regression_parse.py -k "table_of_contents or outline" -q
+
+# full regression
+uv run pytest tests/ -q
+```
+
+(Adjust to whatever your usual build invocation is — noted here only so the plan is
+self-contained; I will not run builds or tests myself.)

--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -1102,6 +1102,19 @@ PYBIND11_MODULE(pdf_parsers, m) {
 
     Returns:
         int: Number of pages that will be emitted by the threaded parser.)")
+    .def("get_annotations",
+         [](docling::docling_threaded_parser& self, const std::string& key) -> nlohmann::json {
+           return self.get_annotations(key);
+         },
+         pybind11::arg("key"),
+         R"(
+    Retrieve annotations for a loaded document and return them as JSON.
+
+    Parameters:
+        key (str): The unique key identifying the document.
+
+    Returns:
+        dict: A JSON object containing the annotations for the document.)")
     .def("unload_document",
          [](docling::docling_threaded_parser& self, const std::string& key) -> bool {
            return self.unload_document(key);
@@ -1311,6 +1324,11 @@ PYBIND11_MODULE(pdf_parsers, m) {
     .def("scheduled_number_of_pages",
          [](docling::docling_threaded_renderer& self, const std::string& key) -> int {
            return self.scheduled_number_of_pages(key);
+         },
+         pybind11::arg("key"))
+    .def("get_annotations",
+         [](docling::docling_threaded_renderer& self, const std::string& key) -> nlohmann::json {
+           return self.get_annotations(key);
          },
          pybind11::arg("key"))
     .def("unload_document",

--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -77,24 +77,6 @@ from docling_parse.pdf_parsers import (  # type: ignore[import]
 _log = logging.getLogger(__name__)
 
 
-class PdfTocEntry(BaseModel):
-    """PDF table of contents entry (recursive structure).
-
-    Attributes:
-        title: The text of the TOC entry
-        level: Nesting level in the hierarchy (0 for top level)
-        page: Page number this entry points to (optional)
-        children: Nested TOC entries (optional)
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    title: str
-    level: int | None = None
-    page: int | None = None
-    children: List["PdfTocEntry"] | None = None
-
-
 class PdfAnnotations(BaseModel):
     """PDF document annotations including form fields, language, metadata, and table of contents.
 
@@ -102,7 +84,8 @@ class PdfAnnotations(BaseModel):
         form: AcroForm data containing interactive form fields (raw dict structure). None if no forms present.
         language: Document language code (e.g., 'en-US', 'fr-FR'). None if not specified.
         meta_xml: XMP metadata as XML string. None if no metadata present.
-        table_of_contents: Document outline/bookmark structure as list of entries. None if no TOC.
+        table_of_contents: Document outline (bookmarks) as a tree under a synthetic root
+            entry. None if no outline present.
     """
 
     model_config = ConfigDict(validate_assignment=True, extra="allow")
@@ -110,7 +93,7 @@ class PdfAnnotations(BaseModel):
     form: Dict[str, Any] | None = None
     language: str | None = None
     meta_xml: str | None = None
-    table_of_contents: List[PdfTocEntry] | None = None
+    table_of_contents: PdfTableOfContents | None = None
 
 
 class Timings(BaseModel):
@@ -692,6 +675,42 @@ def _page_size_from_decoder(
     return abs(bbox[2] - bbox[0]), abs(bbox[3] - bbox[1])
 
 
+def _to_table_of_contents(toc: List[Dict[str, Any]]) -> List[PdfTableOfContents]:
+    """Convert raw outline entries into PdfTableOfContents entries.
+
+    The `destination` sub-dictionary is handed to pydantic as it comes: its keys are
+    the PdfDestination fields, so restating them here would only add a second place
+    to keep in sync. Recursion is safe: the C++ side caps the outline depth.
+    """
+    return [
+        PdfTableOfContents(
+            text=item.get("title", ""),
+            destination=item.get("destination"),
+            children=_to_table_of_contents(item.get("children") or []),
+        )
+        for item in toc
+    ]
+
+
+def _to_annotations(annots: Dict[str, Any]) -> PdfAnnotations:
+    """Convert the raw annotations dictionary into a PdfAnnotations.
+
+    Shared by the single-threaded and the threaded parser so the two cannot drift.
+    """
+    toc = annots.get("table_of_contents")
+
+    return PdfAnnotations(
+        form=annots.get("form"),
+        language=annots.get("language"),
+        meta_xml=annots.get("meta_xml"),
+        table_of_contents=(
+            PdfTableOfContents(text="<root>", children=_to_table_of_contents(toc))
+            if toc
+            else None
+        ),
+    )
+
+
 class PdfDocument:
     def __init__(
         self,
@@ -711,7 +730,6 @@ class PdfDocument:
         ] = {}
         # Per page: the content config the cached page-decoder satisfies.
         self._decoded_content_configs: Dict[int, ContentConfig] = {}
-        self._toc: PdfTableOfContents | None = None
         self._meta: PdfMetaData | None = None
         self._annotations: PdfAnnotations | None = None
 
@@ -847,21 +865,18 @@ class PdfDocument:
             raise RuntimeError("This document is not loaded.")
 
     def get_table_of_contents(self) -> PdfTableOfContents | None:
-        if self.is_loaded():
-            toc = self._parser.get_table_of_contents(key=self._key)
+        """Get the document outline (bookmarks) as a tree under a synthetic root entry.
 
-            if toc is None:
-                return self._toc
+        Each entry carries its `destination`, so a bookmark resolves to a page and,
+        where the PDF specifies one, to a position on that page.
 
-            if self._toc is not None:
-                return self._toc
+        Returns:
+            Optional[PdfTableOfContents]: The root entry, or None if the document has
+                no outline.
+        """
+        annotations = self.get_annotations()
 
-            self._toc = PdfTableOfContents(text="<root>")
-            self._toc.children = self._to_table_of_contents(toc=toc)
-
-            return self._toc
-        else:
-            raise RuntimeError("This document is not loaded.")
+        return annotations.table_of_contents if annotations is not None else None
 
     def iterate_pages(
         self,
@@ -873,31 +888,6 @@ class PdfDocument:
                 page_no + 1,
                 self.get_page(page_no + 1, content_config=content_config),
             )
-
-    def _to_table_of_contents(self, toc: dict) -> List[PdfTableOfContents]:
-
-        result = []
-        for item in toc:
-            subtoc = PdfTableOfContents(text=item["title"])
-            if "children" in item:
-                subtoc.children = self._to_table_of_contents(toc=item["children"])
-            result.append(subtoc)
-
-        return result
-
-    def _to_pdf_toc_entry(self, toc_list: List[Dict]) -> List[PdfTocEntry]:
-        """Convert raw TOC dict list to PdfTocEntry objects."""
-        result = []
-        for item in toc_list:
-            entry = PdfTocEntry(
-                title=item.get("title", ""),
-                level=item.get("level"),
-                page=item.get("page"),
-            )
-            if item.get("children"):
-                entry.children = self._to_pdf_toc_entry(item["children"])
-            result.append(entry)
-        return result
 
     def get_annotations(self) -> PdfAnnotations | None:
         """Get document annotations including form fields, language, metadata, and TOC.
@@ -915,17 +905,7 @@ class PdfDocument:
             if annots_dict is None:
                 return self._annotations
 
-            # Convert table_of_contents list of dicts to PdfTocEntry objects if present
-            toc_entries = None
-            if annots_dict.get("table_of_contents"):
-                toc_entries = self._to_pdf_toc_entry(annots_dict["table_of_contents"])
-
-            self._annotations = PdfAnnotations(
-                form=annots_dict.get("form"),
-                language=annots_dict.get("language"),
-                meta_xml=annots_dict.get("meta_xml"),
-                table_of_contents=toc_entries,
-            )
+            self._annotations = _to_annotations(annots_dict)
 
             return self._annotations
         else:
@@ -1623,6 +1603,24 @@ class DoclingThreadedPdfParser:
         if doc_key not in self._scheduled_page_counts:
             raise ValueError(f"Document key not loaded: {doc_key}")
         return self._scheduled_page_counts[doc_key]
+
+    def get_annotations(self, doc_key: str) -> PdfAnnotations | None:
+        """Get the annotations of a loaded document.
+
+        The annotations are structure-only: reading them decodes no page, so the
+        outline of a document can be read without waiting for, or interfering with,
+        the threaded page decoding.
+
+        Returns:
+            Optional[PdfAnnotations]: Annotations object with form, language, meta_xml
+                and table_of_contents fields. None if the document has no annotations.
+        """
+        if doc_key not in self._page_counts:
+            raise ValueError(f"Document key not loaded: {doc_key}")
+
+        annots = self._parser.get_annotations(key=doc_key)
+
+        return _to_annotations(annots) if annots is not None else None
 
     def unload(self, doc_key: str) -> bool:
         """Unload one document after threaded processing has completed."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pillow>=10.0.0,<13.0.0",
     "pydantic>=2.0.0",
-    "docling-core>=2.85.0,<3.0.0",
+    "docling-core>=2.95.0,<3.0.0",
     "pywin32>=305; sys_platform == 'win32'",
 ]
 [project.urls]
@@ -85,12 +85,6 @@ perf = [
 [tool.uv]
 package = true
 default-groups = "all"
-
-# TEMPORARY: the outline destinations need PdfTableOfContents.destination, which is
-# still under review in docling-core#747. Drop this block and raise the docling-core
-# floor in [project.dependencies] once that PR is released.
-[tool.uv.sources]
-docling-core = { git = "https://github.com/docling-project/docling-core.git", branch = "feat/extending-table-of-contents" }
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,12 @@ perf = [
 package = true
 default-groups = "all"
 
+# TEMPORARY: the outline destinations need PdfTableOfContents.destination, which is
+# still under review in docling-core#747. Drop this block and raise the docling-core
+# floor in [project.dependencies] once that PR is released.
+[tool.uv.sources]
+docling-core = { git = "https://github.com/docling-project/docling-core.git", branch = "feat/extending-table-of-contents" }
+
 [tool.setuptools]
 include-package-data = true
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -77,6 +77,10 @@
 #include <parse/page_items/page_hyperlinks.h>
 #include <parse/page_items/render_instructions.h>
 
+// the outline resolves its destinations against the page geometry, so it comes
+// after the page items rather than next to the other qpdf extractors
+#include <parse/qpdf/outline.h>
+
 // pdf-resource
 #include <parse/pdf_resources/page_font/glyphs.h>
 #include <parse/pdf_resources/page_font/font_cid.h>

--- a/src/parse/enums.h
+++ b/src/parse/enums.h
@@ -383,6 +383,83 @@ namespace pdflib
     return BLEND_MODE_UNKNOWN;
   }
 
+  // Syntax of an explicit destination array (12.3.2.2, table 151). The name that
+  // follows the page in `[page /Kind args]` selects how the viewer positions the
+  // page, and thereby which of the args (if any) is a vertical position.
+  enum pdf_destination_kind {
+    DESTINATION_XYZ,     // [page /XYZ left top zoom]
+    DESTINATION_FIT,     // [page /Fit]
+    DESTINATION_FIT_H,   // [page /FitH top]
+    DESTINATION_FIT_V,   // [page /FitV left]
+    DESTINATION_FIT_R,   // [page /FitR left bottom right top]
+    DESTINATION_FIT_B,   // [page /FitB]
+    DESTINATION_FIT_BH,  // [page /FitBH top]
+    DESTINATION_FIT_BV,  // [page /FitBV left]
+
+    DESTINATION_UNKNOWN,
+  };
+
+  inline std::string to_string(pdf_destination_kind kind)
+  {
+    switch(kind)
+      {
+      case DESTINATION_XYZ:    { return "XYZ"; }
+      case DESTINATION_FIT:    { return "FIT"; }
+      case DESTINATION_FIT_H:  { return "FIT_H"; }
+      case DESTINATION_FIT_V:  { return "FIT_V"; }
+      case DESTINATION_FIT_R:  { return "FIT_R"; }
+      case DESTINATION_FIT_B:  { return "FIT_B"; }
+      case DESTINATION_FIT_BH: { return "FIT_BH"; }
+      case DESTINATION_FIT_BV: { return "FIT_BV"; }
+
+      default: { return "UNKNOWN"; }
+      }
+  }
+
+  inline pdf_destination_kind to_destination_kind(const std::string& name)
+  {
+    if(name=="/XYZ")   { return DESTINATION_XYZ; }
+    if(name=="/Fit")   { return DESTINATION_FIT; }
+    if(name=="/FitH")  { return DESTINATION_FIT_H; }
+    if(name=="/FitV")  { return DESTINATION_FIT_V; }
+    if(name=="/FitR")  { return DESTINATION_FIT_R; }
+    if(name=="/FitB")  { return DESTINATION_FIT_B; }
+    if(name=="/FitBH") { return DESTINATION_FIT_BH; }
+    if(name=="/FitBV") { return DESTINATION_FIT_BV; }
+
+    return DESTINATION_UNKNOWN;
+  }
+
+  // Index of the vertical (top) coordinate within the args of a destination
+  // array, or -1 for the kinds that carry no vertical position.
+  inline int destination_top_index(pdf_destination_kind kind)
+  {
+    switch(kind)
+      {
+      case DESTINATION_XYZ:    { return 1; }  // left top zoom
+      case DESTINATION_FIT_H:  { return 0; }  // top
+      case DESTINATION_FIT_BH: { return 0; }  // top
+      case DESTINATION_FIT_R:  { return 3; }  // left bottom right top
+
+      default: { return -1; }
+      }
+  }
+
+  // Index of the horizontal (left) coordinate within the args of a destination
+  // array, or -1 for the kinds that carry no horizontal position.
+  inline int destination_left_index(pdf_destination_kind kind)
+  {
+    switch(kind)
+      {
+      case DESTINATION_XYZ:    { return 0; }  // left top zoom
+      case DESTINATION_FIT_V:  { return 0; }  // left
+      case DESTINATION_FIT_BV: { return 0; }  // left
+      case DESTINATION_FIT_R:  { return 0; }  // left bottom right top
+
+      default: { return -1; }
+      }
+  }
+
 }
 
 #endif

--- a/src/parse/pdf_decoders/document.h
+++ b/src/parse/pdf_decoders/document.h
@@ -164,6 +164,10 @@ namespace pdflib
         utils::timer annots_timer;
         json_annots = extract_document_annotations_in_json(qpdf_document, qpdf_root);
 
+        // composed here rather than inside the extractor above: resolving the
+        // outline's destinations needs the pages and their geometry
+        json_annots["table_of_contents"] = pdf_outline(qpdf_document, qpdf_pages).get();
+
         double annots_elapsed = annots_timer.get_time();
         timings.add_timing(pdf_timings::KEY_EXTRACT_DOC_ANNOTATIONS, annots_elapsed);
       }

--- a/src/parse/qpdf/annots.h
+++ b/src/parse/qpdf/annots.h
@@ -169,163 +169,6 @@ namespace pdflib
     return result;
   }
   
-  /*** Table of Contents ***/
-
-  nlohmann::json extract_toc_entry_in_json(QPDF& pdf_obj, QPDFObjectHandle& node, int level,
-                                           std::unordered_set<std::string>& visited)
-  {
-    LOG_S(INFO) << __FUNCTION__;
-    
-    nlohmann::json toc_entry = nlohmann::json::object({});
-
-    // securing we dont crash ...
-    if(level>=16)
-      {
-	return toc_entry;
-      }
-
-    //for(auto key : node.getKeys())
-    //{
-    //LOG_S(INFO) << " -> key: " << key;
-    //}
-    
-    // Extract title
-    if(node.hasKey("/Title"))
-      {
-	auto title = node.getKey("/Title");
-	
-	if(title.isString())
-	  {
-	    std::string val = title.getUTF8Value();
-
-            if(utf8::is_valid(val.begin(), val.end()))
-              {
-                toc_entry["title"] = val;
-		LOG_S(INFO) << "level: " << level << "\t" << val;
-              }
-            else
-              {
-                utf8::replace_invalid(val.begin(), val.end(),
-                                      std::back_inserter(val));
-                toc_entry["title"] = val;
-              }	    
-	  }
-	else
-	  {
-	    LOG_S(WARNING) << "title is not a string!";
-	    toc_entry["title"] = "<unknown>";
-	  }
-	
-        toc_entry["level"] = level;
-      }
-    
-    // Extract title
-    if(node.hasKey("/A"))
-      {
-        //toc_entry["link"] = to_json(node.getKey("/A"), {}, 0, 8);
-      }
-    
-    // Extract destination
-    if(node.hasKey("/Dest"))
-      {
-	//LOG_S(INFO) << "found a destination!";
-	
-        // Depending on the type of destination, extract its value
-	//auto dest = node.getKey("/Dest");
-        //toc_entry["destination"] = to_json(dest, {}, 0, 8);
-      }
-    else
-      {
-        //toc_entry["destination"] = "No destination";
-      }
-
-    // Extract children
-    if (node.hasKey("/First"))
-      {
-        QPDFObjectHandle first = node.getKey("/First");
-
-        while(first.isDictionary())
-          {
-            // Check for circular reference
-            std::string obj_ref = first.unparse();
-            if (visited.count(obj_ref))
-              {
-                LOG_S(WARNING) << "Circular TOC reference detected, skipping: " << obj_ref;
-                break;
-              }
-            visited.insert(obj_ref);
-
-            auto child = extract_toc_entry_in_json(pdf_obj, first, level+1, visited);
-            toc_entry["children"].push_back(child);
-
-            if(first.hasKey("/Next"))
-              {
-                first = first.getKey("/Next");
-              }
-            else
-              {
-                break;
-              }
-          }
-      }
-
-    return toc_entry;
-  }
-  
-  nlohmann::json extract_toc_in_json(QPDF& pdf_obj, QPDFObjectHandle& root)
-  {
-    LOG_S(INFO) << __FUNCTION__;
-    
-    nlohmann::json toc = nlohmann::json::value_t::null;
-
-    if(root.hasKey("/Outlines"))
-      {
-	LOG_S(INFO) << "/Outlines (=table-of-contents) detected!";
-	
-        QPDFObjectHandle outlines = root.getKey("/Outlines");
-
-        if(outlines.hasKey("/First"))
-          {
-            QPDFObjectHandle first = outlines.getKey("/First");
-
-            toc = nlohmann::json::array({});
-
-            // Track visited nodes to prevent infinite loops
-            std::unordered_set<std::string> visited;
-
-            while(first.isDictionary())
-              {
-                // Check for circular reference
-                std::string obj_ref = first.unparse();
-                if (visited.count(obj_ref))
-                  {
-                    LOG_S(WARNING) << "Circular TOC reference detected at top level, skipping: " << obj_ref;
-                    break;
-                  }
-                visited.insert(obj_ref);
-
-		int level=0;
-                toc.push_back(extract_toc_entry_in_json(pdf_obj, first, level, visited));
-
-                if(first.hasKey("/Next"))
-                  {
-                    first = first.getKey("/Next");
-                  }
-                else
-                  {
-                    break;
-                  }
-              }
-          }
-      }
-    else
-      {
-        LOG_S(INFO) << "no /Outlines (=table-of-contents) detected ...";
-      }
-
-    return toc;
-  }
-  
   nlohmann::json extract_document_annotations_in_json(QPDF& pdf_obj,
 						      QPDFObjectHandle& root)
   {
@@ -339,8 +182,10 @@ namespace pdflib
 
     annots["language"] = extract_language_in_json(pdf_obj, root);
 
-    annots["table_of_contents"] = extract_toc_in_json(pdf_obj, root);
-    
+    // The table-of-contents is composed by pdf_decoder<DOCUMENT>, not here: it
+    // resolves destinations against the page geometry, and pdf_outline therefore
+    // depends on page_item<PAGE_DIMENSION>, which is declared after this header.
+
     LOG_S(INFO) << "annotations: " << annots.dump(2);
     
     return annots;

--- a/src/parse/qpdf/outline.h
+++ b/src/parse/qpdf/outline.h
@@ -1,0 +1,317 @@
+//-*-C++-*-
+
+#ifndef QPDF_OUTLINE_H
+#define QPDF_OUTLINE_H
+
+#include <array>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <qpdf/QPDF.hh>
+#include <qpdf/QPDFObjGen.hh>
+#include <qpdf/QPDFOutlineDocumentHelper.hh>
+#include <qpdf/QPDFOutlineObjectHelper.hh>
+
+namespace pdflib
+{
+  // The document outline (12.3.3), also known as the bookmarks or the
+  // table-of-contents, with the destination (12.3.2) of every item resolved to a
+  // page and, where the destination specifies one, to a position on that page.
+  //
+  // A destination's coordinates are reported in the frame that page's cells are
+  // reported in: the page normalised by its /Rotate angle, bottom-left origin.
+  // The transform is the one pdf_decoder<PAGE>::rotate_contents() applies, run
+  // through the very same page_item<PAGE_DIMENSION>, so the two cannot drift.
+  //
+  // Only dictionary keys are read here. No content stream is decoded and no font
+  // is loaded, which keeps the outline as cheap as the rest of the annotations.
+  class pdf_outline
+  {
+  public:
+
+    pdf_outline(QPDF& qpdf_document,
+                std::vector<QPDFObjectHandle>& qpdf_pages);
+    ~pdf_outline();
+
+    nlohmann::json get();
+
+  private:
+
+    // Everything needed to place a destination on one page, measured once per
+    // page that is actually targeted by the outline.
+    struct page_frame
+    {
+      int angle;                        // /Rotate, which the transform normalises away
+      std::pair<double, double> delta;  // translation that follows the rotation
+      std::array<double, 4> crop_bbox;  // page rectangle, after the transform
+      double default_x;                 // left edge of the page, before the transform
+      double default_y;                 // top edge of the page, before the transform
+    };
+
+    nlohmann::json to_json(QPDFOutlineObjectHelper& item, int level);
+
+    nlohmann::json get_destination(QPDFOutlineObjectHelper& item);
+
+    int get_destination_page(QPDFObjectHandle page);
+    bool get_destination_arg(QPDFObjectHandle& dest, int arg_index, double& value);
+
+    const page_frame& get_page_frame(int page_number);
+
+    std::string get_title(QPDFOutlineObjectHelper& item);
+
+  private:
+
+    QPDF& qpdf_document;
+    std::vector<QPDFObjectHandle>& qpdf_pages;
+
+    std::map<QPDFObjGen, int> page_numbers;  // page object -> 1-based page number
+    std::map<int, page_frame> page_frames;
+  };
+
+  pdf_outline::pdf_outline(QPDF& qpdf_document_,
+                           std::vector<QPDFObjectHandle>& qpdf_pages_):
+    qpdf_document(qpdf_document_),
+    qpdf_pages(qpdf_pages_),
+
+    page_numbers({}),
+    page_frames({})
+  {
+    for(std::size_t ind=0; ind<qpdf_pages.size(); ind++)
+      {
+        page_numbers[qpdf_pages.at(ind).getObjGen()] = static_cast<int>(ind)+1;
+      }
+  }
+
+  pdf_outline::~pdf_outline()
+  {}
+
+  nlohmann::json pdf_outline::get()
+  {
+    LOG_S(INFO) << __FUNCTION__;
+
+    nlohmann::json outline = nlohmann::json::value_t::null;
+
+    QPDFOutlineDocumentHelper helper(qpdf_document);
+
+    if(not helper.hasOutlines())
+      {
+        LOG_S(INFO) << "no /Outlines (=table-of-contents) detected ...";
+        return outline;
+      }
+
+    LOG_S(INFO) << "/Outlines (=table-of-contents) detected!";
+
+    // The helper has already walked the tree, breaking /First and /Next cycles by
+    // object identity and capping the nesting depth, so the recursion below is
+    // bounded and cycle-free by construction.
+    std::vector<QPDFOutlineObjectHelper> items = helper.getTopLevelOutlines();
+
+    outline = nlohmann::json::array({});
+    for(auto& item : items)
+      {
+        outline.push_back(to_json(item, 0));
+      }
+
+    return outline;
+  }
+
+  nlohmann::json pdf_outline::to_json(QPDFOutlineObjectHelper& item, int level)
+  {
+    nlohmann::json entry = nlohmann::json::object({});
+
+    entry["title"] = get_title(item);
+    entry["level"] = level;
+
+    nlohmann::json destination = get_destination(item);
+    if(not destination.is_null())
+      {
+        entry["destination"] = destination;
+      }
+
+    std::vector<QPDFOutlineObjectHelper> kids = item.getKids();
+
+    if(not kids.empty())
+      {
+        entry["children"] = nlohmann::json::array({});
+        for(auto& kid : kids)
+          {
+            entry["children"].push_back(to_json(kid, level+1));
+          }
+      }
+
+    return entry;
+  }
+
+  std::string pdf_outline::get_title(QPDFOutlineObjectHelper& item)
+  {
+    return utils::string::fix_into_valid_utf8(item.getTitle());
+  }
+
+  nlohmann::json pdf_outline::get_destination(QPDFOutlineObjectHelper& item)
+  {
+    nlohmann::json result = nlohmann::json::value_t::null;
+
+    // Resolves /Dest as well as an /A << /S /GoTo /D >> action, and explicit as
+    // well as named destinations (12.3.2.3). A /GoToR or /GoToE action targets
+    // another document and yields nothing here, which is correct: it has no page
+    // in this one.
+    QPDFObjectHandle dest = item.getDest();
+
+    if(not dest.isInitialized() or
+       not dest.isArray() or
+       dest.getArrayNItems()==0)
+      {
+        return result;
+      }
+
+    int page_number = get_destination_page(dest.getArrayItem(0));
+    if(page_number<1)
+      {
+        return result;
+      }
+
+    pdf_destination_kind kind = DESTINATION_UNKNOWN;
+
+    if(dest.getArrayNItems()>1)
+      {
+        QPDFObjectHandle name = dest.getArrayItem(1);
+        if(name.isName())
+          {
+            kind = to_destination_kind(name.getName());
+          }
+      }
+
+    const page_frame& frame = get_page_frame(page_number);
+
+    result = nlohmann::json::object({});
+
+    result["page_no"] = page_number;
+    result["kind"] = to_string(kind);
+    result["coord_origin"] = "BOTTOMLEFT";
+
+    result["page_size"]["width"] = frame.crop_bbox[2]-frame.crop_bbox[0];
+    result["page_size"]["height"] = frame.crop_bbox[3]-frame.crop_bbox[1];
+
+    double x = frame.default_x;
+    double y = frame.default_y;
+
+    // The horizontal coordinate is only carried along so that the rotation below
+    // is well defined; it is the vertical one that locates an item on the page.
+    get_destination_arg(dest, destination_left_index(kind), x);
+    bool has_top = get_destination_arg(dest, destination_top_index(kind), y);
+
+    // A destination may leave any of its coordinates null, meaning "retain the
+    // current value" (12.3.2.2). There is no current view to retain here, so the
+    // page edge stands in for a coordinate the destination does not give, and the
+    // point is only reported when the vertical position is an actual one.
+    if(has_top)
+      {
+        utils::values::rotate_inplace(frame.angle, x, y);
+        utils::values::translate_inplace(frame.delta, x, y);
+
+        result["point"] = {x, y};
+      }
+
+    return result;
+  }
+
+  int pdf_outline::get_destination_page(QPDFObjectHandle page)
+  {
+    if(page.isInteger())
+      {
+        // A destination names its page with a page *number* only when it points
+        // into another document (12.3.2.2). Producers write one in a local
+        // destination too, so it is read as a 0-based page index here -- a
+        // deliberate deviation from the specification.
+        int page_number = static_cast<int>(page.getIntValue())+1;
+
+        if(page_number<1 or page_number>static_cast<int>(qpdf_pages.size()))
+          {
+            LOG_S(WARNING) << "outline destination has an out-of-range page-index: " << page_number;
+            return -1;
+          }
+
+        LOG_S(WARNING) << "outline destination uses a page-index instead of a page object";
+        return page_number;
+      }
+
+    auto itr = page_numbers.find(page.getObjGen());
+
+    if(itr==page_numbers.end())
+      {
+        LOG_S(WARNING) << "outline destination page is not part of the page-tree";
+        return -1;
+      }
+
+    return itr->second;
+  }
+
+  bool pdf_outline::get_destination_arg(QPDFObjectHandle& dest, int arg_index, double& value)
+  {
+    if(arg_index<0)
+      {
+        return false;
+      }
+
+    // the destination array is [page /Kind arg-0 arg-1 ...]
+    int index = 2+arg_index;
+
+    if(index>=dest.getArrayNItems())
+      {
+        return false;
+      }
+
+    QPDFObjectHandle arg = dest.getArrayItem(index);
+
+    if(not arg.isNumber())
+      {
+        return false;
+      }
+
+    value = utils::numeric::locale_safe_numeric_value(arg);
+    return true;
+  }
+
+  const pdf_outline::page_frame& pdf_outline::get_page_frame(int page_number)
+  {
+    auto itr = page_frames.find(page_number);
+
+    if(itr!=page_frames.end())
+      {
+        return itr->second;
+      }
+
+    page_item<PAGE_DIMENSION> dimension;
+    dimension.execute(qpdf_pages.at(page_number-1));
+
+    // captured before rotate(), which transforms the page boxes in place
+    std::array<double, 4> media_bbox = dimension.get_media_bbox();
+
+    page_frame frame;
+    frame.angle = dimension.get_angle();
+    frame.delta = {0.0, 0.0};
+    frame.default_x = media_bbox[0];
+    frame.default_y = media_bbox[3];
+
+    // pdf_decoder<PAGE>::rotate_contents() leaves a page whose angle is a whole
+    // number of turns untouched, so this frame has to leave it untouched too.
+    if((frame.angle%360)!=0)
+      {
+        frame.delta = dimension.rotate(frame.angle);
+      }
+    else
+      {
+        frame.angle = 0;
+      }
+
+    frame.crop_bbox = dimension.get_crop_bbox();
+
+    return page_frames.emplace(page_number, frame).first->second;
+  }
+
+}
+
+#endif

--- a/src/pybind/docling_threaded_base.h
+++ b/src/pybind/docling_threaded_base.h
@@ -70,6 +70,8 @@ namespace docling
     int number_of_pages(std::string key) const;
     int scheduled_number_of_pages(std::string key) const;
 
+    nlohmann::json get_annotations(std::string key) const;
+
     bool unload_document(std::string key);
     void unload_all_documents();
 
@@ -332,6 +334,18 @@ namespace docling
       }
 
     return itr->second->get_number_of_pages();
+  }
+
+  template<typename Derived, typename ResultType>
+  nlohmann::json docling_threaded_base<Derived, ResultType>::get_annotations(std::string key) const
+  {
+    auto itr = key2doc.find(key);
+    if(itr == key2doc.end())
+      {
+        throw std::runtime_error("Document key not found: " + key);
+      }
+
+    return itr->second->get_annotations();
   }
 
   template<typename Derived, typename ResultType>

--- a/tests/outline_fixtures.py
+++ b/tests/outline_fixtures.py
@@ -87,7 +87,11 @@ def _add_pages(
     titles: List[str],
     rotations: List[int] | None = None,
 ) -> tuple[int, List[int]]:
-    """Add a page tree whose pages each carry one heading. Returns (pages_ref, page_refs)."""
+    """Add a page tree whose pages each carry one heading.
+
+    Returns:
+        A (pages_ref, page_refs) tuple.
+    """
     pages_ref = pdf.reserve()
     font_ref = pdf.add("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
 
@@ -176,7 +180,7 @@ def build_destination_kinds() -> bytes:
 
 
 def build_destination_references() -> bytes:
-    """The four ways an outline item can reference a destination (12.3.2.3, 12.6.4.2)."""
+    """The ways an outline item can reference a destination (12.3.2.3, 12.6.4.2)."""
     pdf = PdfBuilder()
     pdf.reserve()  # catalog is object 1
 

--- a/tests/outline_fixtures.py
+++ b/tests/outline_fixtures.py
@@ -1,0 +1,303 @@
+"""Hand-written PDFs that exercise outline destination resolution.
+
+The repository ships no PDF-authoring dependency, and `tests/data` is a pinned
+Hugging Face snapshot rather than repository content, so these fixtures are
+assembled here from raw objects and handed to the parser as bytes. Every construct
+comes from ISO 32000-1: destinations from 12.3.2, the outline hierarchy from 12.3.3.
+
+The builders return `bytes`; `tests.test_regression_parse` wraps them in a
+`BytesIO`, which `DoclingPdfParser.load()` accepts directly.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+PAGE_WIDTH = 612
+PAGE_HEIGHT = 792
+
+# Where the heading is drawn on every page, in unrotated default user space. The
+# bookmarks point at this exact spot, so a decoded cell and its bookmark must land
+# on top of each other whatever the page rotation.
+HEADING_X = 108
+HEADING_BASELINE = 690
+HEADING_SIZE = 12
+
+
+class PdfBuilder:
+    """Collects indirect objects and serialises them with a valid xref table."""
+
+    def __init__(self) -> None:
+        self._objects: List[str | bytes | None] = [None]  # 1-based
+
+    def reserve(self) -> int:
+        """Reserve an object number to be filled in later."""
+        self._objects.append(None)
+        return len(self._objects) - 1
+
+    def put(self, number: int, body: str | bytes) -> int:
+        self._objects[number] = body
+        return number
+
+    def add(self, body: str | bytes) -> int:
+        return self.put(self.reserve(), body)
+
+    def add_stream(self, content: str) -> int:
+        data = content.encode("ascii")
+        return self.add(
+            f"<< /Length {len(data)} >>\nstream\n".encode("ascii")
+            + data
+            + b"\nendstream"
+        )
+
+    def build(self) -> bytes:
+        out = bytearray(b"%PDF-1.7\n%\xe2\xe3\xcf\xd3\n")
+        offsets = [0] * len(self._objects)
+
+        for number, body in enumerate(self._objects):
+            if number == 0:
+                continue
+            if body is None:
+                raise ValueError(f"object {number} was reserved but never filled in")
+            offsets[number] = len(out)
+            payload = body.encode("ascii") if isinstance(body, str) else body
+            out += f"{number} 0 obj\n".encode("ascii") + payload + b"\nendobj\n"
+
+        xref_offset = len(out)
+        out += f"xref\n0 {len(self._objects)}\n".encode("ascii")
+        out += b"0000000000 65535 f \n"
+        for number in range(1, len(self._objects)):
+            out += f"{offsets[number]:010d} 00000 n \n".encode("ascii")
+
+        out += (
+            f"trailer\n<< /Size {len(self._objects)} /Root 1 0 R >>\n"
+            f"startxref\n{xref_offset}\n%%EOF\n"
+        ).encode("ascii")
+
+        return bytes(out)
+
+
+def _heading_stream(text: str) -> str:
+    return f"BT /F1 {HEADING_SIZE} Tf {HEADING_X} {HEADING_BASELINE} Td ({text}) Tj ET"
+
+
+def _add_pages(
+    pdf: PdfBuilder,
+    *,
+    titles: List[str],
+    rotations: List[int] | None = None,
+) -> tuple[int, List[int]]:
+    """Add a page tree whose pages each carry one heading. Returns (pages_ref, page_refs)."""
+    pages_ref = pdf.reserve()
+    font_ref = pdf.add("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+    page_refs = []
+    for index, title in enumerate(titles):
+        contents_ref = pdf.add_stream(_heading_stream(title))
+        rotate = (rotations or [0] * len(titles))[index]
+        page_refs.append(
+            pdf.add(
+                f"<< /Type /Page /Parent {pages_ref} 0 R "
+                f"/MediaBox [0 0 {PAGE_WIDTH} {PAGE_HEIGHT}] /Rotate {rotate} "
+                f"/Resources << /Font << /F1 {font_ref} 0 R >> >> "
+                f"/Contents {contents_ref} 0 R >>"
+            )
+        )
+
+    kids = " ".join(f"{ref} 0 R" for ref in page_refs)
+    pdf.put(
+        pages_ref,
+        f"<< /Type /Pages /Kids [{kids}] /Count {len(page_refs)} >>",
+    )
+
+    return pages_ref, page_refs
+
+
+def _add_outline_items(
+    pdf: PdfBuilder, outlines_ref: int, entries: List[str]
+) -> List[int]:
+    """Add a flat chain of outline items, each given as its already-formatted body."""
+    refs = [pdf.reserve() for _ in entries]
+
+    for index, (ref, body) in enumerate(zip(refs, entries)):
+        links = f" /Parent {outlines_ref} 0 R"
+        if index > 0:
+            links += f" /Prev {refs[index - 1]} 0 R"
+        if index + 1 < len(refs):
+            links += f" /Next {refs[index + 1]} 0 R"
+        pdf.put(ref, f"<< {body}{links} >>")
+
+    return refs
+
+
+def _finish_catalog(
+    pdf: PdfBuilder, pages_ref: int, outlines_ref: int, extra: str = ""
+) -> None:
+    pdf.put(
+        1,
+        f"<< /Type /Catalog /Pages {pages_ref} 0 R "
+        f"/Outlines {outlines_ref} 0 R{extra} >>",
+    )
+
+
+def build_destination_kinds() -> bytes:
+    """One bookmark per explicit-destination syntax of ISO 32000-1, table 151."""
+    pdf = PdfBuilder()
+    pdf.reserve()  # catalog is object 1
+
+    pages_ref, page_refs = _add_pages(pdf, titles=["Alpha", "Beta", "Gamma"])
+    outlines_ref = pdf.reserve()
+
+    page = page_refs[0]
+    entries = [
+        f"/Title (XYZ) /Dest [{page} 0 R /XYZ 108 702 0]",
+        f"/Title (XYZ null top) /Dest [{page} 0 R /XYZ 108 null 0]",
+        f"/Title (XYZ all null) /Dest [{page} 0 R /XYZ null null null]",
+        f"/Title (Fit) /Dest [{page} 0 R /Fit]",
+        f"/Title (FitH) /Dest [{page} 0 R /FitH 702]",
+        f"/Title (FitV) /Dest [{page} 0 R /FitV 108]",
+        f"/Title (FitR) /Dest [{page} 0 R /FitR 108 90 504 702]",
+        f"/Title (FitB) /Dest [{page} 0 R /FitB]",
+        f"/Title (FitBH) /Dest [{page} 0 R /FitBH 702]",
+        f"/Title (FitBV) /Dest [{page} 0 R /FitBV 108]",
+        f"/Title (no kind) /Dest [{page} 0 R]",
+        "/Title (no destination)",
+    ]
+    item_refs = _add_outline_items(pdf, outlines_ref, entries)
+
+    pdf.put(
+        outlines_ref,
+        f"<< /Type /Outlines /First {item_refs[0]} 0 R "
+        f"/Last {item_refs[-1]} 0 R /Count {len(item_refs)} >>",
+    )
+    _finish_catalog(pdf, pages_ref, outlines_ref)
+
+    return pdf.build()
+
+
+def build_destination_references() -> bytes:
+    """The four ways an outline item can reference a destination (12.3.2.3, 12.6.4.2)."""
+    pdf = PdfBuilder()
+    pdf.reserve()  # catalog is object 1
+
+    pages_ref, page_refs = _add_pages(pdf, titles=["Alpha", "Beta", "Gamma"])
+    target = page_refs[1]
+    dest_array = f"[{target} 0 R /XYZ 108 702 0]"
+
+    # a name-tree destination, reached by a byte string
+    name_tree_ref = pdf.add(f"<< /Names [(beta-string) {dest_array}] >>")
+    names_ref = pdf.add(f"<< /Dests {name_tree_ref} 0 R >>")
+
+    # a legacy catalog /Dests destination, reached by a name object, written as a
+    # destination dictionary rather than a bare array
+    dests_ref = pdf.add(f"<< /BetaName << /D {dest_array} >> >>")
+
+    goto_ref = pdf.add(f"<< /S /GoTo /D {dest_array} >>")
+    goto_named_ref = pdf.add("<< /S /GoTo /D (beta-string) >>")
+    remote_ref = pdf.add(f"<< /S /GoToR /F (other.pdf) /D {dest_array} >>")
+
+    outlines_ref = pdf.reserve()
+    entries = [
+        f"/Title (explicit) /Dest {dest_array}",
+        "/Title (named string) /Dest (beta-string)",
+        "/Title (named object) /Dest /BetaName",
+        f"/Title (goto action) /A {goto_ref} 0 R",
+        f"/Title (goto action named) /A {goto_named_ref} 0 R",
+        f"/Title (remote action) /A {remote_ref} 0 R",
+    ]
+    item_refs = _add_outline_items(pdf, outlines_ref, entries)
+
+    pdf.put(
+        outlines_ref,
+        f"<< /Type /Outlines /First {item_refs[0]} 0 R "
+        f"/Last {item_refs[-1]} 0 R /Count {len(item_refs)} >>",
+    )
+    _finish_catalog(
+        pdf,
+        pages_ref,
+        outlines_ref,
+        extra=f" /Names {names_ref} 0 R /Dests {dests_ref} 0 R",
+    )
+
+    return pdf.build()
+
+
+def build_rotated_pages() -> bytes:
+    """One page per /Rotate value, each with a bookmark on its own heading."""
+    pdf = PdfBuilder()
+    pdf.reserve()  # catalog is object 1
+
+    titles = ["Rotate0", "Rotate90", "Rotate180", "Rotate270"]
+    pages_ref, page_refs = _add_pages(pdf, titles=titles, rotations=[0, 90, 180, 270])
+
+    outlines_ref = pdf.reserve()
+    entries = [
+        f"/Title ({title}) /Dest [{ref} 0 R /XYZ {HEADING_X} "
+        f"{HEADING_BASELINE + HEADING_SIZE} 0]"
+        for title, ref in zip(titles, page_refs)
+    ]
+    item_refs = _add_outline_items(pdf, outlines_ref, entries)
+
+    pdf.put(
+        outlines_ref,
+        f"<< /Type /Outlines /First {item_refs[0]} 0 R "
+        f"/Last {item_refs[-1]} 0 R /Count {len(item_refs)} >>",
+    )
+    _finish_catalog(pdf, pages_ref, outlines_ref)
+
+    return pdf.build()
+
+
+def build_malformed_outline() -> bytes:
+    """Cycles, a missing title and a destination outside the page tree."""
+    pdf = PdfBuilder()
+    pdf.reserve()  # catalog is object 1
+
+    pages_ref, page_refs = _add_pages(pdf, titles=["Alpha", "Beta"])
+    outlines_ref = pdf.reserve()
+
+    # a page object that is deliberately not part of the page tree
+    orphan_ref = pdf.add(
+        f"<< /Type /Page /MediaBox [0 0 {PAGE_WIDTH} {PAGE_HEIGHT}] >>"
+    )
+
+    first_ref = pdf.reserve()
+    second_ref = pdf.reserve()
+    third_ref = pdf.reserve()
+    child_ref = pdf.reserve()
+
+    # /Next points back at the head of the chain
+    pdf.put(
+        first_ref,
+        f"<< /Title (looping next) /Parent {outlines_ref} 0 R "
+        f"/Dest [{page_refs[0]} 0 R /XYZ 108 702 0] "
+        f"/First {child_ref} 0 R /Last {child_ref} 0 R /Count 1 "
+        f"/Next {second_ref} 0 R >>",
+    )
+    # a child whose /First points back at its own parent
+    pdf.put(
+        child_ref,
+        f"<< /Title (looping child) /Parent {first_ref} 0 R "
+        f"/First {first_ref} 0 R /Last {first_ref} 0 R /Count 1 >>",
+    )
+    # no /Title at all
+    pdf.put(
+        second_ref,
+        f"<< /Parent {outlines_ref} 0 R /Prev {first_ref} 0 R "
+        f"/Dest [{page_refs[1]} 0 R /FitH 702] /Next {third_ref} 0 R >>",
+    )
+    # a destination page that is not reachable from the page tree
+    pdf.put(
+        third_ref,
+        f"<< /Title (dangling page) /Parent {outlines_ref} 0 R "
+        f"/Prev {second_ref} 0 R /Dest [{orphan_ref} 0 R /XYZ 108 702 0] "
+        f"/Next {first_ref} 0 R >>",
+    )
+
+    pdf.put(
+        outlines_ref,
+        f"<< /Type /Outlines /First {first_ref} 0 R /Last {third_ref} 0 R /Count 3 >>",
+    )
+    _finish_catalog(pdf, pages_ref, outlines_ref)
+
+    return pdf.build()

--- a/tests/test_regression_parse.py
+++ b/tests/test_regression_parse.py
@@ -1175,7 +1175,10 @@ def test_table_of_contents_resolves_named_goto_destinations():
     assert introduction.point is not None
     assert abs(introduction.point.x - 108.0) < 1e-3
     assert abs(introduction.point.y - 490.534) < 1e-3
-    assert (introduction.page_size.width, introduction.page_size.height) == (612.0, 792.0)
+    assert (introduction.page_size.width, introduction.page_size.height) == (
+        612.0,
+        792.0,
+    )
 
     assert entries["Model Architecture"].destination is not None
     assert entries["Model Architecture"].destination.page_no == 3
@@ -1251,7 +1254,13 @@ def test_outline_destination_references():
     pdf_doc, toc = _outline(build_destination_references())
     entries = _by_title(toc)
 
-    for title in ["explicit", "named string", "named object", "goto action", "goto action named"]:
+    for title in [
+        "explicit",
+        "named string",
+        "named object",
+        "goto action",
+        "goto action named",
+    ]:
         dest = entries[title].destination
         assert dest is not None, f"'{title}' should resolve to a destination"
         assert dest.page_no == 2, f"'{title}' should target page 2"

--- a/tests/test_regression_parse.py
+++ b/tests/test_regression_parse.py
@@ -8,8 +8,10 @@ from collections import Counter
 from io import BytesIO
 from typing import Dict, List, Union
 
+from docling_core.types.doc.base import CoordOrigin
 from docling_core.types.doc.page import (
     BitmapResource,
+    PdfDestinationKind,
     PdfHyperlink,
     PdfPageBoundaryType,
     PdfShape,
@@ -27,6 +29,7 @@ from docling_parse.pdf_parser import (
     ContentLevel,
     DecodeConfig,
     DoclingPdfParser,
+    DoclingThreadedPdfParser,
     PdfDocument,
 )
 from tests.constants import PARSER_PAGE_RESTRICTIONS, SAMPLE_PDF
@@ -39,6 +42,12 @@ from tests.groundtruth_io import (
     read_groundtruth_text,
     resolve_groundtruth_path,
     write_groundtruth_text,
+)
+from tests.outline_fixtures import (
+    build_destination_kinds,
+    build_destination_references,
+    build_malformed_outline,
+    build_rotated_pages,
 )
 
 
@@ -1075,20 +1084,36 @@ def verify_annotations_recursive(true_annots, pred_annots):
         assert True  # Other types pass
 
 
+TOC_PDF = "tests/data/regression/table_of_contents_01.pdf"
+
+
+def _outline(
+    source: Union[str, bytes],
+) -> tuple[PdfDocument, PdfTableOfContents]:
+    """Load a document and return it together with its (non-empty) outline root.
+
+    `bytes` come from tests.outline_fixtures, which builds its PDFs in memory
+    because tests/data is a pinned Hugging Face snapshot, not repository content.
+    """
+    path_or_stream = BytesIO(source) if isinstance(source, bytes) else source
+
+    pdf_doc = DoclingPdfParser(loglevel="fatal").load(
+        path_or_stream=path_or_stream, lazy=True
+    )
+    toc = pdf_doc.get_table_of_contents()
+    assert toc is not None, "the document should have an outline"
+    return pdf_doc, toc
+
+
+def _by_title(toc: PdfTableOfContents) -> Dict[str, PdfTableOfContents]:
+    return {entry.text: entry for _, entry in toc.iterate()}
+
+
 def test_table_of_contents():
     """Test table of contents extraction from PDF documents."""
-    parser = DoclingPdfParser(loglevel="fatal")
+    pdf_doc, toc = _outline(TOC_PDF)
 
-    # Test with a PDF that has a TOC
-    pdf_doc = parser.load(
-        path_or_stream="tests/data/regression/table_of_contents_01.pdf", lazy=True
-    )
-
-    # Test get_table_of_contents() method
-    toc = pdf_doc.get_table_of_contents()
-    assert toc is not None, "TOC should not be None for table_of_contents_01.pdf"
     assert toc.text == "<root>", "Root TOC entry should have text '<root>'"
-    assert toc.children is not None, "Root TOC should have children"
     assert len(toc.children) > 0, "Root TOC should have at least one child"
 
     # Verify expected top-level entries exist
@@ -1104,9 +1129,6 @@ def test_table_of_contents():
         (child for child in toc.children if child.text == "Model Architecture"), None
     )
     assert model_arch_entry is not None, "Should find 'Model Architecture' entry"
-    assert model_arch_entry.children is not None, (
-        "'Model Architecture' should have children"
-    )
     assert len(model_arch_entry.children) >= 2, (
         "'Model Architecture' should have at least 2 children"
     )
@@ -1117,44 +1139,216 @@ def test_table_of_contents():
         "Should contain 'Mixture-of-Expert models' nested entry"
     )
 
+    # iterate() derives the level from the depth in the tree
+    levels = {entry.text: level for level, entry in toc.iterate()}
+    assert levels["Introduction"] == 0, "Top-level entries should be at level 0"
+    assert levels["Dense Models"] == 1, "Nested entries should be at level 1"
+
     # Test caching - calling again should return same instance
     toc2 = pdf_doc.get_table_of_contents()
     assert toc is toc2, "get_table_of_contents should return cached instance"
 
-    # Test get_annotations().table_of_contents
+    # get_annotations() exposes the very same tree
     annotations = pdf_doc.get_annotations()
     assert annotations is not None, "Annotations should not be None"
-    assert annotations.table_of_contents is not None, (
-        "annotations.table_of_contents should not be None"
+    assert annotations.table_of_contents is toc, (
+        "get_table_of_contents() and get_annotations() should return one tree"
     )
-    assert len(annotations.table_of_contents) > 0, (
-        "annotations.table_of_contents should have entries"
-    )
-
-    # Verify PdfTocEntry structure
-    first_entry = annotations.table_of_contents[0]
-    assert first_entry.title == "Introduction", "First entry should be 'Introduction'"
-    assert first_entry.level == 0, "Top-level entries should have level 0"
-
-    # Find entry with children and verify nested structure
-    model_arch_annot = next(
-        (e for e in annotations.table_of_contents if e.title == "Model Architecture"),
-        None,
-    )
-    assert model_arch_annot is not None, (
-        "Should find 'Model Architecture' in annotations TOC"
-    )
-    assert model_arch_annot.children is not None, (
-        "'Model Architecture' annotation should have children"
-    )
-    assert len(model_arch_annot.children) >= 2, (
-        "'Model Architecture' annotation should have at least 2 children"
-    )
-
-    for child in model_arch_annot.children:
-        assert child.level == 1, "Children of top-level entry should have level 1"
 
     pdf_doc.unload()
+
+
+def test_table_of_contents_resolves_named_goto_destinations():
+    """The outline of table_of_contents_01.pdf reaches its pages via /A /GoTo names."""
+    pdf_doc, toc = _outline(TOC_PDF)
+
+    number_of_pages = pdf_doc.number_of_pages()
+    entries = _by_title(toc)
+
+    # 'Introduction' is /A << /S /GoTo /D (section.1) >>, resolved through the
+    # /Names /Dests name tree to [<page 2> /XYZ 108 490.534 null]
+    introduction = entries["Introduction"].destination
+    assert introduction is not None, "'Introduction' should resolve to a destination"
+    assert introduction.page_no == 2
+    assert introduction.kind == PdfDestinationKind.XYZ
+    assert introduction.coord_origin == CoordOrigin.BOTTOMLEFT
+    assert introduction.point is not None
+    assert abs(introduction.point.x - 108.0) < 1e-3
+    assert abs(introduction.point.y - 490.534) < 1e-3
+    assert (introduction.page_size.width, introduction.page_size.height) == (612.0, 792.0)
+
+    assert entries["Model Architecture"].destination is not None
+    assert entries["Model Architecture"].destination.page_no == 3
+
+    # Every resolved destination lands on a real page, at a position on that page.
+    resolved = 0
+    for _, entry in toc.iterate():
+        dest = entry.destination
+        if dest is None:
+            # this fixture is a 4-page excerpt, so later sections target pages that
+            # were cut away and are no longer part of the page tree
+            continue
+        resolved += 1
+        assert 1 <= dest.page_no <= number_of_pages
+        assert dest.point is not None
+        assert 0.0 <= dest.point.y <= dest.page_size.height
+
+    assert resolved > 0, "at least some destinations should resolve"
+
+    pdf_doc.unload()
+
+
+def test_outline_destination_kinds():
+    """Every explicit-destination syntax of ISO 32000-1, table 151, is understood."""
+    pdf_doc, toc = _outline(build_destination_kinds())
+    entries = _by_title(toc)
+
+    expected_kinds = {
+        "XYZ": PdfDestinationKind.XYZ,
+        "XYZ null top": PdfDestinationKind.XYZ,
+        "XYZ all null": PdfDestinationKind.XYZ,
+        "Fit": PdfDestinationKind.FIT,
+        "FitH": PdfDestinationKind.FIT_H,
+        "FitV": PdfDestinationKind.FIT_V,
+        "FitR": PdfDestinationKind.FIT_R,
+        "FitB": PdfDestinationKind.FIT_B,
+        "FitBH": PdfDestinationKind.FIT_BH,
+        "FitBV": PdfDestinationKind.FIT_BV,
+        "no kind": PdfDestinationKind.UNKNOWN,
+    }
+    for title, kind in expected_kinds.items():
+        dest = entries[title].destination
+        assert dest is not None, f"'{title}' should resolve to a destination"
+        assert dest.kind == kind, f"'{title}' should have kind {kind}"
+        assert dest.page_no == 1, f"'{title}' should target the first page"
+
+    # only the syntaxes that carry a vertical position produce a point
+    with_point = {"XYZ", "FitH", "FitR", "FitBH"}
+    for title in expected_kinds:
+        dest = entries[title].destination
+        assert dest is not None
+        assert (dest.point is not None) == (title in with_point), (
+            f"'{title}' should {'' if title in with_point else 'not '}carry a point"
+        )
+
+    xyz = entries["XYZ"].destination
+    assert xyz is not None and xyz.point is not None
+    assert abs(xyz.point.x - 108.0) < 1e-3
+    assert abs(xyz.point.y - 702.0) < 1e-3
+
+    # a null coordinate means "retain the current value", so it is not a position
+    assert entries["XYZ null top"].destination.point is None
+    assert entries["XYZ all null"].destination.point is None
+
+    # an item without /Dest and without /A has nowhere to go
+    assert entries["no destination"].destination is None
+
+    pdf_doc.unload()
+
+
+def test_outline_destination_references():
+    """Explicit, named and action destinations all reach the same page."""
+    pdf_doc, toc = _outline(build_destination_references())
+    entries = _by_title(toc)
+
+    for title in ["explicit", "named string", "named object", "goto action", "goto action named"]:
+        dest = entries[title].destination
+        assert dest is not None, f"'{title}' should resolve to a destination"
+        assert dest.page_no == 2, f"'{title}' should target page 2"
+        assert dest.point is not None
+        assert abs(dest.point.y - 702.0) < 1e-3
+
+    # /GoToR points into another document, so it has no page in this one
+    assert entries["remote action"].destination is None, (
+        "a remote destination should not resolve to a page of this document"
+    )
+
+    pdf_doc.unload()
+
+
+def test_outline_destinations_follow_page_rotation():
+    """A destination lands on its heading whatever the page's /Rotate angle."""
+    pdf_doc, toc = _outline(build_rotated_pages())
+    entries = _by_title(toc)
+
+    for page_no, title in enumerate(
+        ["Rotate0", "Rotate90", "Rotate180", "Rotate270"], start=1
+    ):
+        dest = entries[title].destination
+        assert dest is not None, f"'{title}' should resolve to a destination"
+        assert dest.page_no == page_no
+        assert dest.point is not None
+
+        page = pdf_doc.get_page(page_no)
+        cells = [c for c in page.word_cells if c.text.strip() == title]
+        assert len(cells) == 1, f"page {page_no} should hold exactly one '{title}'"
+
+        bbox = cells[0].rect.to_bounding_box()
+        assert bbox.coord_origin == dest.coord_origin, (
+            "the destination and the cells must share a coordinate origin"
+        )
+
+        # The destination points at the top-left of the heading, so it sits within a
+        # line's height of the decoded cell. Without the /Rotate transform it would
+        # be most of a page away on three of these four pages.
+        eps = 20.0
+        assert bbox.l - eps <= dest.point.x <= bbox.r + eps, (
+            f"'{title}' destination x={dest.point.x} is not near the cell {bbox}"
+        )
+        assert bbox.b - eps <= dest.point.y <= bbox.t + eps, (
+            f"'{title}' destination y={dest.point.y} is not near the cell {bbox}"
+        )
+
+        # the rotated page is reported upright, so the size follows the rotation
+        assert (dest.page_size.width, dest.page_size.height) == (
+            (792.0, 612.0) if page_no in (2, 4) else (612.0, 792.0)
+        )
+
+    pdf_doc.unload()
+
+
+def test_outline_survives_malformed_entries():
+    """Cycles, missing titles and dangling pages degrade instead of throwing."""
+    pdf_doc, toc = _outline(build_malformed_outline())
+
+    entries = list(toc.iterate())
+    assert 0 < len(entries) < 100, "a cyclic outline must not walk forever"
+
+    titles = [entry.text for _, entry in entries]
+    assert "looping next" in titles
+    assert "looping child" in titles
+    assert "dangling page" in titles
+    assert "" in titles, "an item without /Title should keep an empty title"
+
+    by_title = _by_title(toc)
+
+    # a /FitH destination on a real page still resolves
+    untitled = by_title[""].destination
+    assert untitled is not None
+    assert untitled.page_no == 2
+    assert untitled.kind == PdfDestinationKind.FIT_H
+
+    # a destination page that is not in the page tree cannot be numbered
+    assert by_title["dangling page"].destination is None
+
+    pdf_doc.unload()
+
+
+def test_threaded_parser_annotations_match_single_threaded():
+    """The threaded parser reads the same outline, without decoding a page."""
+    pdf_doc, toc = _outline(TOC_PDF)
+    expected = toc.export_to_dict()
+    pdf_doc.unload()
+
+    threaded = DoclingThreadedPdfParser()
+    doc_key = threaded.load(path_or_stream=TOC_PDF)
+    try:
+        annotations = threaded.get_annotations(doc_key)
+        assert annotations is not None
+        assert annotations.table_of_contents is not None
+        assert annotations.table_of_contents.export_to_dict() == expected
+    finally:
+        threaded.unload_all()
 
 
 def test_table_of_contents_none_for_pdf_without_toc():
@@ -1169,9 +1363,9 @@ def test_table_of_contents_none_for_pdf_without_toc():
 
     annotations = pdf_doc.get_annotations()
     assert annotations is not None, "Annotations should not be None even without TOC"
-    assert (
-        annotations.table_of_contents is None or len(annotations.table_of_contents) == 0
-    ), "table_of_contents should be None or empty for PDF without TOC"
+    assert annotations.table_of_contents is None, (
+        "table_of_contents should be None for PDF without TOC"
+    )
 
     pdf_doc.unload()
 
@@ -1209,10 +1403,7 @@ def test_annotations_match_groundtruth():
             "table_of_contents": (
                 None
                 if pred_annotations.table_of_contents is None
-                else [
-                    entry.model_dump(exclude_none=True)
-                    for entry in pred_annotations.table_of_contents
-                ]
+                else pred_annotations.table_of_contents.export_to_dict()
             ),
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -89,9 +89,9 @@ name = "build"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "os_name == 'nt'" },
-    { name = "packaging" },
-    { name = "pyproject-hooks" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and os_name == 'nt'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pyproject-hooks", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/18/94eaffda7b329535d91f00fe605ab1f1e5cd68b2074d03f255c7d250687d/build-1.4.0.tar.gz", hash = "sha256:f1b91b925aa322be454f8330c6fb48b465da993d1e7e7e6fa35027ec49f3c936", size = 50054, upload-time = "2026-01-08T16:41:47.696Z" }
 wheels = [
@@ -295,15 +295,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "bashlex" },
-    { name = "bracex" },
-    { name = "certifi" },
-    { name = "dependency-groups" },
-    { name = "filelock" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "tomli" },
-    { name = "typing-extensions" },
+    { name = "bashlex", marker = "python_full_version < '3.11'" },
+    { name = "bracex", marker = "python_full_version < '3.11'" },
+    { name = "certifi", marker = "python_full_version < '3.11'" },
+    { name = "dependency-groups", marker = "python_full_version < '3.11'" },
+    { name = "filelock", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "platformdirs", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/f5/2c06c8229e291e121cb26ed2efa1ba5d89053a93631d8f1d795f2dacabb8/cibuildwheel-2.23.3.tar.gz", hash = "sha256:d85dd15b7eb81711900d8129e67efb32b12f99cc00fc271ab060fa6270c38397", size = 295383, upload-time = "2025-04-26T10:41:28.258Z" }
 wheels = [
@@ -319,18 +319,18 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "bashlex" },
-    { name = "bracex" },
-    { name = "build" },
-    { name = "certifi" },
-    { name = "dependency-groups" },
-    { name = "filelock" },
-    { name = "humanize" },
-    { name = "packaging" },
-    { name = "patchelf", marker = "(platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "platformdirs" },
-    { name = "pyelftools" },
-    { name = "wheel" },
+    { name = "bashlex", marker = "python_full_version >= '3.11'" },
+    { name = "bracex", marker = "python_full_version >= '3.11'" },
+    { name = "build", marker = "python_full_version >= '3.11'" },
+    { name = "certifi", marker = "python_full_version >= '3.11'" },
+    { name = "dependency-groups", marker = "python_full_version >= '3.11'" },
+    { name = "filelock", marker = "python_full_version >= '3.11'" },
+    { name = "humanize", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "patchelf", marker = "(python_full_version >= '3.11' and platform_machine == 'aarch64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'darwin') or (python_full_version >= '3.11' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.11' and platform_machine == 'arm64' and sys_platform == 'linux') or (python_full_version >= '3.11' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "platformdirs", marker = "python_full_version >= '3.11'" },
+    { name = "pyelftools", marker = "python_full_version >= '3.11'" },
+    { name = "wheel", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/8c/61b0cca8be7eef6af32b0c0e62f78dc8c91572ea8870bc6c4d061f259832/cibuildwheel-3.3.1.tar.gz", hash = "sha256:ae6eafe6f7ed3bab38919e08bf3eb92085f6387c5f7a746b40cc4775a8462f9a", size = 358374, upload-time = "2026-01-05T19:58:17.606Z" }
 wheels = [
@@ -404,7 +404,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -475,7 +475,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -678,8 +678,8 @@ wheels = [
 
 [[package]]
 name = "docling-core"
-version = "2.85.0"
-source = { registry = "https://pypi.org/simple" }
+version = "2.94.1"
+source = { git = "https://github.com/docling-project/docling-core.git?branch=feat%2Fextending-table-of-contents#3aab5e5d52ffd8a0d942b01b5c18930d6630408e" }
 dependencies = [
     { name = "defusedxml" },
     { name = "doclang" },
@@ -694,10 +694,6 @@ dependencies = [
     { name = "tabulate" },
     { name = "typer" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/02/f1cd4003d06240aa229acb5074b1dc5bec227580fd82a2dbe40b1cbefc80/docling_core-2.85.0.tar.gz", hash = "sha256:c4f49148ad8ac7cbe58d85cce90d2b3b0741d2b73cbfabb332e2df9e9583b3b4", size = 323268, upload-time = "2026-06-25T16:16:32.726Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/c9/fe3bca4d1b431a32a7cbbe7afebfa5dae5a8bd0eb6ca4e132473f64239a1/docling_core-2.85.0-py3-none-any.whl", hash = "sha256:7c9e7e77966b91a61bffebb74f043fbecebe6e6e38bcf3790f05bddd5a4e306f", size = 260749, upload-time = "2026-06-25T16:16:30.988Z" },
 ]
 
 [[package]]
@@ -744,7 +740,7 @@ perf = [
 
 [package.metadata]
 requires-dist = [
-    { name = "docling-core", specifier = ">=2.85.0,<3.0.0" },
+    { name = "docling-core", git = "https://github.com/docling-project/docling-core.git?branch=feat%2Fextending-table-of-contents" },
     { name = "pillow", specifier = ">=10.0.0,<13.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=305" },
@@ -804,7 +800,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1918,6 +1914,10 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/a7/8c4f86c78ec03db954d05fd9c57a114cc3a172a2d3e4a8b949cd5ff89471/patchelf-0.17.2.4-py3-none-macosx_10_9_universal2.whl", hash = "sha256:343bb1b94e959f9070ca9607453b04390e36bbaa33c88640b989cefad0aa049e", size = 184436, upload-time = "2025-07-23T21:16:20.578Z" },
     { url = "https://files.pythonhosted.org/packages/7e/19/f7821ef31aab01fa7dc8ebe697ece88ec4f7a0fdd3155dab2dfee4b00e5c/patchelf-0.17.2.4-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:d9b35ebfada70c02679ad036407d9724ffe1255122ba4ac5e4be5868618a5689", size = 482846, upload-time = "2025-07-23T21:16:23.73Z" },
     { url = "https://files.pythonhosted.org/packages/d1/50/107fea848ecfd851d473b079cab79107487d72c4c3cdb25b9d2603a24ca2/patchelf-0.17.2.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:2931a1b5b85f3549661898af7bf746afbda7903c7c9a967cfc998a3563f84fad", size = 477811, upload-time = "2025-07-23T21:16:25.145Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a9/a9a2103e159fd65bffbc21ecc5c8c36e44eb34fe53b4ef85fb6d08c2a635/patchelf-0.17.2.4-py3-none-manylinux2014_armv7l.manylinux_2_17_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:ae44cb3c857d50f54b99e5697aa978726ada33a8a6129d4b8b7ffd28b996652d", size = 431226, upload-time = "2025-07-23T21:16:26.765Z" },
+    { url = "https://files.pythonhosted.org/packages/87/93/897d612f6df7cfd987bdf668425127efeff8d8e4ad8bfbab1c69d2a0d861/patchelf-0.17.2.4-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:680a266a70f60a7a4f4c448482c5bdba80cc8e6bb155a49dcc24238ba49927b0", size = 540276, upload-time = "2025-07-23T21:16:27.983Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b8/2b92d11533482bac9ee989081d6880845287751b5f528adbd6bb27667fbd/patchelf-0.17.2.4-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.musllinux_1_1_s390x.whl", hash = "sha256:d842b51f0401460f3b1f3a3a67d2c266a8f515a5adfbfa6e7b656cb3ac2ed8bc", size = 596632, upload-time = "2025-07-23T21:16:29.253Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/975d4bdb418f942b53e6187b95bd9e0d5e0488b7bc214685a1e43e2c2751/patchelf-0.17.2.4-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:7076d9e127230982e20a81a6e2358d3343004667ba510d9f822d4fdee29b0d71", size = 508281, upload-time = "2025-07-23T21:16:30.865Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The document outline now carries **where each bookmark points** — a 1-based page number and,
  where the PDF specifies one, a position on that page in the same coordinate frame as the page's
  cells. Destination resolution previously existed only as commented-out code in `annots.h`, so
  every entry came out as `{title, level, children}` and `PdfTocEntry.page` was always `None`.

  Fixes the root cause of [docling#4162](https://github.com/docling-project/docling/issues/4162),
  which [docling#4169](https://github.com/docling-project/docling/pull/4169) currently works
  around by opening a second, throwaway PDFium document just to read bookmarks.

  Requires [docling-core v2.95.0](https://github.com/docling-project/docling-core/pull/747)
  (`PdfDestination`, `PdfTableOfContents.destination`).

  ## Changes

  - **`src/parse/qpdf/outline.h`** (new) — resolves destinations with qpdf's
    `QPDFOutlineDocumentHelper`: explicit, named (catalog `/Dests` *and* `/Names /Dests` name
    tree) and `/A /GoTo` actions. Replaces the hand-rolled walk, whose `unparse()`-based loop
    detection was expensive *and* not an identity test.
  - **Coordinates** run through the same `page_item<PAGE_DIMENSION>` transform that
    `rotate_contents()` applies to cells, so a destination and a heading are directly comparable
    on rotated pages. No new geometry maths; measured once per targeted page.
  - **One ToC model.** `PdfTocEntry` is deleted; `PdfAnnotations.table_of_contents` is now
    `PdfTableOfContents | None`, and `get_table_of_contents()` returns the same object.
  - **`DoclingThreadedPdfParser.get_annotations()`** — the threaded backend no longer needs to
    load a second document to read an outline.

  ## Breaking

  - `PdfTocEntry` removed (never populated; not re-exported from `__init__`).
  - `PdfAnnotations.table_of_contents` retyped to `PdfTableOfContents | None`.
  - `docling-core>=2.95.0`.

  ## Tests

  `tests/outline_fixtures.py` builds four PDFs in memory (`tests/data` is a pinned HF snapshot,
  not repo content): all eight destination syntaxes, the four reference forms, `/Rotate`
  0/90/180/270, and cyclic/malformed outlines. The rotation test asserts the destination lands on
  the decoded heading cell — the PDFium path would fail it.