### PR TITLE
fix: expose bookmark target page indices

### DIFF
--- a/app/pybind_parse.cpp
+++ b/app/pybind_parse.cpp
@@ -1089,6 +1089,12 @@ PYBIND11_MODULE(pdf_parsers, m) {
 
     Returns:
         int: Number of pages in the loaded document.)")
+    .def("get_table_of_contents",
+         [](docling::docling_threaded_parser& self, const std::string& key) {
+           return self.get_table_of_contents(key);
+         },
+         pybind11::arg("key"),
+         "Retrieve the document outline, including zero-based target page indices.")
     .def("scheduled_number_of_pages",
          [](docling::docling_threaded_parser& self, const std::string& key) -> int {
            return self.scheduled_number_of_pages(key);
@@ -1308,6 +1314,12 @@ PYBIND11_MODULE(pdf_parsers, m) {
            return self.number_of_pages(key);
          },
          pybind11::arg("key"))
+    .def("get_table_of_contents",
+         [](docling::docling_threaded_renderer& self, const std::string& key) {
+           return self.get_table_of_contents(key);
+         },
+         pybind11::arg("key"),
+         "Retrieve the document outline, including zero-based target page indices.")
     .def("scheduled_number_of_pages",
          [](docling::docling_threaded_renderer& self, const std::string& key) -> int {
            return self.scheduled_number_of_pages(key);

--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -95,6 +95,13 @@ class PdfTocEntry(BaseModel):
     children: List["PdfTocEntry"] | None = None
 
 
+class PdfTableOfContentsWithPage(PdfTableOfContents):
+    """A table-of-contents entry with its optional zero-based target page."""
+
+    page: int | None = None
+    children: List["PdfTableOfContentsWithPage"] = []
+
+
 class PdfAnnotations(BaseModel):
     """PDF document annotations including form fields, language, metadata, and table of contents.
 
@@ -711,7 +718,7 @@ class PdfDocument:
         ] = {}
         # Per page: the content config the cached page-decoder satisfies.
         self._decoded_content_configs: Dict[int, ContentConfig] = {}
-        self._toc: PdfTableOfContents | None = None
+        self._toc: PdfTableOfContentsWithPage | None = None
         self._meta: PdfMetaData | None = None
         self._annotations: PdfAnnotations | None = None
 
@@ -856,7 +863,7 @@ class PdfDocument:
             if self._toc is not None:
                 return self._toc
 
-            self._toc = PdfTableOfContents(text="<root>")
+            self._toc = PdfTableOfContentsWithPage(text="<root>")
             self._toc.children = self._to_table_of_contents(toc=toc)
 
             return self._toc
@@ -874,11 +881,15 @@ class PdfDocument:
                 self.get_page(page_no + 1, content_config=content_config),
             )
 
-    def _to_table_of_contents(self, toc: dict) -> List[PdfTableOfContents]:
+    def _to_table_of_contents(
+        self, toc: list[dict[str, Any]]
+    ) -> List[PdfTableOfContentsWithPage]:
 
-        result = []
+        result: List[PdfTableOfContentsWithPage] = []
         for item in toc:
-            subtoc = PdfTableOfContents(text=item["title"])
+            subtoc = PdfTableOfContentsWithPage(
+                text=item["title"], page=item.get("page")
+            )
             if "children" in item:
                 subtoc.children = self._to_table_of_contents(toc=item["children"])
             result.append(subtoc)
@@ -1623,6 +1634,32 @@ class DoclingThreadedPdfParser:
         if doc_key not in self._scheduled_page_counts:
             raise ValueError(f"Document key not loaded: {doc_key}")
         return self._scheduled_page_counts[doc_key]
+
+    def get_table_of_contents(self, doc_key: str) -> List[PdfTocEntry] | None:
+        """Return the page-aware table of contents for a loaded document."""
+        if doc_key not in self._page_counts:
+            raise ValueError(f"Document key not loaded: {doc_key}")
+
+        toc = self._parser.get_table_of_contents(key=doc_key)
+        if toc is None:
+            return None
+        return self._to_pdf_toc_entry(toc)
+
+    @staticmethod
+    def _to_pdf_toc_entry(toc_list: list[dict[str, Any]]) -> List[PdfTocEntry]:
+        result: List[PdfTocEntry] = []
+        for item in toc_list:
+            entry = PdfTocEntry(
+                title=item.get("title", ""),
+                level=item.get("level"),
+                page=item.get("page"),
+            )
+            if item.get("children"):
+                entry.children = DoclingThreadedPdfParser._to_pdf_toc_entry(
+                    item["children"]
+                )
+            result.append(entry)
+        return result
 
     def unload(self, doc_key: str) -> bool:
         """Unload one document after threaded processing has completed."""

--- a/src/parse/qpdf/annots.h
+++ b/src/parse/qpdf/annots.h
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <iostream>
 #include <iomanip>
+#include <optional>
 #include <unordered_set>
 
 #include <nlohmann/json.hpp>
@@ -15,6 +16,47 @@
 
 namespace pdflib
 {
+  std::optional<int> get_toc_page_number(QPDF& pdf_obj, QPDFObjectHandle node)
+  {
+    QPDFObjectHandle destination;
+
+    if(node.hasKey("/Dest"))
+      {
+        destination = node.getKey("/Dest");
+      }
+    else if(node.hasKey("/A"))
+      {
+        QPDFObjectHandle action = node.getKey("/A");
+        if(action.isDictionary() and action.getKey("/S").isName() and
+           action.getKey("/S").getName() == "/GoTo" and action.hasKey("/D"))
+          {
+            destination = action.getKey("/D");
+          }
+      }
+
+    // Named destinations need name-tree resolution. Keep them page-less so
+    // unresolved destinations retain the existing API behaviour.
+    if(not destination.isArray() or destination.getArrayNItems() == 0)
+      {
+        return std::nullopt;
+      }
+
+    QPDFObjectHandle page = destination.getArrayItem(0);
+    if(not page.isIndirect())
+      {
+        return std::nullopt;
+      }
+
+    try
+      {
+        return pdf_obj.findPage(page);
+      }
+    catch(const std::exception&)
+      {
+        return std::nullopt;
+      }
+  }
+
   // FIXME: add a begin time to cap the max time spent in this routine
   nlohmann::json extract_annots_in_json(QPDFObjectHandle obj,
                                         std::unordered_set<std::string> prev_objs={},
@@ -225,18 +267,10 @@ namespace pdflib
         //toc_entry["link"] = to_json(node.getKey("/A"), {}, 0, 8);
       }
     
-    // Extract destination
-    if(node.hasKey("/Dest"))
+    // Extract destination page (zero-based), when it is directly resolvable.
+    if(auto page = get_toc_page_number(pdf_obj, node))
       {
-	//LOG_S(INFO) << "found a destination!";
-	
-        // Depending on the type of destination, extract its value
-	//auto dest = node.getKey("/Dest");
-        //toc_entry["destination"] = to_json(dest, {}, 0, 8);
-      }
-    else
-      {
-        //toc_entry["destination"] = "No destination";
+	 toc_entry["page"] = *page;
       }
 
     // Extract children

--- a/src/pybind/docling_threaded_base.h
+++ b/src/pybind/docling_threaded_base.h
@@ -69,6 +69,7 @@ namespace docling
 
     int number_of_pages(std::string key) const;
     int scheduled_number_of_pages(std::string key) const;
+    nlohmann::json get_table_of_contents(std::string key) const;
 
     bool unload_document(std::string key);
     void unload_all_documents();
@@ -123,6 +124,19 @@ namespace docling
   // ---------------------------------------------------------------------------
   // Implementation
   // ---------------------------------------------------------------------------
+
+  template<typename Derived, typename ResultType>
+  nlohmann::json docling_threaded_base<Derived, ResultType>::get_table_of_contents(
+      std::string key) const
+  {
+    auto itr = key2doc.find(key);
+    if(itr == key2doc.end())
+      {
+        return nlohmann::json::value_t::null;
+      }
+
+    return itr->second->get_table_of_contents();
+  }
 
   template<typename Derived, typename ResultType>
   docling_threaded_base<Derived, ResultType>::docling_threaded_base(

--- a/tests/test_regression_parse.py
+++ b/tests/test_regression_parse.py
@@ -1135,6 +1135,8 @@ def test_table_of_contents():
     first_entry = annotations.table_of_contents[0]
     assert first_entry.title == "Introduction", "First entry should be 'Introduction'"
     assert first_entry.level == 0, "Top-level entries should have level 0"
+    assert first_entry.page is not None, "Bookmark destination page should be exposed"
+    assert first_entry.page >= 0, "Bookmark destination page should be zero-based"
 
     # Find entry with children and verify nested structure
     model_arch_annot = next(
@@ -1153,6 +1155,10 @@ def test_table_of_contents():
 
     for child in model_arch_annot.children:
         assert child.level == 1, "Children of top-level entry should have level 1"
+
+    assert all(child.page is not None for child in model_arch_annot.children), (
+        "Nested bookmark destination pages should be exposed"
+    )
 
     pdf_doc.unload()
 

--- a/tests/test_unit_table_of_contents.py
+++ b/tests/test_unit_table_of_contents.py
@@ -1,0 +1,53 @@
+"""Focused tests for page-aware PDF outlines."""
+
+from pathlib import Path
+
+import pytest
+
+from docling_parse.pdf_parser import DoclingPdfParser, DoclingThreadedPdfParser
+
+
+def _make_outlined_pdf(path: Path) -> None:
+    canvas_module = pytest.importorskip("reportlab.pdfgen.canvas")
+    canvas = canvas_module.Canvas(str(path))
+    for key, title, level in (("page1", "Chapter 1", 0), ("page2", "Section 1.1", 1)):
+        canvas.bookmarkPage(key)
+        canvas.addOutlineEntry(title, key, level=level)
+        canvas.drawString(72, 720, title)
+        canvas.showPage()
+    canvas.save()
+
+
+def test_sequential_outline_exposes_nested_target_pages(tmp_path: Path) -> None:
+    path = tmp_path / "outlined.pdf"
+    _make_outlined_pdf(path)
+
+    document = DoclingPdfParser(loglevel="fatal").load(path, lazy=True)
+    try:
+        toc = document.get_table_of_contents()
+        assert toc is not None
+        assert [(entry.text, entry.page) for entry in toc.children] == [
+            ("Chapter 1", 0)
+        ]
+        assert [(entry.text, entry.page) for entry in toc.children[0].children] == [
+            ("Section 1.1", 1)
+        ]
+    finally:
+        document.unload()
+
+
+def test_threaded_outline_matches_sequential_outline(tmp_path: Path) -> None:
+    path = tmp_path / "outlined.pdf"
+    _make_outlined_pdf(path)
+
+    parser = DoclingThreadedPdfParser()
+    key = parser.load(path)
+    try:
+        toc = parser.get_table_of_contents(key)
+        assert toc is not None
+        assert [(entry.title, entry.page, entry.level) for entry in toc] == [
+            ("Chapter 1", 0, 0),
+            ("Section 1.1", 1, 1),
+        ]
+    finally:
+        parser.unload(key)


### PR DESCRIPTION
## Summary

  Expose zero-based target page indices for PDF table-of-contents bookmarks.

  This allows consumers to constrain bookmark matching to the intended page and avoids unnecessary document-wide fuzzy
  matching.

  ## Changes

  - Resolve direct `/Dest` page destinations.
  - Resolve `/GoTo` action destinations.
  - Preserve page-less behavior for named or unresolved destinations.
  - Expose the ToC accessor on threaded parser and renderer bindings.
  - Add regression coverage for top-level and nested bookmark page indices.

  ## Validation

  - Ruff check passed.
  - Ruff formatting passed.
  - Focused unit tests passed: `6 passed`.
  - `git diff --check` passed.

  ## Issue

  Closes #340
