### PR TITLE
fix: answer shape geometry queries in the frame of the text cells

### DIFF
--- a/docling_parse/pdf_parser.py
+++ b/docling_parse/pdf_parser.py
@@ -1269,8 +1269,10 @@ class PageParseResult:
     ) -> bool:
         """Return whether visible page content intersects bbox.
 
-        bbox may use top-left or bottom-left coordinates. Native code expects
-        page coordinates with bottom-left origin as [left, bottom, right, top].
+        bbox may use top-left or bottom-left coordinates, in the frame of the
+        text cells: relative to the page boundary and rotated by /Rotate.
+        Native code expects page coordinates with bottom-left origin as
+        [left, bottom, right, top].
         """
         bbox_bl = bbox.to_bottom_left_origin(page_height=self.page_height)
         left = min(bbox_bl.l, bbox_bl.r)
@@ -1292,7 +1294,11 @@ class PageParseResult:
         vertical: bool = True,
         tolerance: float = 1e-3,
     ) -> List[BoundingBox]:
-        """Return visible horizontal and/or vertical stroked shape segments."""
+        """Return visible horizontal and/or vertical stroked shape segments.
+
+        Boxes are in the frame of the text cells: bottom-left origin, relative
+        to the page boundary and rotated by /Rotate.
+        """
         return [
             _to_bounding_box(tuple(bbox))
             for bbox in self._require_page_decoder().get_shape_lines(
@@ -1307,7 +1313,11 @@ class PageParseResult:
         *,
         tolerance: float = 0.0,
     ) -> List[BoundingBox]:
-        """Return bboxes of visible shapes connected by overlapping bboxes."""
+        """Return bboxes of visible shapes connected by overlapping bboxes.
+
+        Boxes are in the frame of the text cells: bottom-left origin, relative
+        to the page boundary and rotated by /Rotate.
+        """
         return [
             _to_bounding_box(tuple(bbox))
             for bbox in self._require_page_decoder().get_connected_shape_bounding_boxes(

--- a/src/parse/pdf_decoders/page.h
+++ b/src/parse/pdf_decoders/page.h
@@ -147,6 +147,10 @@ namespace pdflib
 
     void rotate_contents();
 
+    // Map a bbox from the raw content-stream space of the render instructions
+    // onto the frame of the sanitized page items (see page_frame_* below).
+    std::array<double, 4> to_page_frame(std::array<double, 4> bbox) const;
+
     bool can_reuse_sanitised_cells_for_line_cells(const decode_config& config) const;
 
     void sanitise_contents(std::string page_boundary);
@@ -211,6 +215,16 @@ namespace pdflib
     std::shared_ptr<pdf_resource<PAGE_FONTS>> acroform_fonts;
 
     pdf_render_instructions instructions;
+
+    // The render instructions stay in unrotated user space (the renderer
+    // orients its own canvas), while page_cells, page_shapes and page_images
+    // are rotated by rotate_contents() and moved to the page boundary by the
+    // dimension sanitator. Geometry queries that walk the instructions apply
+    // the same /Rotate and boundary origin, so their boxes land in the frame
+    // of the cells.
+    int page_frame_angle = 0;
+    std::pair<double, double> page_frame_delta = {0.0, 0.0};
+    std::pair<double, double> page_frame_origin = {0.0, 0.0};
 
     pdf_timings timings;
   };
@@ -557,7 +571,8 @@ namespace pdflib
             const std::array<double, 4> visible_shape_bbox =
               clipped_bbox(shape_bbox, instr.get_clip_state(), shape_visible);
 
-            if(shape_visible and bbox_intersects(bbox, visible_shape_bbox))
+            if(shape_visible and
+               bbox_intersects(bbox, to_page_frame(visible_shape_bbox)))
               {
                 return true;
               }
@@ -591,6 +606,10 @@ namespace pdflib
 
     const double tol = std::max(0.0, tolerance);
 
+    // a quarter-turn /Rotate swaps the axes between the raw instruction
+    // space and the page frame the caller asks about
+    const bool swaps_axes = (std::abs(page_frame_angle) % 180) == 90;
+
     for(const auto& instr : instructions.get_shape_instructions())
       {
         if(not shape_instruction_strokes_visible(instr)) { continue; }
@@ -613,10 +632,12 @@ namespace pdflib
               const bool is_vertical = std::abs(x1 - x0) <= tol;
 
               if(is_horizontal and is_vertical) { return; }
+              if(not is_horizontal and not is_vertical) { return; }
 
-              if((is_horizontal and not horizontal) or
-                 (is_vertical and not vertical) or
-                 (not is_horizontal and not is_vertical))
+              const bool frame_horizontal = swaps_axes ? is_vertical : is_horizontal;
+              const bool frame_vertical = swaps_axes ? is_horizontal : is_vertical;
+              if((frame_horizontal and not horizontal) or
+                 (frame_vertical and not vertical))
                 {
                   return;
                 }
@@ -625,7 +646,7 @@ namespace pdflib
               if(clip_axis_aligned_segment(x0, y0, x1, y1,
                                            instr.get_clip_state(), tol, bbox))
                 {
-                  result.push_back(bbox);
+                  result.push_back(to_page_frame(bbox));
                 }
             };
 
@@ -678,7 +699,7 @@ namespace pdflib
         std::array<double, 4> bbox = {0.0, 0.0, 0.0, 0.0};
         if(shape_visible_bbox(instr, bbox))
           {
-            boxes.push_back(bbox);
+            boxes.push_back(to_page_frame(bbox));
           }
       }
 
@@ -899,6 +920,14 @@ namespace pdflib
       sanitator.sanitize(page_cells, config.page_boundary);
       sanitator.sanitize(page_shapes, config.page_boundary);
       sanitator.sanitize(page_images, config.page_boundary);
+
+      // the same boundary the sanitator subtracted from the cells, read after
+      // rotate_contents() so it is already in the rotated space
+      std::array<double, 4> boundary = (config.page_boundary == "media_box")
+        ? page_dimension.get_media_bbox()
+        : page_dimension.get_crop_bbox();
+      page_frame_origin = {boundary[0], boundary[1]};
+
       timings.add_timing(pdf_timings::KEY_SANITIZE_ORIENTATION, local.get_time());
     }
 
@@ -2071,6 +2100,9 @@ namespace pdflib
 
     int angle = page_dimension.get_angle();
 
+    page_frame_angle = 0;
+    page_frame_delta = {0.0, 0.0};
+
     if((angle%360)==0)
       {
         return;
@@ -2086,11 +2118,29 @@ namespace pdflib
     std::pair<double, double> delta = page_dimension.rotate(angle);
     LOG_S(INFO) << "translation delta: " << delta.first << ", " << delta.second;
 
+    page_frame_angle = angle;
+    page_frame_delta = delta;
+
     page_cells.rotate(angle, delta);
     page_shapes.rotate(angle, delta);
     page_images.rotate(angle, delta);
     page_widgets.rotate(angle, delta);
     page_hyperlinks.rotate(angle, delta);
+  }
+
+  std::array<double, 4> pdf_decoder<PAGE>::to_page_frame(std::array<double, 4> bbox) const
+  {
+    // the rotation page_shapes received in rotate_contents() ...
+    utils::values::transform_bottomleft_bbox_inplace(page_frame_angle,
+                                                     page_frame_delta, bbox);
+
+    // ... followed by the translation the dimension sanitator applied
+    bbox[0] -= page_frame_origin.first;
+    bbox[1] -= page_frame_origin.second;
+    bbox[2] -= page_frame_origin.first;
+    bbox[3] -= page_frame_origin.second;
+
+    return bbox;
   }
 
   bool pdf_decoder<PAGE>::can_reuse_sanitised_cells_for_line_cells(const decode_config& config) const

--- a/tests/test_unit_shape_queries_page_frame.py
+++ b/tests/test_unit_shape_queries_page_frame.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python
+"""Text, shapes and bitmaps of a page share one frame, and so do the queries.
+
+The render instructions stay in raw, unrotated user space so the renderer can
+orient its own canvas. The text cells, shapes and images of the page are
+instead rotated by /Rotate and moved to the page boundary (the crop box by
+default), and `page_width` / `page_height` are the boundary size.
+`get_shape_lines()`, `get_connected_shape_bounding_boxes()` and
+`intersects_with()` walked the instructions and answered in raw space: on a
+page whose crop box does not start at the origin they were off by exactly the
+boundary origin, and on a rotated page by the rotation as well, so a table
+frame no longer matched its text and `has_content_in()` looked for shapes in
+the wrong place (docling-project/docling-parse#343).
+
+The page is built in memory: media box 400x300 at the origin, crop box
+300x200 at (50, 40), the word `Hello`, a filled underline directly below it,
+a stroked line 6 points lower and a small RGB image to the right of the word.
+For each /Rotate value the expected frame is computed here from the raw
+user-space geometry, and the word, the sanitized shapes, the bitmap and the
+three queries must all agree with it.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+from docling_core.types.doc.base import BoundingBox, CoordOrigin
+from docling_core.types.doc.page import TextCellUnit
+
+from docling_parse.pdf_parser import DoclingThreadedPdfParser, ThreadedPdfParserConfig
+from tests.pdf_builder import build_pdf, content_stream, stream_object
+
+MEDIA_BOX = (0.0, 0.0, 400.0, 300.0)
+CROP_BOX = (50.0, 40.0, 350.0, 240.0)
+
+# raw user-space geometry of the page content
+WORD_X, WORD_Y = 100.0, 120.0
+UNDERLINE = (100.0, 116.0, 140.0, 117.0)  # `re f`
+LINE = (100.0, 110.0, 140.0, 110.0)  # `m l S`, no area
+LINE_WIDTH = 1.0
+IMAGE = (150.0, 116.0, 170.0, 132.0)  # `cm Do`
+
+Box = tuple[float, float, float, float]
+
+
+def _page(rotate: int) -> bytes:
+    rotate_entry = f" /Rotate {rotate}" if rotate else ""
+    ix0, iy0, ix1, iy1 = IMAGE
+    return build_pdf(
+        [
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R"
+            f" /MediaBox [{' '.join(f'{v:g}' for v in MEDIA_BOX)}]"
+            f" /CropBox [{' '.join(f'{v:g}' for v in CROP_BOX)}]{rotate_entry}"
+            " /Resources << /Font << /F1 5 0 R >> /XObject << /Im1 6 0 R >> >>"
+            " /Contents 4 0 R >>",
+            content_stream(
+                f"BT /F1 12 Tf {WORD_X:g} {WORD_Y:g} Td (Hello) Tj ET\n"
+                f"0 0 0 rg {UNDERLINE[0]:g} {UNDERLINE[1]:g}"
+                f" {UNDERLINE[2] - UNDERLINE[0]:g} {UNDERLINE[3] - UNDERLINE[1]:g} re f\n"
+                f"0 0 0 RG {LINE_WIDTH:g} w {LINE[0]:g} {LINE[1]:g} m"
+                f" {LINE[2]:g} {LINE[3]:g} l S\n"
+                f"q {ix1 - ix0:g} 0 0 {iy1 - iy0:g} {ix0:g} {iy0:g} cm /Im1 Do Q\n"
+            ),
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            stream_object(
+                "/Type /XObject /Subtype /Image /Width 4 /Height 4"
+                " /ColorSpace /DeviceRGB /BitsPerComponent 8",
+                bytes([255, 0, 0] * 16),
+            ),
+        ]
+    )
+
+
+def _expected(rotate: int, box: Box) -> Box:
+    """Raw user-space box -> page frame: /Rotate clockwise, then crop origin.
+
+    Mirrors `page_item<PAGE_DIMENSION>::rotate()` (the rotated page is moved
+    back into the first quadrant by the media box size) and the dimension
+    sanitator (the boundary origin is subtracted).
+    """
+    _, _, media_w, media_h = MEDIA_BOX
+
+    def point(x: float, y: float) -> tuple[float, float]:
+        if rotate == 0:
+            return x, y
+        if rotate == 90:
+            return y, media_w - x
+        if rotate == 180:
+            return media_w - x, media_h - y
+        if rotate == 270:
+            return media_h - y, x
+        raise ValueError(rotate)
+
+    (ax, ay), (bx, by) = point(box[0], box[1]), point(box[2], box[3])
+    (cx0, cy0), (cx1, cy1) = (
+        point(CROP_BOX[0], CROP_BOX[1]),
+        point(CROP_BOX[2], CROP_BOX[3]),
+    )
+    ox, oy = min(cx0, cx1), min(cy0, cy1)
+    return (min(ax, bx) - ox, min(ay, by) - oy, max(ax, bx) - ox, max(ay, by) - oy)
+
+
+def _box(b: BoundingBox) -> Box:
+    return (b.l, b.b, b.r, b.t)
+
+
+def _close(a: Box, b: Box, tol: float) -> bool:
+    return all(abs(x - y) <= tol for x, y in zip(a, b))
+
+
+def _assert_one_close(boxes: list[Box], want: Box, tol: float, what: str) -> None:
+    assert any(_close(got, want, tol) for got in boxes), (what, want, boxes)
+
+
+def _probe(box: Box, pad: float = 1.0) -> BoundingBox:
+    return BoundingBox(
+        l=box[0] - pad,
+        b=box[1] - pad,
+        r=box[2] + pad,
+        t=box[3] + pad,
+        coord_origin=CoordOrigin.BOTTOMLEFT,
+    )
+
+
+@pytest.mark.parametrize("rotate", [0, 90, 180, 270])
+def test_text_shapes_and_bitmaps_share_one_frame(rotate: int) -> None:
+    parser = DoclingThreadedPdfParser(
+        parser_config=ThreadedPdfParserConfig(loglevel="fatal", threads=1)
+    )
+    parser.load(BytesIO(_page(rotate)))
+    try:
+        (result,) = list(parser.iterate_results())
+        assert result.success, result.error_message
+
+        expected_size = (300.0, 200.0) if rotate % 180 == 0 else (200.0, 300.0)
+        assert _close((result.page_width, result.page_height), expected_size, 1e-6)
+
+        page = result.get_page()
+
+        # the text cell contains the start of its baseline and shares an edge
+        # with the underline, which starts at the same raw x
+        word = next(
+            cell
+            for cell in page.iterate_cells(TextCellUnit.WORD)
+            if cell.text == "Hello"
+        )
+        word_box = _box(word.rect.to_bounding_box())
+        bx, by, _, _ = _expected(rotate, (WORD_X, WORD_Y, WORD_X, WORD_Y))
+        assert word_box[0] - 1 <= bx <= word_box[2] + 1, (rotate, word_box, bx)
+        assert word_box[1] - 1 <= by <= word_box[3] + 1, (rotate, word_box, by)
+        underline = _expected(rotate, UNDERLINE)
+        assert min(abs(w - u) for w in word_box for u in underline) < 0.5, (
+            rotate,
+            word_box,
+        )
+
+        # the sanitized shapes of the segmented page
+        sanitized = [
+            (
+                min(p.x for p in shape.points),
+                min(p.y for p in shape.points),
+                max(p.x for p in shape.points),
+                max(p.y for p in shape.points),
+            )
+            for shape in page.shapes
+        ]
+        assert len(sanitized) == 2
+        _assert_one_close(sanitized, _expected(rotate, UNDERLINE), 1e-6, "underline")
+        _assert_one_close(sanitized, _expected(rotate, LINE), 1e-6, "line")
+
+        # the bitmap of the segmented page
+        bitmaps = [_box(b.rect.to_bounding_box()) for b in page.bitmap_resources]
+        assert len(bitmaps) == 1
+        _assert_one_close(bitmaps, _expected(rotate, IMAGE), 1e-6, "bitmap")
+
+        # the shape queries; the stroked line is padded by half its width
+        connected = [_box(b) for b in result.get_connected_shape_bounding_boxes()]
+        assert len(connected) == 2
+        _assert_one_close(
+            connected, _expected(rotate, UNDERLINE), 1e-6, "connected underline"
+        )
+        _assert_one_close(
+            connected, _expected(rotate, LINE), LINE_WIDTH / 2 + 1e-6, "connected line"
+        )
+
+        (line,) = result.get_shape_lines(
+            horizontal=(rotate % 180 == 0), vertical=(rotate % 180 != 0)
+        )
+        assert _close(_box(line), _expected(rotate, LINE), 1e-6), (rotate, _box(line))
+
+        # has_content_in(): the frame of the query is the frame of the page
+        for raw, kind in ((UNDERLINE, "shapes"), (LINE, "shapes"), (IMAGE, "bitmaps")):
+            flags = {
+                "chars": False,
+                "shapes": kind == "shapes",
+                "bitmaps": kind == "bitmaps",
+            }
+            assert result.intersects_with(
+                bbox=_probe(_expected(rotate, raw)), **flags
+            ), (
+                rotate,
+                kind,
+            )
+            # ... and nothing of that kind is left at the raw user-space location
+            assert not result.intersects_with(bbox=_probe(raw, pad=0.0), **flags), (
+                rotate,
+                kind,
+            )
+    finally:
+        parser.unload_all()
+
+
+def test_underline_sits_under_its_word() -> None:
+    """The readable version of the check above, for the unrotated page."""
+    parser = DoclingThreadedPdfParser(
+        parser_config=ThreadedPdfParserConfig(loglevel="fatal", threads=1)
+    )
+    parser.load(BytesIO(_page(0)))
+    try:
+        (result,) = list(parser.iterate_results())
+        assert result.success, result.error_message
+
+        page = result.get_page()
+        word = next(
+            cell
+            for cell in page.iterate_cells(TextCellUnit.WORD)
+            if cell.text == "Hello"
+        )
+        word_box = word.rect.to_bounding_box()
+        # user-space x=100 relative to the crop box at x=50
+        assert abs(word_box.l - 50.0) < 1.0
+
+        shapes = result.get_connected_shape_bounding_boxes()
+        assert len(shapes) == 2
+        underline = max(shapes, key=lambda box: box.t)
+        assert abs(underline.l - word_box.l) < 0.5
+        assert abs(underline.r - (word_box.l + 40.0)) < 0.5
+        assert word_box.b - 2.0 <= underline.t <= word_box.b
+
+        (line,) = result.get_shape_lines(horizontal=True, vertical=False)
+        assert abs(line.l - word_box.l) < 0.5
+        assert abs(line.t - (underline.b - 6.0)) < 1.0
+
+        (bitmap,) = page.bitmap_resources
+        image = bitmap.rect.to_bounding_box()
+        assert abs(image.l - (word_box.l + 50.0)) < 0.5  # 50 pt right of the word
+        assert abs(image.b - underline.b) < 0.5  # on the underline's baseline
+    finally:
+        parser.unload_all()


### PR DESCRIPTION
## Summary

`PageParseResult.get_shape_lines()`, `get_connected_shape_bounding_boxes()` and `intersects_with()` (docling's `has_content_in()`) answered in raw PDF user space, while the text cells, shapes and images of the same page are rotated by `/Rotate` and relative to the page boundary (the crop box by default), and `page_width` / `page_height` are the boundary size. On a page whose boundary does not start at the origin the queries were off by exactly the boundary origin; on a rotated page they were off by the rotation as well.

Fixes #343. Complementary to #344, which translates the two list-returning wrappers in Python: this moves the fix into the decoder so that `intersects_with()` and rotated pages are covered too. Happy to fold it into #344 if @bharm16 prefers to carry it.

## Cause

`pdf_decoder<PAGE>::get_shape_lines`, `get_connected_shape_bounding_boxes` and the `shapes` branch of `intersects_with` (`src/parse/pdf_decoders/page.h`) iterate `instructions.get_shape_instructions()`. The render instructions are deliberately kept in unrotated user space so the renderer can orient its own canvas (see `decode_dimensions()`), whereas `page_cells`, `page_shapes` and `page_images` go through `rotate_contents()` and `page_item_sanitator<PAGE_DIMENSION>`. The `chars` and `bitmaps` branches of `intersects_with` read the sanitized items and were already correct.

## Change

- `rotate_contents()` records the angle and delta it applied; `decode_page()` records the boundary origin the dimension sanitator subtracted, read after rotation so it is in the rotated space.
- `get_shape_lines()` classifies a segment as horizontal or vertical in the page frame, so a quarter-turn page reports its lines by their orientation on the page rather than in the content stream.
- `to_page_frame(bbox)` applies `utils::values::transform_bottomleft_bbox_inplace` with that angle and delta, then the boundary translation, to a raw-space box. The three queries pass each box through it. The instructions are untouched, so rendering is unaffected; pages with `/Rotate 0` and a boundary at the origin return exactly what they did before.
- The docstrings of the Python wrappers now state the frame.

## Test

`tests/test_unit_shape_queries_page_frame.py` builds the page from #344 in memory with `tests/pdf_builder.py` (media box 400x300 at the origin, crop box 300x200 at (50, 40), the word `Hello`, a filled underline under it, a stroked line 6 points lower and a small RGB image to the right of the word), parametrized over `/Rotate` 0/90/180/270. For each rotation the expected frame is computed in the test from the raw user-space geometry, and the text cell, the sanitized shapes, the bitmap and the three queries must all agree with it. `intersects_with()` is probed with `shapes=True` and with `bitmaps=True` at the expected boxes (must hit) and at the raw user-space location (must miss). A second test keeps the readable "underline sits under its word" assertions from #344 for the unrotated page.

Observed on 7.19.0 before the change, for the underline:

| | /Rotate 0 | /Rotate 90 |
|---|---|---|
| `page.shapes` (sanitized) | l 50, b 76, r 90, t 77 | l 76, b 210, r 77, t 250 |
| `get_connected_shape_bounding_boxes()` | l 100, b 116, r 140, t 117 | l 100, b 116, r 140, t 117 |
| `intersects_with(shapes=True)` at the sanitized box | False | False |

## Validation

Built the extension locally from this branch and ran:

- `tests/test_unit_shape_queries_page_frame.py`: 5 passed (four rotations, text + shapes + bitmap, plus the readable check). Against the 7.19.0 build the rotated and shifted cases fail as in the table above.
- The two existing shape-query tests in `tests/test_regression_threaded_parse.py` (`get_shape_lines_returns_only_visible_straight_lines`, `get_connected_shape_bounding_boxes`): 2 passed, run standalone because the regression module's Hugging Face download is not reachable from my network. The full regression suite runs in CI.

## Not changed

The shape branch of the dimension sanitator sets `is_contained_in_boundary=true` in its else branch, so it never filters shapes outside the boundary. Left alone here since fixing it changes regression output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeLRiBBA9VkM81fUwUQfyt
